### PR TITLE
feat: support ferrflow.json and ferrflow.json5 config formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +251,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,12 +269,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -295,6 +333,7 @@ dependencies = [
  "clap",
  "colored",
  "git2",
+ "json5",
  "quick-xml",
  "regex",
  "semver",
@@ -328,6 +367,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -565,6 +614,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,6 +770,49 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pkg-config"
@@ -908,6 +1011,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1064,6 +1178,18 @@ name = "toml_writer"
 version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+json5 = "0.4"
 toml_edit = { version = "0.25", features = ["serde"] }
 quick-xml = "0.39"
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }

--- a/README.md
+++ b/README.md
@@ -67,13 +67,72 @@ ferrflow release --dry-run
 
 # Scaffold a config file
 ferrflow init
+
+# Scaffold a config file in a specific format
+ferrflow init --format json5
 ```
 
 ## Configuration
 
-FerrFlow reads `ferrflow.toml` at the root of your repository. If no config file is found, it auto-detects common version files in the current directory.
+FerrFlow looks for a config file at the root of your repository, in this order:
 
-### Single package
+1. `ferrflow.json`
+2. `ferrflow.json5`
+3. `ferrflow.toml`
+
+If multiple config files exist, the highest priority one is used and a warning is printed for the others. If no config file is found, FerrFlow auto-detects common version files in the current directory.
+
+Run `ferrflow init` to scaffold a config file interactively. Use `--format` to skip the format prompt:
+
+```bash
+ferrflow init               # asks which format (default: json)
+ferrflow init --format json5
+ferrflow init --format toml
+```
+
+### JSON (default)
+
+```json
+{
+  "workspace": {
+    "remote": "origin",
+    "branch": "main"
+  },
+  "package": [
+    {
+      "name": "my-app",
+      "path": ".",
+      "changelog": "CHANGELOG.md",
+      "versioned_files": [
+        { "path": "package.json", "format": "json" }
+      ]
+    }
+  ]
+}
+```
+
+### JSON5
+
+```json5
+{
+  workspace: {
+    remote: "origin",
+    branch: "main",
+  },
+  package: [
+    {
+      name: "my-app",
+      path: ".",
+      changelog: "CHANGELOG.md",
+      versioned_files: [
+        { path: "package.json", format: "json" },
+      ],
+    },
+  ],
+}
+```
+
+### TOML
 
 ```toml
 [workspace]
@@ -92,12 +151,44 @@ format = "toml"
 
 ### Monorepo
 
+<details>
+<summary>JSON</summary>
+
+```json
+{
+  "package": [
+    {
+      "name": "api",
+      "path": "services/api",
+      "changelog": "services/api/CHANGELOG.md",
+      "shared_paths": ["services/shared/"],
+      "versioned_files": [
+        { "path": "services/api/Cargo.toml", "format": "toml" }
+      ]
+    },
+    {
+      "name": "frontend",
+      "path": "frontend",
+      "changelog": "frontend/CHANGELOG.md",
+      "versioned_files": [
+        { "path": "frontend/package.json", "format": "json" }
+      ]
+    }
+  ]
+}
+```
+
+</details>
+
+<details>
+<summary>TOML</summary>
+
 ```toml
 [[package]]
 name = "api"
 path = "services/api"
 changelog = "services/api/CHANGELOG.md"
-shared_paths = ["services/shared/"]  # bump this package when shared/ changes
+shared_paths = ["services/shared/"]
 
 [[package.versioned_files]]
 path = "services/api/Cargo.toml"
@@ -112,6 +203,8 @@ changelog = "frontend/CHANGELOG.md"
 path = "frontend/package.json"
 format = "json"
 ```
