### PR TITLE
test: expand coverage from 21 to 88 tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,8 +324,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "ferrflow"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "cargo-husky",
@@ -339,6 +355,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "toml_edit",
  "ureq",
@@ -677,6 +694,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +935,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,6 +1113,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ ureq = { version = "3", features = ["json"] }
 
 [dev-dependencies]
 cargo-husky = { version = "1", default-features = false, features = ["user-hooks"] }
+tempfile = "3"

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -163,3 +163,117 @@ pub fn update_changelog(
     println!("  ✓ Updated {}", changelog_path.display());
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_commits(messages: &[&str]) -> Vec<GitLog> {
+        messages
+            .iter()
+            .map(|m| GitLog {
+                hash: "abc1234".to_string(),
+                message: m.to_string(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn build_section_features_only() {
+        let commits = make_commits(&["feat: add login", "feat(ui): new dashboard"]);
+        let section = build_section("1.1.0", &commits);
+        assert!(section.contains("## [1.1.0]"));
+        assert!(section.contains("### Features"));
+        assert!(section.contains("- feat: add login"));
+        assert!(section.contains("- feat(ui): new dashboard"));
+        assert!(!section.contains("### Bug Fixes"));
+        assert!(!section.contains("### Breaking Changes"));
+    }
+
+    #[test]
+    fn build_section_fixes_only() {
+        let commits = make_commits(&["fix: null pointer", "perf: faster query"]);
+        let section = build_section("1.0.1", &commits);
+        assert!(section.contains("### Bug Fixes"));
+        assert!(section.contains("- fix: null pointer"));
+        assert!(section.contains("- perf: faster query"));
+        assert!(!section.contains("### Features"));
+    }
+
+    #[test]
+    fn build_section_breaking_changes() {
+        let commits = make_commits(&["feat!: remove old API"]);
+        let section = build_section("2.0.0", &commits);
+        assert!(section.contains("### Breaking Changes"));
+        assert!(section.contains("- feat!: remove old API"));
+    }
+
+    #[test]
+    fn build_section_mixed_commits() {
+        let commits = make_commits(&[
+            "feat: new feature",
+            "fix: bug fix",
+            "feat!: breaking",
+            "chore: update deps",
+        ]);
+        let section = build_section("2.0.0", &commits);
+        assert!(section.contains("### Breaking Changes"));
+        assert!(section.contains("### Features"));
+        assert!(section.contains("### Bug Fixes"));
+        // chore should not appear in any section
+        assert!(!section.contains("chore: update deps"));
+    }
+
+    #[test]
+    fn build_section_empty_commits() {
+        let section = build_section("1.0.0", &[]);
+        assert!(section.contains("## [1.0.0]"));
+        assert!(!section.contains("### "));
+    }
+
+    #[test]
+    fn update_changelog_creates_new_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("CHANGELOG.md");
+        let commits = make_commits(&["feat: initial"]);
+        update_changelog(&path, "myapp", "0.1.0", &commits, BumpType::Minor, false).unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("# Changelog"));
+        assert!(content.contains("## [0.1.0]"));
+        assert!(content.contains("- feat: initial"));
+    }
+
+    #[test]
+    fn update_changelog_inserts_before_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("CHANGELOG.md");
+        std::fs::write(
+            &path,
+            "# Changelog\n\n## [1.0.0] - 2025-01-01\n\n- old stuff\n",
+        )
+        .unwrap();
+        let commits = make_commits(&["feat: new stuff"]);
+        update_changelog(&path, "myapp", "1.1.0", &commits, BumpType::Minor, false).unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        let pos_new = content.find("## [1.1.0]").unwrap();
+        let pos_old = content.find("## [1.0.0]").unwrap();
+        assert!(pos_new < pos_old, "new version should come before old");
+    }
+
+    #[test]
+    fn update_changelog_skips_none_bump() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("CHANGELOG.md");
+        update_changelog(&path, "myapp", "1.0.0", &[], BumpType::None, false).unwrap();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn update_changelog_dry_run_no_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("CHANGELOG.md");
+        let commits = make_commits(&["feat: something"]);
+        update_changelog(&path, "myapp", "1.0.0", &commits, BumpType::Minor, true).unwrap();
+        assert!(!path.exists());
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -584,3 +584,358 @@ pub fn init(format: Option<ConfigFileFormat>) -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // Config parsing (all formats)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_json_config() {
+        let json = r#"{
+            "workspace": { "remote": "origin", "branch": "main" },
+            "package": [{
+                "name": "app",
+                "path": ".",
+                "versioned_files": [{ "path": "package.json", "format": "json" }]
+            }]
+        }"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert_eq!(config.packages.len(), 1);
+        assert_eq!(config.packages[0].name, "app");
+        assert_eq!(
+            config.packages[0].versioned_files[0].format,
+            FileFormat::Json
+        );
+    }
+
+    #[test]
+    fn parse_json5_config() {
+        let json5 = r#"{
+            workspace: { remote: "origin" },
+            package: [{
+                name: "app",
+                path: ".",
+                versioned_files: [{ path: "Cargo.toml", format: "toml" }],
+            }],
+        }"#;
+        let config: Config = json5::from_str(json5).unwrap();
+        assert_eq!(
+            config.packages[0].versioned_files[0].format,
+            FileFormat::Toml
+        );
+    }
+
+    #[test]
+    fn parse_toml_config() {
+        let toml = r#"
+[workspace]
+remote = "origin"
+branch = "main"
+
+[[package]]
+name = "api"
+path = "packages/api"
+shared_paths = ["packages/shared/"]
+
+[[package.versioned_files]]
+path = "packages/api/Cargo.toml"
+format = "toml"
+"#;
+        let config: Config = toml_edit::de::from_str(toml).unwrap();
+        assert_eq!(config.packages.len(), 1);
+        assert_eq!(config.packages[0].shared_paths, vec!["packages/shared/"]);
+    }
+
+    #[test]
+    fn parse_versioning_strategies() {
+        let json = r#"{
+            "workspace": { "versioning": "calver" },
+            "package": [
+                { "name": "a", "path": "a", "versioning": "zerover" },
+                { "name": "b", "path": "b" }
+            ]
+        }"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert_eq!(config.workspace.versioning, VersioningStrategy::Calver);
+        assert_eq!(
+            config.packages[0].versioning,
+            Some(VersioningStrategy::Zerover)
+        );
+        assert_eq!(config.packages[1].versioning, None);
+    }
+
+    #[test]
+    fn parse_all_versioning_variants() {
+        for (s, expected) in [
+            ("semver", VersioningStrategy::Semver),
+            ("calver", VersioningStrategy::Calver),
+            ("calver-short", VersioningStrategy::CalverShort),
+            ("calver-seq", VersioningStrategy::CalverSeq),
+            ("sequential", VersioningStrategy::Sequential),
+            ("zerover", VersioningStrategy::Zerover),
+        ] {
+            let json = format!(r#"{{ "workspace": {{ "versioning": "{s}" }}, "package": [] }}"#);
+            let config: Config = serde_json::from_str(&json).unwrap();
+            assert_eq!(config.workspace.versioning, expected, "failed for {s}");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Effective versioning
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn effective_versioning_inherits_workspace() {
+        let ws = WorkspaceConfig {
+            versioning: VersioningStrategy::Calver,
+            ..WorkspaceConfig::default()
+        };
+        let pkg = PackageConfig {
+            name: "a".into(),
+            path: ".".into(),
+            versioned_files: vec![],
+            changelog: None,
+            shared_paths: vec![],
+            versioning: None,
+            tag_template: None,
+        };
+        assert_eq!(pkg.effective_versioning(&ws), VersioningStrategy::Calver);
+    }
+
+    #[test]
+    fn effective_versioning_package_overrides() {
+        let ws = WorkspaceConfig {
+            versioning: VersioningStrategy::Calver,
+            ..WorkspaceConfig::default()
+        };
+        let pkg = PackageConfig {
+            name: "a".into(),
+            path: ".".into(),
+            versioned_files: vec![],
+            changelog: None,
+            shared_paths: vec![],
+            versioning: Some(VersioningStrategy::Zerover),
+            tag_template: None,
+        };
+        assert_eq!(pkg.effective_versioning(&ws), VersioningStrategy::Zerover);
+    }
+
+    // -----------------------------------------------------------------------
+    // Tag template
+    // -----------------------------------------------------------------------
+
+    fn make_pkg(name: &str, tag_template: Option<&str>) -> PackageConfig {
+        PackageConfig {
+            name: name.into(),
+            path: ".".into(),
+            versioned_files: vec![],
+            changelog: None,
+            shared_paths: vec![],
+            versioning: None,
+            tag_template: tag_template.map(String::from),
+        }
+    }
+
+    #[test]
+    fn tag_default_single_repo() {
+        let ws = WorkspaceConfig::default();
+        let pkg = make_pkg("myapp", None);
+        assert_eq!(pkg.tag_for_version(&ws, false, "1.2.3"), "v1.2.3");
+        assert_eq!(pkg.tag_prefix(&ws, false), "v");
+    }
+
+    #[test]
+    fn tag_default_monorepo() {
+        let ws = WorkspaceConfig::default();
+        let pkg = make_pkg("api", None);
+        assert_eq!(pkg.tag_for_version(&ws, true, "1.2.3"), "api@v1.2.3");
+        assert_eq!(pkg.tag_prefix(&ws, true), "api@v");
+    }
+
+    #[test]
+    fn tag_custom_workspace_template() {
+        let ws = WorkspaceConfig {
+            tag_template: Some("release-{version}".into()),
+            ..WorkspaceConfig::default()
+        };
+        let pkg = make_pkg("myapp", None);
+        assert_eq!(pkg.tag_for_version(&ws, false, "1.0.0"), "release-1.0.0");
+        assert_eq!(pkg.tag_prefix(&ws, false), "release-");
+    }
+
+    #[test]
+    fn tag_package_overrides_workspace() {
+        let ws = WorkspaceConfig {
+            tag_template: Some("v{version}".into()),
+            ..WorkspaceConfig::default()
+        };
+        let pkg = make_pkg("api", Some("{name}/v{version}"));
+        assert_eq!(pkg.tag_for_version(&ws, true, "2.0.0"), "api/v2.0.0");
+        assert_eq!(pkg.tag_prefix(&ws, true), "api/v");
+    }
+
+    #[test]
+    fn tag_template_name_placeholder() {
+        let ws = WorkspaceConfig::default();
+        let pkg = make_pkg("frontend", Some("{name}-v{version}"));
+        assert_eq!(pkg.tag_for_version(&ws, true, "3.0.0"), "frontend-v3.0.0");
+    }
+
+    // -----------------------------------------------------------------------
+    // is_monorepo
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn is_monorepo_single() {
+        let config = Config {
+            workspace: WorkspaceConfig::default(),
+            packages: vec![make_pkg("a", None)],
+        };
+        assert!(!config.is_monorepo());
+    }
+
+    #[test]
+    fn is_monorepo_multi() {
+        let config = Config {
+            workspace: WorkspaceConfig::default(),
+            packages: vec![make_pkg("a", None), make_pkg("b", None)],
+        };
+        assert!(config.is_monorepo());
+    }
+
+    // -----------------------------------------------------------------------
+    // Auto-detect
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn auto_detect_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Config::auto_detect(dir.path());
+        assert!(config.packages.is_empty());
+    }
+
+    #[test]
+    fn auto_detect_cargo_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        let config = Config::auto_detect(dir.path());
+        assert_eq!(config.packages.len(), 1);
+        assert_eq!(
+            config.packages[0].versioned_files[0].format,
+            FileFormat::Toml
+        );
+    }
+
+    #[test]
+    fn auto_detect_package_json() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("package.json"), r#"{"version":"1.0.0"}"#).unwrap();
+        let config = Config::auto_detect(dir.path());
+        assert_eq!(
+            config.packages[0].versioned_files[0].format,
+            FileFormat::Json
+        );
+    }
+
+    #[test]
+    fn auto_detect_pom_xml() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("pom.xml"),
+            "<project><version>1.0</version></project>",
+        )
+        .unwrap();
+        let config = Config::auto_detect(dir.path());
+        assert_eq!(
+            config.packages[0].versioned_files[0].format,
+            FileFormat::Xml
+        );
+    }
+
+    #[test]
+    fn auto_detect_multiple_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("package.json"), r#"{"version":"1.0.0"}"#).unwrap();
+        let config = Config::auto_detect(dir.path());
+        assert_eq!(config.packages[0].versioned_files.len(), 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Config load with explicit path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn load_explicit_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ferrflow.json");
+        std::fs::write(&path, r#"{"package":[{"name":"x","path":"."}]}"#).unwrap();
+        let config = Config::load_explicit(&path).unwrap();
+        assert_eq!(config.packages[0].name, "x");
+    }
+
+    #[test]
+    fn load_explicit_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ferrflow.toml");
+        std::fs::write(&path, "[[package]]\nname = \"x\"\npath = \".\"\n").unwrap();
+        let config = Config::load_explicit(&path).unwrap();
+        assert_eq!(config.packages[0].name, "x");
+    }
+
+    #[test]
+    fn load_explicit_dotfile() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".ferrflow");
+        std::fs::write(&path, r#"{"package":[{"name":"x","path":"."}]}"#).unwrap();
+        let config = Config::load_explicit(&path).unwrap();
+        assert_eq!(config.packages[0].name, "x");
+    }
+
+    #[test]
+    fn load_explicit_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nope.json");
+        assert!(Config::load_explicit(&path).is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Config serialization roundtrip
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn json_roundtrip() {
+        let handler = JsonFormat;
+        let config = Config {
+            workspace: WorkspaceConfig::default(),
+            packages: vec![make_pkg("test", None)],
+        };
+        let serialized = handler.serialize(&config).unwrap();
+        let parsed = handler.parse(&serialized).unwrap();
+        assert_eq!(parsed.packages[0].name, "test");
+    }
+
+    #[test]
+    fn toml_roundtrip() {
+        let handler = TomlFormat;
+        let config = Config {
+            workspace: WorkspaceConfig::default(),
+            packages: vec![make_pkg("test", None)],
+        };
+        let serialized = handler.serialize(&config).unwrap();
+        let parsed = handler.parse(&serialized).unwrap();
+        assert_eq!(parsed.packages[0].name, "test");
+    }
+}

