### PR TITLE
Detect default branch from git remote instead of hardcoding main

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -23,8 +23,19 @@ pub struct WorkspaceConfig {
 fn default_remote() -> String {
     "origin".to_string()
 }
+
 fn default_branch() -> String {
-    "main".to_string()
+    // Try to detect the default branch from the remote HEAD ref
+    let detected = std::process::Command::new("git")
+        .args(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().trim_start_matches("origin/").to_string())
+        .filter(|s| !s.is_empty());
+
+    detected.unwrap_or_else(|| "main".to_string())
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]


### PR DESCRIPTION
Closes #18

## Changes

`default_branch()` in `config.rs` now runs `git symbolic-ref --short refs/remotes/origin/HEAD` to detect the actual default branch of the remote, instead of returning `"main"` unconditionally.

Falls back to `"main"` if the command fails or returns an empty result (e.g. no remote configured).

This makes the `[workspace]` section fully optional for standard setups.