### PR TITLE
fix: use plain English in error messages instead of config key names

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -43,7 +43,7 @@ pub fn generate_only(config_path: Option<&Path>, dry_run: bool) -> Result<()> {
             println!(
                 "{}",
                 format!(
-                    "  Skipping {}: no versioned_files configured, cannot determine version.",
+                    "  Skipping {}: no versioned files configured, cannot determine version.",
                     pkg.name
                 )
                 .yellow()

--- a/src/monorepo.rs
+++ b/src/monorepo.rs
@@ -128,7 +128,7 @@ fn run_release_logic(root: &Path, config: &Config, dry_run: bool, verbose: bool)
 
         let Some(vf) = pkg.versioned_files.first() else {
             println!(
-                "{} {} — no versioned_files configured",
+                "{} {} — no versioned files configured",
                 "!".yellow(),
                 pkg.name.yellow()
             );


### PR DESCRIPTION
## Summary
- Replace `no versioned_files configured` with `no versioned files configured` in error messages
- Error messages should not reference internal config key names

Closes #87