### PR TITLE
fix(ci): update release workflow for v{version} tag format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to build (e.g. ferrflow@v0.4.0)'
+        description: 'Tag to build (e.g. v0.6.0)'
         required: true
 
 jobs:
@@ -147,7 +147,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Move major version tag
         run: |
-          MAJOR="v$(echo "${GITHUB_REF_NAME#ferrflow@v}" | cut -d. -f1)"
+          MAJOR="v$(echo "${GITHUB_REF_NAME#v}" | cut -d. -f1)"
           git tag -f "$MAJOR"
           git push origin "refs/tags/$MAJOR" --force
 
@@ -173,7 +173,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Extract version
         id: version
-        run: echo "value=${GITHUB_REF_NAME#ferrflow@v}" >> $GITHUB_OUTPUT
+        run: echo "value=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
       - uses: docker/build-push-action@v7
         with:
           context: .

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
         if [ "${{ inputs.version }}" = "latest" ]; then
           URL="https://github.com/FerrFlow-Org/ferrflow/releases/latest/download/${ARCHIVE}"
         else
-          URL="https://github.com/FerrFlow-Org/ferrflow/releases/download/ferrflow%40v${{ inputs.version }}/${ARCHIVE}"
+          URL="https://github.com/FerrFlow-Org/ferrflow/releases/download/v${{ inputs.version }}/${ARCHIVE}"
         fi
 
         INSTALL_DIR="${RUNNER_TEMP:-$HOME/.local/bin}/ferrflow-bin"


### PR DESCRIPTION
## Summary
- Update `release.yml` version extraction from `ferrflow@v` to `v` prefix stripping
- Update `action.yml` download URL to use `v{version}` tag format instead of `ferrflow@v{version}`
- Update workflow_dispatch description to reflect new tag format

The tag format changed from `ferrflow@v0.6.0` to `v0.6.0` (single repo default).
This caused the Application CI to 404 when downloading the binary.