### PR TITLE
feat: add version and tag query commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ ferrflow check --config path/to/ferrflow.toml
 
 # Or set via environment variable
 FERRFLOW_CONFIG=path/to/ferrflow.toml ferrflow check
+
+# Print current version
+ferrflow version              # single repo
+ferrflow version api          # monorepo, specific package
+
+# Print last release tag
+ferrflow tag
+ferrflow tag api
+
+# JSON output (for scripting)
+ferrflow version --json
+ferrflow tag --json
 ```
 
 ## Configuration

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,6 +47,22 @@ pub enum Commands {
         #[arg(long, value_enum, default_value = "text")]
         output: OutputFormat,
     },
+    /// Print the current version of a package
+    Version {
+        /// Package name (required in monorepos, optional in single repos)
+        package: Option<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Print the last release tag of a package
+    Tag {
+        /// Package name (required in monorepos, optional in single repos)
+        package: Option<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 impl Cli {
@@ -61,6 +77,12 @@ impl Cli {
             }
             Commands::Init { format } => crate::config::init(format),
             Commands::Status { output } => crate::status::run(self.config.as_deref(), &output),
+            Commands::Version { package, json } => {
+                crate::query::version(self.config.as_deref(), package.as_deref(), json)
+            }
+            Commands::Tag { package, json } => {
+                crate::query::tag(self.config.as_deref(), package.as_deref(), json)
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod conventional_commits;
 mod formats;
 mod git;
 mod monorepo;
+mod query;
 mod release;
 mod status;
 mod telemetry;

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,0 +1,184 @@
+use crate::config::Config;
+use crate::formats::read_version;
+use crate::git::{find_last_tag_name, get_repo_root, open_repo};
+use anyhow::{Result, bail};
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct VersionEntry {
+    name: String,
+    version: String,
+}
+
+#[derive(Serialize)]
+struct TagEntry {
+    name: String,
+    tag: Option<String>,
+}
+
+pub fn version(
+    config_path: Option<&std::path::Path>,
+    package: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    let repo = open_repo(&std::env::current_dir()?)?;
+    let root = get_repo_root(&repo)?;
+    let config = Config::load(&root, config_path)?;
+
+    if config.packages.is_empty() {
+        bail!("No packages configured. Run `ferrflow init` to create a config.");
+    }
+
+    if let Some(name) = package {
+        let pkg = config
+            .packages
+            .iter()
+            .find(|p| p.name == name)
+            .ok_or_else(|| anyhow::anyhow!("package '{}' not found", name))?;
+
+        let version = pkg
+            .versioned_files
+            .first()
+            .map(|vf| read_version(vf, &root))
+            .transpose()?
+            .unwrap_or_else(|| "unknown".to_string());
+
+        if json {
+            println!(
+                "{}",
+                serde_json::to_string(&VersionEntry {
+                    name: pkg.name.clone(),
+                    version,
+                })?
+            );
+        } else {
+            println!("{version}");
+        }
+        return Ok(());
+    }
+
+    // No package specified
+    if config.packages.len() == 1 {
+        let pkg = &config.packages[0];
+        let version = pkg
+            .versioned_files
+            .first()
+            .map(|vf| read_version(vf, &root))
+            .transpose()?
+            .unwrap_or_else(|| "unknown".to_string());
+
+        if json {
+            println!(
+                "{}",
+                serde_json::to_string(&VersionEntry {
+                    name: pkg.name.clone(),
+                    version,
+                })?
+            );
+        } else {
+            println!("{version}");
+        }
+    } else {
+        let entries: Vec<VersionEntry> = config
+            .packages
+            .iter()
+            .map(|pkg| {
+                let version = pkg
+                    .versioned_files
+                    .first()
+                    .and_then(|vf| read_version(vf, &root).ok())
+                    .unwrap_or_else(|| "unknown".to_string());
+                VersionEntry {
+                    name: pkg.name.clone(),
+                    version,
+                }
+            })
+            .collect();
+
+        if json {
+            println!("{}", serde_json::to_string(&entries)?);
+        } else {
+            for e in &entries {
+                println!("{}\t{}", e.name, e.version);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn tag(config_path: Option<&std::path::Path>, package: Option<&str>, json: bool) -> Result<()> {
+    let repo = open_repo(&std::env::current_dir()?)?;
+    let root = get_repo_root(&repo)?;
+    let config = Config::load(&root, config_path)?;
+
+    if config.packages.is_empty() {
+        bail!("No packages configured. Run `ferrflow init` to create a config.");
+    }
+
+    if let Some(name) = package {
+        let pkg = config
+            .packages
+            .iter()
+            .find(|p| p.name == name)
+            .ok_or_else(|| anyhow::anyhow!("package '{}' not found", name))?;
+
+        let prefix = pkg.tag_prefix(&config.workspace, config.is_monorepo());
+        let last_tag = find_last_tag_name(&repo, &prefix)?;
+
+        if json {
+            println!(
+                "{}",
+                serde_json::to_string(&TagEntry {
+                    name: pkg.name.clone(),
+                    tag: last_tag,
+                })?
+            );
+        } else {
+            println!("{}", last_tag.unwrap_or_else(|| "none".to_string()));
+        }
+        return Ok(());
+    }
+
+    // No package specified
+    if config.packages.len() == 1 {
+        let pkg = &config.packages[0];
+        let prefix = pkg.tag_prefix(&config.workspace, config.is_monorepo());
+        let last_tag = find_last_tag_name(&repo, &prefix)?;
+
+        if json {
+            println!(
+                "{}",
+                serde_json::to_string(&TagEntry {
+                    name: pkg.name.clone(),
+                    tag: last_tag,
+                })?
+            );
+        } else {
+            println!("{}", last_tag.unwrap_or_else(|| "none".to_string()));
+        }
+    } else {
+        let entries: Vec<TagEntry> = config
+            .packages
+            .iter()
+            .map(|pkg| {
+                let prefix = pkg.tag_prefix(&config.workspace, config.is_monorepo());
+                let tag = find_last_tag_name(&repo, &prefix).unwrap_or(None);
+                TagEntry {
+                    name: pkg.name.clone(),
+                    tag,
+                }
+            })
+            .collect();
+
+        if json {
+            println!("{}", serde_json::to_string(&entries)?);
+        } else {
+            for e in &entries {
+                println!("{}\t{}", e.name, e.tag.as_deref().unwrap_or("none"));
+            }
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Add `ferrflow version [package]` to print current version from versioned files
- Add `ferrflow tag [package]` to print last release tag
- Both support `--json` for structured output
- Single repo: no package arg needed, prints raw value
- Monorepo: without arg lists all packages, with arg prints single value

Designed for CI scripting:
```yaml
# GitLab
- echo "VERSION=$(ferrflow version)" >> release.env

# GitHub Actions
- echo "version=$(ferrflow version)" >> "$GITHUB_OUTPUT"
```

Closes #73