### PR TITLE
fix(bench): configure git identity in fixture generator

### DIFF
--- a/benchmarks/fixtures/generate.sh
+++ b/benchmarks/fixtures/generate.sh
@@ -48,6 +48,8 @@ create_single() {
   mkdir -p "$dir"
   cd "$dir"
   git init -q
+  git config user.email "bench@ferrflow.dev"
+  git config user.name "FerrFlow Bench"
   git checkout -q -b main
 
   # Create ferrflow.json
@@ -94,6 +96,8 @@ create_mono() {
   mkdir -p "$dir"
   cd "$dir"
   git init -q
+  git config user.email "bench@ferrflow.dev"
+  git config user.name "FerrFlow Bench"
   git checkout -q -b main
 
   # Generate packages


### PR DESCRIPTION
## Summary

- Add `git config user.email/name` after `git init` in fixture generator
- Fixes CI failure when runner has no global git identity configured

Relates to #47