### PR TITLE
Add telemetry module for anonymous usage stats

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,8 @@ use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
+use crate::telemetry;
+
 // ---------------------------------------------------------------------------
 // Config structs
 // ---------------------------------------------------------------------------
@@ -21,6 +23,12 @@ pub struct WorkspaceConfig {
     pub remote: String,
     #[serde(default = "default_branch")]
     pub branch: String,
+    #[serde(default = "default_telemetry")]
+    pub telemetry: bool,
+}
+
+fn default_telemetry() -> bool {
+    true
 }
 
 fn default_remote() -> String {
@@ -459,5 +467,10 @@ pub fn init(format: Option<ConfigFileFormat>) -> Result<()> {
     std::fs::write(filename, &content)?;
     println!("Created {filename}");
     println!("Run: ferrflow check");
+
+    if config.workspace.telemetry {
+        telemetry::send_event("init", None, None, None);
+    }
+
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod git;
 mod monorepo;
 mod release;
 mod status;
+mod telemetry;
 mod versioning;
 
 use anyhow::Result;

--- a/src/monorepo.rs
+++ b/src/monorepo.rs
@@ -7,6 +7,7 @@ use crate::git::{
     get_repo_root, get_repo_slug, open_repo, push,
 };
 use crate::release::create_github_release;
+use crate::telemetry;
 use crate::versioning::bump_version;
 use anyhow::Result;
 use colored::Colorize;
@@ -20,7 +21,13 @@ pub fn check(verbose: bool) -> Result<()> {
     println!("{}", "FerrFlow — Check (dry run)".bold().blue());
     println!();
 
-    run_release_logic(&root, &config, true, verbose)
+    let result = run_release_logic(&root, &config, true, verbose);
+
+    if config.workspace.telemetry {
+        telemetry::send_event("check", None, None, None);
+    }
+
+    result
 }
 
 pub fn release(dry_run: bool, verbose: bool) -> Result<()> {
@@ -198,6 +205,15 @@ fn run_release_logic(root: &Path, config: &Config, dry_run: bool, verbose: bool)
             "  ✓ Pushed to {}/{}",
             config.workspace.remote, config.workspace.branch
         );
+
+        if config.workspace.telemetry {
+            for (tag_name, _, _) in &tags_to_create {
+                // Parse "name@vX.Y.Z" into package name and version
+                if let Some((name, version)) = tag_name.split_once("@v") {
+                    telemetry::send_event("release", Some(name), Some(version), None);
+                }
+            }
+        }
 
         if let Ok(token) = std::env::var("GITHUB_TOKEN")
             && let Some(slug) = get_repo_slug(&repo, &config.workspace.remote)

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,53 @@
+use serde::Serialize;
+
+const DEFAULT_API_URL: &str = "https://api.ferrflow.com";
+
+#[derive(Serialize)]
+struct EventPayload {
+    event_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    package_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    package_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<serde_json::Value>,
+}
+
+fn is_enabled() -> bool {
+    match std::env::var("FERRFLOW_TELEMETRY") {
+        Ok(val) => !matches!(val.to_lowercase().as_str(), "false" | "0" | "off" | "no"),
+        Err(_) => true,
+    }
+}
+
+fn api_url() -> String {
+    std::env::var("FERRFLOW_API_URL").unwrap_or_else(|_| DEFAULT_API_URL.to_string())
+}
+
+pub fn send_event(
+    event_type: &str,
+    package_name: Option<&str>,
+    package_version: Option<&str>,
+    metadata: Option<serde_json::Value>,
+) {
+    if !is_enabled() {
+        return;
+    }
+
+    let payload = EventPayload {
+        event_type: event_type.to_string(),
+        package_name: package_name.map(String::from),
+        package_version: package_version.map(String::from),
+        metadata,
+    };
+
+    let url = format!("{}/events", api_url());
+
+    std::thread::spawn(move || {
+        let agent = ureq::Agent::new_with_defaults();
+        let _ = agent
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .send_json(&payload);
+    });
+}


### PR DESCRIPTION
## Summary
- Add fire-and-forget telemetry module sending anonymous usage events to the FerrFlow API
- Events sent: `release` (per-package with name/version), `check`, `init`
- Opt-out via `telemetry: false` in config or `FERRFLOW_TELEMETRY=false` env var
- Configurable API URL via `FERRFLOW_API_URL` env var
- Background thread, silent failure, never blocks CLI

Closes #60

## Test plan
- [ ] `ferrflow check` sends a check event (verify with API logs or network capture)
- [ ] `ferrflow release` sends per-package release events
- [ ] `ferrflow init` sends an init event
- [ ] `FERRFLOW_TELEMETRY=false ferrflow check` sends nothing
- [ ] `telemetry = false` in config disables sending