### PR TITLE
chore: sync version to 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrflow"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 description = "Universal semantic versioning for monorepos and classic repos"
 license = "MIT"

--- a/npm/package.json
+++ b/npm/package.json
@@ -25,5 +25,5 @@
     "url": "git+https://github.com/FerrFlow/FerrFlow.git"
   },
   "type": "module",
-  "version": "0.6.0"
+  "version": "0.7.0"
 }


### PR DESCRIPTION
Sync Cargo.toml and npm/package.json to 0.7.0 to match the existing v0.7.0 tag and release.