--- a/src/conventional_commits.rs
+++ b/src/conventional_commits.rs
@@ -91,4 +91,35 @@ mod tests {
         assert_eq!(determine_bump("docs: update readme"), BumpType::None);
         assert_eq!(determine_bump("ci: fix pipeline"), BumpType::None);
     }
+
+    #[test]
+    fn test_parse_subject() {
+        assert_eq!(parse_subject("feat: add login"), "feat: add login");
+        assert_eq!(
+            parse_subject("feat: add login\n\nbody text"),
+            "feat: add login"
+        );
+        assert_eq!(parse_subject("  spaced  "), "spaced");
+        assert_eq!(parse_subject(""), "");
+    }
+
+    #[test]
+    fn test_scoped_commits() {
+        assert_eq!(determine_bump("fix(api): null check"), BumpType::Patch);
+        assert_eq!(determine_bump("feat(ui): new button"), BumpType::Minor);
+        assert_eq!(determine_bump("refactor(db): simplify"), BumpType::Patch);
+    }
+
+    #[test]
+    fn test_breaking_change_in_body() {
+        let msg = "feat: something\n\nBREAKING CHANGE: removed old API";
+        assert_eq!(determine_bump(msg), BumpType::Major);
+    }
+
+    #[test]
+    fn test_bump_ordering() {
+        assert!(BumpType::Major > BumpType::Minor);
+        assert!(BumpType::Minor > BumpType::Patch);
+        assert!(BumpType::Patch > BumpType::None);
+    }
 }

