### PR TITLE
fix(ci): use Rust generate-fixtures instead of deleted bash script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
         with:
           node-version: '24'
       - name: Generate fixtures
-        run: bash benchmarks/fixtures/generate.sh benchmarks/fixtures
+        run: cargo run --release --bin generate-fixtures -- benchmarks/fixtures
       - name: Run benchmarks
         run: bash benchmarks/run.sh
       - name: Download baseline


### PR DESCRIPTION
The benchmark job still referenced `generate.sh` which was removed in #110. Switch to `cargo run --release --bin generate-fixtures`.