### PR TITLE
fix: vendor libgit2 in Dockerfile to fix Alpine musl build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml_edit = { version = "0.22", features = ["serde"] }
 quick-xml = "0.37"
-git2 = "0.20"
+git2 = { version = "0.20", features = ["vendored-libgit2"] }
 semver = "1"
 regex = "1"
 anyhow = "1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage
 FROM rustlang/rust:nightly-alpine AS builder
-RUN apk add --no-cache musl-dev openssl-dev pkgconfig libgit2-dev
+RUN apk add --no-cache musl-dev openssl-dev pkgconfig cmake make
 WORKDIR /app
 # Cache dependencies
 COPY Cargo.toml Cargo.lock ./
@@ -13,7 +13,7 @@ RUN cargo build --release
 
 # Runtime stage
 FROM alpine:3.21
-RUN apk add --no-cache libgit2 ca-certificates
+RUN apk add --no-cache ca-certificates
 COPY --from=builder /app/target/release/ferrflow /usr/local/bin/ferrflow
 ENTRYPOINT ["ferrflow"]
 CMD ["--help"]


### PR DESCRIPTION
The Alpine musl linker can't find the system static libraries for libgit2, openssl, and zlib during `cargo build --release`. The `git2` crate supports building libgit2 from source via the `vendored-libgit2` feature, which bundles and compiles libgit2 and its dependencies (including libssh2 and openssl) statically.

Changes:
- `git2`: add `vendored-libgit2` feature
- Dockerfile: replace `libgit2-dev` with `cmake make` (needed to compile vendored libgit2), remove `libgit2` from runtime image