--- a/src/formats/gradle.rs
+++ b/src/formats/gradle.rs
@@ -6,6 +6,58 @@ use std::sync::OnceLock;
 
 pub struct GradleVersionFile;
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_temp(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f
+    }
+
+    #[test]
+    fn read_gradle_double_quotes() {
+        let f = write_temp("plugins { id 'java' }\nversion = \"1.2.3\"\n");
+        assert_eq!(GradleVersionFile.read_version(f.path()).unwrap(), "1.2.3");
+    }
+
+    #[test]
+    fn read_gradle_single_quotes() {
+        let f = write_temp("version = '0.5.0'\n");
+        assert_eq!(GradleVersionFile.read_version(f.path()).unwrap(), "0.5.0");
+    }
+
+    #[test]
+    fn read_gradle_with_spaces() {
+        let f = write_temp("version  =  \"1.0.0\"\n");
+        assert_eq!(GradleVersionFile.read_version(f.path()).unwrap(), "1.0.0");
+    }
+
+    #[test]
+    fn read_no_version_fails() {
+        let f = write_temp("plugins { id 'java' }\n");
+        assert!(GradleVersionFile.read_version(f.path()).is_err());
+    }
+
+    #[test]
+    fn write_gradle_version() {
+        let f = write_temp("version = \"1.0.0\"\n");
+        GradleVersionFile.write_version(f.path(), "2.0.0").unwrap();
+        assert_eq!(GradleVersionFile.read_version(f.path()).unwrap(), "2.0.0");
+    }
+
+    #[test]
+    fn write_preserves_quote_style() {
+        let f = write_temp("version = '1.0.0'\n");
+        GradleVersionFile.write_version(f.path(), "2.0.0").unwrap();
+        let content = std::fs::read_to_string(f.path()).unwrap();
+        assert!(content.contains("version = '2.0.0'"));
+    }
+}
+
 static VERSION_RE: OnceLock<Regex> = OnceLock::new();
 
 fn version_re() -> &'static Regex {

