### PR TITLE
chore: switch .ferrflow config to camelCase

### DIFF
--- a/.ferrflow
+++ b/.ferrflow
@@ -2,15 +2,15 @@
   "workspace": {
     "remote": "origin",
     "branch": "main",
-    "tag_template": "v{version}"
+    "tagTemplate": "v{version}"
   },
   "package": [
     {
       "name": "ferrflow",
       "path": ".",
       "changelog": "CHANGELOG.md",
-      "shared_paths": ["src/"],
-      "versioned_files": [
+      "sharedPaths": ["src/"],
+      "versionedFiles": [
         { "path": "Cargo.toml", "format": "toml" },
         { "path": "npm/package.json", "format": "json" }
       ]


### PR DESCRIPTION
Switch `tag_template`, `shared_paths`, and `versioned_files` to their camelCase equivalents (`tagTemplate`, `sharedPaths`, `versionedFiles`) for consistency with the JSON schema.