### PR TITLE
chore: use snake_case config keys for backwards compatibility

### DIFF
--- a/.ferrflow
+++ b/.ferrflow
@@ -2,15 +2,15 @@
   "workspace": {
     "remote": "origin",
     "branch": "main",
-    "tagTemplate": "v{version}"
+    "tag_template": "v{version}"
   },
   "package": [
     {
       "name": "ferrflow",
       "path": ".",
       "changelog": "CHANGELOG.md",
-      "sharedPaths": ["src/"],
-      "versionedFiles": [
+      "shared_paths": ["src/"],
+      "versioned_files": [
         { "path": "Cargo.toml", "format": "toml" },
         { "path": "npm/package.json", "format": "json" }
       ]


### PR DESCRIPTION
## Summary
- Revert `.ferrflow` config to snake_case keys so the current released binary (v0.6.0, pre-camelCase support) can parse it
- This unblocks the release pipeline — once the new version is released with camelCase support, the config can be switched back

## Test plan
- [ ] CI passes
- [ ] After merge, FerrFlow release job creates a new version