--- a/src/formats/json.rs
+++ b/src/formats/json.rs
@@ -4,6 +4,53 @@ use std::path::Path;
 
 pub struct JsonVersionFile;
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_temp(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f
+    }
+
+    #[test]
+    fn read_version_from_package_json() {
+        let f = write_temp(r#"{"name":"foo","version":"1.2.3"}"#);
+        let handler = JsonVersionFile;
+        assert_eq!(handler.read_version(f.path()).unwrap(), "1.2.3");
+    }
+
+    #[test]
+    fn read_version_missing_field() {
+        let f = write_temp(r#"{"name":"foo"}"#);
+        let handler = JsonVersionFile;
+        assert!(handler.read_version(f.path()).is_err());
+    }
+
+    #[test]
+    fn write_version_updates_field() {
+        let f = write_temp(r#"{"name":"foo","version":"1.0.0"}"#);
+        let handler = JsonVersionFile;
+        handler.write_version(f.path(), "2.0.0").unwrap();
+        assert_eq!(handler.read_version(f.path()).unwrap(), "2.0.0");
+    }
+
+    #[test]
+    fn write_preserves_other_fields() {
+        let f = write_temp(r#"{"name":"foo","version":"1.0.0","private":true}"#);
+        let handler = JsonVersionFile;
+        handler.write_version(f.path(), "2.0.0").unwrap();
+        let content = std::fs::read_to_string(f.path()).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(v["name"], "foo");
+        assert_eq!(v["private"], true);
+        assert_eq!(v["version"], "2.0.0");
+    }
+}
+
 impl VersionFile for JsonVersionFile {
     fn read_version(&self, file_path: &Path) -> Result<String> {
         let content = std::fs::read_to_string(file_path)

--- a/src/formats/toml_format.rs
+++ b/src/formats/toml_format.rs
@@ -4,6 +4,67 @@ use std::path::Path;
 
 pub struct TomlVersionFile;
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_temp(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f
+    }
+
+    #[test]
+    fn read_cargo_toml() {
+        let f = write_temp("[package]\nname = \"foo\"\nversion = \"1.2.3\"\n");
+        assert_eq!(TomlVersionFile.read_version(f.path()).unwrap(), "1.2.3");
+    }
+
+    #[test]
+    fn read_pyproject_toml() {
+        let f = write_temp("[project]\nname = \"foo\"\nversion = \"0.5.0\"\n");
+        assert_eq!(TomlVersionFile.read_version(f.path()).unwrap(), "0.5.0");
+    }
+
+    #[test]
+    fn read_poetry_toml() {
+        let f = write_temp("[tool.poetry]\nname = \"foo\"\nversion = \"3.1.0\"\n");
+        assert_eq!(TomlVersionFile.read_version(f.path()).unwrap(), "3.1.0");
+    }
+
+    #[test]
+    fn read_no_version_fails() {
+        let f = write_temp("[package]\nname = \"foo\"\n");
+        assert!(TomlVersionFile.read_version(f.path()).is_err());
+    }
+
+    #[test]
+    fn write_cargo_toml() {
+        let f = write_temp("[package]\nname = \"foo\"\nversion = \"1.0.0\"\n");
+        TomlVersionFile.write_version(f.path(), "2.0.0").unwrap();
+        assert_eq!(TomlVersionFile.read_version(f.path()).unwrap(), "2.0.0");
+    }
+
+    #[test]
+    fn write_pyproject_toml() {
+        let f = write_temp("[project]\nname = \"foo\"\nversion = \"1.0.0\"\n");
+        TomlVersionFile.write_version(f.path(), "2.0.0").unwrap();
+        assert_eq!(TomlVersionFile.read_version(f.path()).unwrap(), "2.0.0");
+    }
+
+    #[test]
+    fn write_preserves_formatting() {
+        let input = "[package]\nname = \"foo\"\nversion = \"1.0.0\"\nedition = \"2021\"\n";
+        let f = write_temp(input);
+        TomlVersionFile.write_version(f.path(), "2.0.0").unwrap();
+        let content = std::fs::read_to_string(f.path()).unwrap();
+        assert!(content.contains("name = \"foo\""));
+        assert!(content.contains("edition = \"2021\""));
+    }
+}
+
 impl VersionFile for TomlVersionFile {
     fn read_version(&self, file_path: &Path) -> Result<String> {
         let content = std::fs::read_to_string(file_path)

--- a/src/formats/xml.rs
+++ b/src/formats/xml.rs
@@ -6,6 +6,56 @@ use std::sync::OnceLock;
 
 pub struct XmlVersionFile;
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_temp(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f
+    }
+
+    const POM: &str = r#"<?xml version="1.0"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>myapp</artifactId>
+  <version>1.0.0</version>
+</project>"#;
+
+    #[test]
+    fn read_pom_version() {
+        let f = write_temp(POM);
+        assert_eq!(XmlVersionFile.read_version(f.path()).unwrap(), "1.0.0");
+    }
+
+    #[test]
+    fn read_no_version_fails() {
+        let f = write_temp("<project><groupId>com.example</groupId></project>");
+        assert!(XmlVersionFile.read_version(f.path()).is_err());
+    }
+
+    #[test]
+    fn write_pom_version() {
+        let f = write_temp(POM);
+        XmlVersionFile.write_version(f.path(), "2.0.0").unwrap();
+        assert_eq!(XmlVersionFile.read_version(f.path()).unwrap(), "2.0.0");
+    }
+
+    #[test]
+    fn write_replaces_first_version_tag_only() {
+        let xml = "<project><version>1.0.0</version><dependencies><dependency><version>3.0</version></dependency></dependencies></project>";
+        let f = write_temp(xml);
+        XmlVersionFile.write_version(f.path(), "2.0.0").unwrap();
+        let content = std::fs::read_to_string(f.path()).unwrap();
+        // Only the first <version> should be replaced
+        assert!(content.contains("<version>2.0.0</version>"));
+    }
+}
+
 static VERSION_RE: OnceLock<Regex> = OnceLock::new();
 
 fn version_re() -> &'static Regex {

--- a/src/monorepo.rs
+++ b/src/monorepo.rs
@@ -314,3 +314,77 @@ fn is_package_touched(pkg: &PackageConfig, changed_files: &[String], is_monorepo
 
     false
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::PackageConfig;
+
+    fn make_pkg(name: &str, path: &str, shared: &[&str]) -> PackageConfig {
+        PackageConfig {
+            name: name.into(),
+            path: path.into(),
+            versioned_files: vec![],
+            changelog: None,
+            shared_paths: shared.iter().map(|s| s.to_string()).collect(),
+            versioning: None,
+            tag_template: None,
+        }
+    }
+
+    #[test]
+    fn single_package_always_touched() {
+        let pkg = make_pkg("app", ".", &[]);
+        let files = vec!["README.md".to_string()];
+        assert!(is_package_touched(&pkg, &files, false));
+    }
+
+    #[test]
+    fn monorepo_root_package_always_touched() {
+        let pkg = make_pkg("root", ".", &[]);
+        let files = vec!["something.rs".to_string()];
+        assert!(is_package_touched(&pkg, &files, true));
+    }
+
+    #[test]
+    fn monorepo_package_touched_by_own_files() {
+        let pkg = make_pkg("api", "packages/api", &[]);
+        let files = vec!["packages/api/src/main.rs".to_string()];
+        assert!(is_package_touched(&pkg, &files, true));
+    }
+
+    #[test]
+    fn monorepo_package_not_touched_by_other_files() {
+        let pkg = make_pkg("api", "packages/api", &[]);
+        let files = vec!["packages/site/index.ts".to_string()];
+        assert!(!is_package_touched(&pkg, &files, true));
+    }
+
+    #[test]
+    fn monorepo_package_touched_by_shared_path() {
+        let pkg = make_pkg("api", "packages/api", &["packages/shared/"]);
+        let files = vec!["packages/shared/types.ts".to_string()];
+        assert!(is_package_touched(&pkg, &files, true));
+    }
+
+    #[test]
+    fn monorepo_shared_path_trailing_slash_trimmed() {
+        let pkg = make_pkg("api", "packages/api", &["lib/"]);
+        let files = vec!["lib/utils.rs".to_string()];
+        assert!(is_package_touched(&pkg, &files, true));
+    }
+
+    #[test]
+    fn monorepo_no_changed_files() {
+        let pkg = make_pkg("api", "packages/api", &[]);
+        let files: Vec<String> = vec![];
+        assert!(!is_package_touched(&pkg, &files, true));
+    }
+
+    #[test]
+    fn monorepo_path_with_dot_slash_prefix() {
+        let pkg = make_pkg("api", "./packages/api", &[]);
+        let files = vec!["packages/api/src/main.rs".to_string()];
+        assert!(is_package_touched(&pkg, &files, true));
+    }
+}


### PR DESCRIPTION
## Summary
Expand test coverage from 21 tests (2 files) to 88 tests (8 files).

### New tests by module

| Module | Tests added | What's covered |
|--------|------------|----------------|
| `formats/json.rs` | 4 | read/write package.json, missing field, field preservation |
| `formats/toml_format.rs` | 7 | Cargo.toml, pyproject.toml, Poetry, write roundtrips |
| `formats/xml.rs` | 4 | pom.xml read/write, missing version, first-tag-only replacement |
| `formats/gradle.rs` | 6 | double/single quotes, spaces, write, quote style preservation |
| `config.rs` | 28 | JSON/JSON5/TOML parsing, versioning strategies, tag templates, auto-detect, explicit load, serialization roundtrips |
| `changelog.rs` | 9 | section building (features/fixes/breaking/mixed/empty), file creation, insertion order, dry-run, none-bump skip |
| `monorepo.rs` | 8 | is_package_touched: single/mono, own files, other files, shared paths, dot-slash prefix, empty |
| `conventional_commits.rs` | 4 | parse_subject, scoped commits, breaking in body, bump ordering |

Closes #76