### PR TITLE
chore: sync version to 0.6.0 to match existing tag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrflow"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 description = "Universal semantic versioning for monorepos and classic repos"
 license = "MIT"

--- a/npm/package.json
+++ b/npm/package.json
@@ -25,5 +25,5 @@
     "url": "git+https://github.com/FerrFlow/FerrFlow.git"
   },
   "type": "module",
-  "version": "0.4.0"
+  "version": "0.6.0"
 }


### PR DESCRIPTION
## Summary
- Update Cargo.toml from 0.5.0 to 0.6.0
- Update npm/package.json from 0.4.0 to 0.6.0
- These were out of sync with the existing v0.6.0 tag, causing FerrFlow to skip releases

## Test plan
- [ ] After merge, FerrFlow release job should detect new commits and create v0.7.0