### PR TITLE
ci: trigger release workflow on published release event

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
             binary: ferrflow
             archive: ferrflow-linux-arm64.tar.gz
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-latest
             binary: ferrflow
             archive: ferrflow-darwin-x64.tar.gz
           - target: aarch64-apple-darwin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.5+3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +700,7 @@ checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml_edit = { version = "0.22", features = ["serde"] }
 quick-xml = "0.37"
-git2 = { version = "0.20", features = ["vendored-libgit2"] }
+git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
 semver = "1"
 regex = "1"
 anyhow = "1"


### PR DESCRIPTION
## Problem

Release binaries were never built. All release commits contain `[skip ci]` (added by FerrFlow to prevent CI loops), which also suppresses workflows triggered by pushing those tags. So `release.yml` never ran.

## Fix

Switch the trigger from `push: tags: ferrflow@v*` to `release: types: [published]`. FerrFlow already creates a GitHub release via the API after tagging — that event is not subject to `[skip ci]`, so the binary build workflow will fire reliably.

The `workflow_dispatch` input is kept for manual/backfill builds.