### PR TITLE
feat(versioning): support per-package versioning strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,34 @@ format = "json"
 
 </details>
 
+## Versioning Strategies
+
+Each package can use its own versioning strategy. Set a default at the workspace level and override per package:
+
+```toml
+[workspace]
+versioning = "semver"  # default for all packages
+
+[[package]]
+name = "api"
+path = "packages/api"
+# inherits semver from workspace
+
+[[package]]
+name = "site"
+path = "packages/site"
+versioning = "calver"  # override: date-based
+```
+
+| Strategy | Format | Example | Description |
+|----------|--------|---------|-------------|
+| `semver` | `MAJOR.MINOR.PATCH` | `1.4.2` | Default, driven by conventional commits |
+| `calver` | `YYYY.M.D` | `2025.3.28` | Date-based, ignores commit types |
+| `calver-short` | `YY.M.D` | `25.3.28` | Compact date-based |
+| `calver-seq` | `YYYY.M.SEQ` | `2025.3.3` | Date + daily sequence counter |
+| `sequential` | `N` | `42` | Simple incrementing build number |
+| `zerover` | `0.MINOR.PATCH` | `0.15.2` | Permanently unstable, never hits 1.0 |
+
 ## Conventional Commits
 
 FerrFlow follows the [Conventional Commits](https://www.conventionalcommits.org/) spec.

--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -27,6 +27,12 @@
           "type": "boolean",
           "description": "Send anonymous usage statistics to improve FerrFlow.",
           "default": true
+        },
+        "versioning": {
+          "type": "string",
+          "description": "Default versioning strategy for all packages.",
+          "enum": ["semver", "calver", "calver-short", "calver-seq", "sequential", "zerover"],
+          "default": "semver"
         }
       },
       "additionalProperties": false
@@ -76,6 +82,11 @@
             "items": {
               "type": "string"
             }
+          },
+          "versioning": {
+            "type": "string",
+            "description": "Versioning strategy for this package. Overrides workspace default.",
+            "enum": ["semver", "calver", "calver-short", "calver-seq", "sequential", "zerover"]
           }
         },
         "additionalProperties": false

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,8 @@ pub struct WorkspaceConfig {
     pub branch: String,
     #[serde(default = "default_telemetry")]
     pub telemetry: bool,
+    #[serde(default)]
+    pub versioning: VersioningStrategy,
 }
 
 fn default_telemetry() -> bool {
@@ -57,6 +59,25 @@ pub struct PackageConfig {
     pub changelog: Option<String>,
     #[serde(default)]
     pub shared_paths: Vec<String>,
+    pub versioning: Option<VersioningStrategy>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum VersioningStrategy {
+    #[default]
+    Semver,
+    Calver,
+    CalverShort,
+    CalverSeq,
+    Sequential,
+    Zerover,
+}
+
+impl PackageConfig {
+    pub fn effective_versioning(&self, workspace: &WorkspaceConfig) -> VersioningStrategy {
+        self.versioning.unwrap_or(workspace.versioning)
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -299,6 +320,7 @@ impl Config {
                     versioned_files,
                     changelog: Some("CHANGELOG.md".to_string()),
                     shared_paths: Vec::new(),
+                    versioning: None,
                 }]
             },
         }
@@ -468,6 +490,7 @@ fn collect_package(path_default: &str, monorepo: bool) -> PackageConfig {
         }],
         changelog: Some(changelog),
         shared_paths: Vec::new(),
+        versioning: None,
     }
 }
 

--- a/src/monorepo.rs
+++ b/src/monorepo.rs
@@ -1,5 +1,5 @@
 use crate::changelog::{build_section, update_changelog};
-use crate::config::{Config, PackageConfig};
+use crate::config::{Config, PackageConfig, VersioningStrategy};
 use crate::conventional_commits::{BumpType, determine_bump};
 use crate::formats::{get_handler, read_version, write_version};
 use crate::git::{
@@ -8,7 +8,7 @@ use crate::git::{
 };
 use crate::release::create_github_release;
 use crate::telemetry;
-use crate::versioning::bump_version;
+use crate::versioning::compute_next_version;
 use anyhow::Result;
 use colored::Colorize;
 use std::path::Path;
@@ -100,13 +100,23 @@ fn run_release_logic(root: &Path, config: &Config, dry_run: bool, verbose: bool)
             continue;
         }
 
+        let strategy = pkg.effective_versioning(&config.workspace);
+
         let bump = commits
             .iter()
             .map(|c| determine_bump(&c.message))
             .max()
             .unwrap_or(BumpType::None);
 
