### PR TITLE
chore: sync version to 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrflow"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 description = "Universal semantic versioning for monorepos and classic repos"
 license = "MIT"

--- a/npm/package.json
+++ b/npm/package.json
@@ -25,5 +25,5 @@
     "url": "git+https://github.com/FerrFlow/FerrFlow.git"
   },
   "type": "module",
-  "version": "0.7.0"
+  "version": "0.8.0"
 }


### PR DESCRIPTION
Last manual version sync. From 0.9.0 onwards, releaseCommitMode handles this automatically.