### PR TITLE
feat: add GitHub Action for public use

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install ferrflow
+    - name: Install FerrFlow
       shell: bash
       run: |
         OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -48,6 +48,6 @@ runs:
         curl -sSL "$URL" | tar -xz -C /usr/local/bin
         chmod +x /usr/local/bin/ferrflow
 
-    - name: Run ferrflow release
+    - name: Run FerrFlow release
       shell: bash
       run: ferrflow ${{ inputs.dry_run == 'true' && '--dry-run' || '' }} release


### PR DESCRIPTION
## Summary

- Adds `action.yml` at the repo root to expose FerrFlow as a reusable GitHub Action
- Downloads the pre-built binary from GitHub Releases (linux/darwin, x64/arm64)
- Supports `version` and `dry_run` inputs

## Usage

```yaml
- uses: FerrFlow-Org/ferrflow@v1
  with:
    dry_run: false
  env:
    GITHUB_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}
```