-        if bump == BumpType::None {
+        let is_date_or_seq = matches!(
+            strategy,
+            VersioningStrategy::Calver
+                | VersioningStrategy::CalverShort
+                | VersioningStrategy::CalverSeq
+                | VersioningStrategy::Sequential
+        );
+
+        if bump == BumpType::None && !is_date_or_seq {
             println!(
                 "{} {} — no releasable commits",
                 "○".dimmed(),
@@ -125,7 +135,20 @@ fn run_release_logic(root: &Path, config: &Config, dry_run: bool, verbose: bool)
         };
 
         let current_version = read_version(vf, root)?;
-        let new_version = bump_version(&current_version, bump)?;
+        let new_version = compute_next_version(&current_version, bump, strategy)?;
+
+        if current_version == new_version {
+            if verbose {
+                println!("{} {} — version unchanged", "○".dimmed(), pkg.name.dimmed());
+            }
+            continue;
+        }
+
+        let strategy_label = if is_date_or_seq {
+            format!("{strategy:?}").to_lowercase()
+        } else {
+            bump.to_string()
+        };
 
         println!(
             "{} {}  {} → {}  ({})",
@@ -133,7 +156,7 @@ fn run_release_logic(root: &Path, config: &Config, dry_run: bool, verbose: bool)
             pkg.name.bold(),
             current_version.dimmed(),
             new_version.green().bold(),
-            bump.to_string().cyan()
+            strategy_label.cyan()
         );
 
         if verbose {

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -1,8 +1,25 @@
+use crate::config::VersioningStrategy;
 use crate::conventional_commits::BumpType;
 use anyhow::Result;
+use chrono::Local;
 use semver::Version;
 
-pub fn bump_version(current: &str, bump: BumpType) -> Result<String> {
+pub fn compute_next_version(
+    current: &str,
+    bump: BumpType,
+    strategy: VersioningStrategy,
+) -> Result<String> {
+    match strategy {
+        VersioningStrategy::Semver => bump_semver(current, bump),
+        VersioningStrategy::Calver => calver_version("%Y.%m.%d"),
+        VersioningStrategy::CalverShort => calver_version("short"),
+        VersioningStrategy::CalverSeq => calver_seq_version(current),
+        VersioningStrategy::Sequential => bump_sequential(current),
+        VersioningStrategy::Zerover => bump_zerover(current, bump),
+    }
+}
+
+fn bump_semver(current: &str, bump: BumpType) -> Result<String> {
     let mut v = Version::parse(current.trim_start_matches('v'))
         .map_err(|e| anyhow::anyhow!("Invalid semver '{}': {}", current, e))?;
 
@@ -23,6 +40,79 @@ pub fn bump_version(current: &str, bump: BumpType) -> Result<String> {
     }
 
     Ok(v.to_string())
+}
+
+fn calver_version(format: &str) -> Result<String> {
+    let now = Local::now();
+    if format == "short" {
+        Ok(format!(
+            "{}.{}.{}",
+            now.format("%y"),
+            now.format("%-m"),
+            now.format("%-d")
+        ))
+    } else {
+        Ok(now.format("%Y.%-m.%-d").to_string())
+    }
+}
+
+fn calver_seq_version(current: &str) -> Result<String> {
+    let now = Local::now();
+    let year_month = format!("{}.{}", now.format("%Y"), now.format("%-m"));
+
+    // Parse current version to check if same year.month prefix
+    let seq = if current.starts_with(&year_month) {
+        // Same month — increment the sequence number
+        let parts: Vec<&str> = current.splitn(3, '.').collect();
+        if parts.len() == 3 {
+            parts[2].parse::<u32>().unwrap_or(0) + 1
+        } else {
+            1
+        }
+    } else {
+        1
+    };
+
+    Ok(format!("{year_month}.{seq}"))
+}
+
+fn bump_sequential(current: &str) -> Result<String> {
+    let n: u64 = current.trim_start_matches('v').parse().unwrap_or_else(|_| {
+        // Try parsing as semver and use patch as sequence
+        Version::parse(current.trim_start_matches('v'))
+            .map(|v| v.patch)
+            .unwrap_or(0)
+    });
+    Ok((n + 1).to_string())
+}
+
+fn bump_zerover(current: &str, bump: BumpType) -> Result<String> {
+    let mut v = Version::parse(current.trim_start_matches('v'))
+        .map_err(|e| anyhow::anyhow!("Invalid semver '{}': {}", current, e))?;
+
+    match bump {
+        // Major bump becomes minor in zerover
+        BumpType::Major => {
+            v.minor += 1;
+            v.patch = 0;
+        }
+        BumpType::Minor => {
+            v.minor += 1;
+            v.patch = 0;
+        }
+        BumpType::Patch => {
+            v.patch += 1;
+        }
+        BumpType::None => {}
+    }
+
+    v.major = 0;
+    Ok(v.to_string())
+}
+
+// Keep backward-compatible alias used by tests and other modules
+pub fn bump_version(current: &str, bump: BumpType) -> Result<String> {
+    bump_semver(current, bump)
 }
 
 #[cfg(test)]
@@ -52,5 +142,87 @@ mod tests {
     #[test]
     fn test_bump_with_v_prefix() {
         assert_eq!(bump_version("v1.2.3", BumpType::Patch).unwrap(), "1.2.4");
+    }
+
+    #[test]
+    fn test_zerover_major_becomes_minor() {
+        assert_eq!(bump_zerover("0.5.2", BumpType::Major).unwrap(), "0.6.0");
+    }
+
+    #[test]
+    fn test_zerover_clamps_major() {
+        assert_eq!(bump_zerover("0.9.0", BumpType::Major).unwrap(), "0.10.0");
+    }
+
+    #[test]
+    fn test_zerover_patch() {
+        assert_eq!(bump_zerover("0.5.2", BumpType::Patch).unwrap(), "0.5.3");
+    }
+
+    #[test]
+    fn test_sequential() {
+        assert_eq!(bump_sequential("41").unwrap(), "42");
+    }
+
+    #[test]
+    fn test_sequential_from_zero() {
+        assert_eq!(bump_sequential("0").unwrap(), "1");
+    }
+
+    #[test]
+    fn test_calver_format() {
+        let v = calver_version("%Y.%m.%d").unwrap();
+        // Should have 3 dot-separated parts
+        assert_eq!(v.split('.').count(), 3);
+    }
+
+    #[test]
+    fn test_calver_short_format() {
+        let v = calver_version("short").unwrap();
+        assert_eq!(v.split('.').count(), 3);
+        // Year part should be 2 digits
+        let year: u32 = v.split('.').next().unwrap().parse().unwrap();
+        assert!(year < 100);
+    }
+
+    #[test]
+    fn test_calver_seq_new_month() {
+        let v = calver_seq_version("2024.1.5").unwrap();
+        let parts: Vec<&str> = v.split('.').collect();
+        assert_eq!(parts.len(), 3);
+        // Should be current year.month.1 (new month resets seq)
+        assert_eq!(parts[2], "1");
+    }
+
+    #[test]
+    fn test_calver_seq_same_month() {
+        let now = chrono::Local::now();
+        let current = format!("{}.{}.3", now.format("%Y"), now.format("%-m"));
+        let v = calver_seq_version(&current).unwrap();
+        assert!(v.ends_with(".4"));
+    }
+
+    #[test]
+    fn test_compute_next_version_semver() {
+        assert_eq!(
+            compute_next_version("1.2.3", BumpType::Minor, VersioningStrategy::Semver).unwrap(),
+            "1.3.0"
+        );
+    }
+
+    #[test]
+    fn test_compute_next_version_zerover() {
+        assert_eq!(
+            compute_next_version("0.5.2", BumpType::Major, VersioningStrategy::Zerover).unwrap(),
+            "0.6.0"
+        );
+    }
+
+    #[test]
+    fn test_compute_next_version_sequential() {
+        assert_eq!(
+            compute_next_version("10", BumpType::Patch, VersioningStrategy::Sequential).unwrap(),
+            "11"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add `versioning` field to workspace config (default) and package config (override)
- Package-level strategy takes precedence over workspace-level
- 6 strategies: `semver`, `calver`, `calver-short`, `calver-seq`, `sequential`, `zerover`
- Date-based and sequential strategies release on any commit (ignore bump type)
- Update JSON schema with versioning field on both workspace and package
- 12 new tests covering all strategies

### Strategies

| Strategy | Format | Example |
|----------|--------|---------|
| `semver` | `MAJOR.MINOR.PATCH` | `1.4.2` |
| `calver` | `YYYY.M.D` | `2025.3.28` |
| `calver-short` | `YY.M.D` | `25.3.28` |
| `calver-seq` | `YYYY.M.SEQ` | `2025.3.3` |
| `sequential` | `N` | `42` |
| `zerover` | `0.MINOR.PATCH` | `0.15.2` |

Closes #23