+
+</details>
 
 ## Conventional Commits
 

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -16,7 +16,7 @@ pub fn generate_only(dry_run: bool) -> Result<()> {
     if config.packages.is_empty() {
         println!(
             "{}",
-            "No packages configured. Run `ferrflow init` to create a ferrflow.toml.".yellow()
+            "No packages configured. Run `ferrflow init` to create a ferrflow config.".yellow()
         );
         return Ok(());
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
+use crate::config::ConfigFileFormat;
 use crate::status::OutputFormat;
 
 #[derive(Parser)]
@@ -28,8 +29,12 @@ pub enum Commands {
     Release,
     /// Generate/update CHANGELOG.md only
     Changelog,
-    /// Scaffold a ferrflow.toml configuration file
-    Init,
+    /// Scaffold a ferrflow configuration file
+    Init {
+        /// Config file format (json, json5, toml)
+        #[arg(long)]
+        format: Option<ConfigFileFormat>,
+    },
     /// Print each package name, current version, and last release tag
     Status {
         /// Output format
@@ -44,7 +49,7 @@ impl Cli {
             Commands::Check => crate::monorepo::check(self.verbose),
             Commands::Release => crate::monorepo::release(self.dry_run, self.verbose),
             Commands::Changelog => crate::changelog::generate_only(self.dry_run),
-            Commands::Init => crate::config::init(),
+            Commands::Init { format } => crate::config::init(format),
             Commands::Status { output } => crate::status::run(&output),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,11 @@
 use anyhow::{Context, Result};
+use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
-pub const CONFIG_FILE: &str = "ferrflow.toml";
+// ---------------------------------------------------------------------------
+// Config structs
+// ---------------------------------------------------------------------------
 
 #[derive(Debug, Deserialize, Serialize, Default)]
 pub struct Config {
@@ -25,7 +28,6 @@ fn default_remote() -> String {
 }
 
 fn default_branch() -> String {
-    // Try to detect the default branch from the remote HEAD ref
     let detected = std::process::Command::new("git")
         .args(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"])
         .output()
@@ -66,15 +68,115 @@ pub enum FileFormat {
     Xml,
 }
 
+// ---------------------------------------------------------------------------
+// Config file format enum (for CLI --format flag)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum ConfigFileFormat {
+    Json,
+    Json5,
+    Toml,
+}
+
+// ---------------------------------------------------------------------------
+// ConfigFormatHandler trait + implementations
+// ---------------------------------------------------------------------------
+
+pub trait ConfigFormatHandler {
+    fn filename(&self) -> &str;
+    fn parse(&self, content: &str) -> Result<Config>;
+    fn serialize(&self, config: &Config) -> Result<String>;
+}
+
+struct JsonFormat;
+struct Json5Format;
+struct TomlFormat;
+
+impl ConfigFormatHandler for JsonFormat {
+    fn filename(&self) -> &str {
+        "ferrflow.json"
+    }
+    fn parse(&self, content: &str) -> Result<Config> {
+        serde_json::from_str(content).with_context(|| "Failed to parse ferrflow.json")
+    }
+    fn serialize(&self, config: &Config) -> Result<String> {
+        let mut out = serde_json::to_string_pretty(config)?;
+        out.push('\n');
+        Ok(out)
+    }
+}
+
+impl ConfigFormatHandler for Json5Format {
+    fn filename(&self) -> &str {
+        "ferrflow.json5"
+    }
+    fn parse(&self, content: &str) -> Result<Config> {
+        json5::from_str(content).with_context(|| "Failed to parse ferrflow.json5")
+    }
+    fn serialize(&self, config: &Config) -> Result<String> {
+        // json5 crate has no serializer; valid JSON is valid JSON5
+        let mut out = serde_json::to_string_pretty(config)?;
+        out.push('\n');
+        Ok(out)
+    }
+}
+
+impl ConfigFormatHandler for TomlFormat {
+    fn filename(&self) -> &str {
+        "ferrflow.toml"
+    }
+    fn parse(&self, content: &str) -> Result<Config> {
+        toml_edit::de::from_str(content).with_context(|| "Failed to parse ferrflow.toml")
+    }
+    fn serialize(&self, config: &Config) -> Result<String> {
+        toml_edit::ser::to_string_pretty(config).with_context(|| "Failed to serialize to TOML")
+    }
+}
+
+/// Ordered by priority: json > json5 > toml
+const CONFIG_FORMATS: &[&dyn ConfigFormatHandler] = &[&JsonFormat, &Json5Format, &TomlFormat];
+
+pub fn format_handler(fmt: ConfigFileFormat) -> &'static dyn ConfigFormatHandler {
+    match fmt {
+        ConfigFileFormat::Json => &JsonFormat,
+        ConfigFileFormat::Json5 => &Json5Format,
+        ConfigFileFormat::Toml => &TomlFormat,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Config loading
+// ---------------------------------------------------------------------------
+
 impl Config {
     pub fn load(repo_root: &Path) -> Result<Self> {
-        let config_path = repo_root.join(CONFIG_FILE);
-        if !config_path.exists() {
+        let mut found: Vec<(&dyn ConfigFormatHandler, PathBuf)> = Vec::new();
+
+        for handler in CONFIG_FORMATS {
+            let path = repo_root.join(handler.filename());
+            if path.exists() {
+                found.push((*handler, path));
+            }
+        }
+
+        if found.is_empty() {
             return Ok(Self::auto_detect(repo_root));
         }
-        let content = std::fs::read_to_string(&config_path)
-            .with_context(|| format!("Failed to read {}", config_path.display()))?;
-        toml_edit::de::from_str(&content).with_context(|| "Failed to parse ferrflow.toml")
+
+        // Warn about ignored config files
+        for (handler, _) in &found[1..] {
+            eprintln!(
+                "Warning: {} found but ignored (using {} instead)",
+                handler.filename(),
+                found[0].0.filename()
+            );
+        }
+
+        let (handler, path) = &found[0];
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+        handler.parse(&content)
     }
 
     fn auto_detect(root: &Path) -> Self {
@@ -149,6 +251,10 @@ impl Config {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Interactive helpers
+// ---------------------------------------------------------------------------
+
 fn prompt(question: &str, default: &str) -> String {
     use std::io::Write;
     if default.is_empty() {
@@ -198,6 +304,27 @@ fn prompt_format(indent: bool) -> String {
     }
 }
 
+const ALLOWED_CONFIG_FORMATS: &[&str] = &["json", "json5", "toml"];
+
+fn prompt_config_format() -> ConfigFileFormat {
+    let question = "Config file format [json/json5/toml]";
+    loop {
+        let input = prompt(question, "json");
+        let normalized = input.trim().to_lowercase();
+        if ALLOWED_CONFIG_FORMATS.contains(&normalized.as_str()) {
+            return match normalized.as_str() {
+                "json5" => ConfigFileFormat::Json5,
+                "toml" => ConfigFileFormat::Toml,
+                _ => ConfigFileFormat::Json,
+            };
+        }
+        eprintln!(
+            "Invalid format '{}'. Allowed values: json, json5, toml.",
+            input
+        );
+    }
+}
+
 fn default_version_file(format: &str) -> &'static str {
     match format {
         "json" => "package.json",
@@ -208,7 +335,17 @@ fn default_version_file(format: &str) -> &'static str {
     }
 }
 
-fn collect_package(path_default: &str, monorepo: bool) -> String {
+fn parse_file_format(s: &str) -> FileFormat {
+    match s {
+        "json" => FileFormat::Json,
+        "xml" => FileFormat::Xml,
+        "gradle" => FileFormat::Gradle,
+        "gomod" => FileFormat::GoMod,
+        _ => FileFormat::Toml,
+    }
+}
+
+fn collect_package(path_default: &str, monorepo: bool) -> PackageConfig {
     let dir_name = std::env::current_dir()
         .ok()
         .and_then(|p| {
@@ -226,9 +363,9 @@ fn collect_package(path_default: &str, monorepo: bool) -> String {
 
     let path = prompt(if monorepo { "  Path" } else { "Path" }, path_default);
 
-    let format = prompt_format(monorepo);
+    let format_str = prompt_format(monorepo);
 
-    let version_file_default = default_version_file(&format);
+    let version_file_default = default_version_file(&format_str);
     let version_file_path = if path == "." {
         prompt(
             if monorepo {
@@ -263,56 +400,64 @@ fn collect_package(path_default: &str, monorepo: bool) -> String {
         &changelog_default,
     );
 
-    format!(
-        "\n[[package]]\nname = \"{name}\"\npath = \"{path}\"\nchangelog = \"{changelog}\"\n\n[[package.versioned_files]]\npath = \"{version_file_path}\"\nformat = \"{format}\"\n"
-    )
+    PackageConfig {
+        name,
+        path,
+        versioned_files: vec![VersionedFile {
+            path: version_file_path,
+            format: parse_file_format(&format_str),
+        }],
+        changelog: Some(changelog),
+        shared_paths: Vec::new(),
+    }
 }
 
-pub fn init() -> Result<()> {
-    let config_path = PathBuf::from(CONFIG_FILE);
-    if config_path.exists() {
-        anyhow::bail!("ferrflow.toml already exists");
+// ---------------------------------------------------------------------------
+// Init command
+// ---------------------------------------------------------------------------
+
+pub fn init(format: Option<ConfigFileFormat>) -> Result<()> {
+    // Check if any config file already exists
+    for handler in CONFIG_FORMATS {
+        let path = PathBuf::from(handler.filename());
+        if path.exists() {
+            anyhow::bail!("{} already exists", handler.filename());
+        }
     }
 
-    let mut output = String::from("[workspace]\n");
+    let fmt = format.unwrap_or_else(prompt_config_format);
+    let handler = format_handler(fmt);
 
     let monorepo = prompt_bool("Is this a monorepo?", false);
 
-    if monorepo {
+    let packages = if monorepo {
         println!("Add packages (leave name empty to finish):");
-        let mut count = 0;
+        let mut pkgs = Vec::new();
         loop {
-            let name = prompt("  Package name", "");
-            if name.is_empty() {
-                if count == 0 {
+            let pkg = collect_package("", true);
+            if pkg.name.is_empty() {
+                if pkgs.is_empty() {
                     eprintln!("At least one package is required.");
                     continue;
                 }
                 break;
             }
-            let path = prompt("  Path", &name);
-            let format = prompt_format(true);
-            let version_file_default = default_version_file(&format);
-            let version_file_path = if path == "." {
-                prompt("  Version file path", version_file_default)
-            } else {
-                prompt(
-                    "  Version file path",
-                    &format!("{path}/{version_file_default}"),
-                )
-            };
-            let changelog = prompt("  Changelog path", &format!("{path}/CHANGELOG.md"));
-            output.push_str(&format!(
-                "\n[[package]]\nname = \"{name}\"\npath = \"{path}\"\nchangelog = \"{changelog}\"\n\n[[package.versioned_files]]\npath = \"{version_file_path}\"\nformat = \"{format}\"\n"
-            ));
-            count += 1;
+            pkgs.push(pkg);
         }
+        pkgs
     } else {
-        output.push_str(&collect_package(".", false));
-    }
+        vec![collect_package(".", false)]
+    };
 
-    std::fs::write(&config_path, &output)?;
-    println!("Created ferrflow.toml");
+    let config = Config {
+        workspace: WorkspaceConfig::default(),
+        packages,
+    };
+
+    let content = handler.serialize(&config)?;
+    let filename = handler.filename();
+    std::fs::write(filename, &content)?;
+    println!("Created {filename}");
     println!("Run: ferrflow check");
     Ok(())
 }

--- a/src/monorepo.rs
+++ b/src/monorepo.rs
@@ -42,7 +42,7 @@ fn run_release_logic(root: &Path, config: &Config, dry_run: bool, verbose: bool)
     if config.packages.is_empty() {
         println!(
             "{}",
-            "No packages configured. Run `ferrflow init` to create a ferrflow.toml.".yellow()
+            "No packages configured. Run `ferrflow init` to create a ferrflow config.".yellow()
         );
         return Ok(());
     }

--- a/src/status.rs
+++ b/src/status.rs
@@ -28,7 +28,7 @@ pub fn run(output: &OutputFormat) -> Result<()> {
     if config.packages.is_empty() {
         println!(
             "{}",
-            "No packages configured. Run `ferrflow init` to create a ferrflow.toml.".yellow()
+            "No packages configured. Run `ferrflow init` to create a ferrflow config.".yellow()
         );
         return Ok(());
     }


### PR DESCRIPTION
## Summary

- Add `ferrflow.json` and `ferrflow.json5` as config file alternatives to `ferrflow.toml`
- Priority order: json > json5 > toml, with warnings when multiple config files exist
- Add `--format` flag to `ferrflow init` (also available as interactive prompt)
- Trait-based `ConfigFormatHandler` design for easy addition of future formats

Closes #17