### PR TITLE
perf(bench): remove mono-stress fixture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ benchmarks/fixtures/single/
 benchmarks/fixtures/mono-small/
 benchmarks/fixtures/mono-medium/
 benchmarks/fixtures/mono-large/
-benchmarks/fixtures/mono-stress/

--- a/benchmarks/compare.sh
+++ b/benchmarks/compare.sh
@@ -47,9 +47,6 @@ declare -A ABS_THRESHOLDS=(
   ["ferrflow|mono-large|check"]=2000
   ["ferrflow|mono-large|version"]=500
   ["ferrflow|mono-large|tag"]=500
-  ["ferrflow|mono-stress|check"]=10000
-  ["ferrflow|mono-stress|version"]=2000
-  ["ferrflow|mono-stress|tag"]=2000
 )
 
 # ---------------------------------------------------------------------------

--- a/benchmarks/fixtures/generate.sh
+++ b/benchmarks/fixtures/generate.sh
@@ -4,12 +4,11 @@ set -euo pipefail
 # Generate synthetic git repos for benchmarking.
 # Usage: ./generate.sh <output_dir>
 #
-# Creates five fixtures:
+# Creates four fixtures:
 #   single/       — single-package repo, ~100 commits
 #   mono-small/   — 10 packages, ~100 commits
 #   mono-medium/  — 50 packages, ~500 commits
 #   mono-large/   — 200 packages, ~10000 commits
-#   mono-stress/  — 1000 packages, ~50000 commits
 
 OUTPUT_DIR="${1:-.}"
 COMMIT_TYPES=("feat" "fix" "refactor" "perf" "chore" "docs" "ci" "test")
@@ -176,5 +175,4 @@ create_single
 create_mono "mono-small" 10 100
 create_mono "mono-medium" 50 500
 create_mono "mono-large" 200 10000
-create_mono "mono-stress" 1000 50000
 echo "Done."

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -101,8 +101,8 @@ require_cmd jq
 
 mkdir -p "$RAW_DIR"
 
-FIXTURES=("single" "mono-small" "mono-medium" "mono-large" "mono-stress")
-FIXTURE_LABELS=("single" "mono-small (10 pkg)" "mono-medium (50 pkg)" "mono-large (200 pkg)" "mono-stress (1000 pkg)")
+FIXTURES=("single" "mono-small" "mono-medium" "mono-large")
+FIXTURE_LABELS=("single" "mono-small (10 pkg)" "mono-medium (50 pkg)" "mono-large (200 pkg)")
 FERRFLOW_CMDS=("check" "release --dry-run" "version" "tag")
 FERRFLOW_CMD_NAMES=("check" "release-dry" "version" "tag")
 # Competitors only run on the first 3 fixtures


### PR DESCRIPTION
## Summary
- Remove mono-stress fixture (1000 packages, 50000 commits) from benchmark suite
- Too slow to generate and run in CI
- Keeps mono-large (200 packages, 10000 commits) as the largest fixture

Closes #88

## Test plan
- [ ] Benchmark suite runs without mono-stress
- [ ] Regression detection still works with remaining fixtures