### PR TITLE
feat(formats): support plain text version files

### DIFF
--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -95,7 +95,7 @@
                 "format": {
                   "type": "string",
                   "description": "File format used to locate and update the version field.",
-                  "enum": ["toml", "json", "xml", "gradle", "gomod"]
+                  "enum": ["toml", "json", "xml", "gradle", "gomod", "txt"]
                 }
               },
               "additionalProperties": false

--- a/src/config.rs
+++ b/src/config.rs
@@ -158,6 +158,7 @@ pub enum FileFormat {
     Gradle,
     Json,
     Toml,
+    Txt,
     Xml,
 }
 
@@ -413,6 +414,15 @@ impl Config {
                 format: FileFormat::Xml,
             });
         }
+        for name in &["VERSION", "VERSION.txt"] {
+            if root.join(name).exists() {
+                versioned_files.push(VersionedFile {
+                    path: name.to_string(),
+                    format: FileFormat::Txt,
+                });
+                break;
+            }
+        }
         if root.join("pyproject.toml").exists() {
             versioned_files.push(VersionedFile {
                 path: "pyproject.toml".to_string(),
@@ -481,13 +491,13 @@ fn prompt_bool(question: &str, default: bool) -> bool {
     }
 }
 
-const ALLOWED_FORMATS: &[&str] = &["toml", "json", "xml", "gradle", "gomod"];
+const ALLOWED_FORMATS: &[&str] = &["toml", "json", "xml", "gradle", "gomod", "txt"];
 
 fn prompt_format(indent: bool) -> String {
     let question = if indent {
-        "  Version file format [toml/json/xml/gradle/gomod]"
+        "  Version file format [toml/json/xml/gradle/gomod/txt]"
     } else {
-        "Version file format [toml/json/xml/gradle/gomod]"
+        "Version file format [toml/json/xml/gradle/gomod/txt]"
     };
     loop {
         let input = prompt(question, "toml");
@@ -496,7 +506,7 @@ fn prompt_format(indent: bool) -> String {
             return normalized;
         }
         eprintln!(
-            "Invalid format '{}'. Allowed values: toml, json, xml, gradle, gomod.",
+            "Invalid format '{}'. Allowed values: toml, json, xml, gradle, gomod, txt.",
             input
         );
     }
@@ -530,6 +540,7 @@ fn default_version_file(format: &str) -> &'static str {
         "xml" => "pom.xml",
         "gradle" => "build.gradle",
         "gomod" => "go.mod",
+        "txt" => "VERSION.txt",
         _ => "Cargo.toml",
     }
 }
@@ -540,6 +551,7 @@ fn parse_file_format(s: &str) -> FileFormat {
         "xml" => FileFormat::Xml,
         "gradle" => FileFormat::Gradle,
         "gomod" => FileFormat::GoMod,
+        "txt" => FileFormat::Txt,
         _ => FileFormat::Toml,
     }
 }

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -2,6 +2,7 @@ pub mod gomod;
 pub mod gradle;
 pub mod json;
 pub mod toml_format;
+pub mod txt;
 pub mod xml;
 
 use anyhow::Result;
@@ -25,6 +26,7 @@ pub fn get_handler(format: &FileFormat) -> Box<dyn VersionFile> {
         FileFormat::Gradle => Box::new(gradle::GradleVersionFile),
         FileFormat::Json => Box::new(json::JsonVersionFile),
         FileFormat::Toml => Box::new(toml_format::TomlVersionFile),
+        FileFormat::Txt => Box::new(txt::TxtVersionFile),
         FileFormat::Xml => Box::new(xml::XmlVersionFile),
     }
 }

--- a/src/formats/txt.rs
+++ b/src/formats/txt.rs
@@ -1,0 +1,62 @@
+use anyhow::{Context, Result};
+use std::path::Path;
+
+pub struct TxtVersionFile;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::formats::VersionFile;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn read_version_from_txt() {
+        let mut f = NamedTempFile::new().unwrap();
+        writeln!(f, "1.2.3").unwrap();
+        let v = TxtVersionFile.read_version(f.path()).unwrap();
+        assert_eq!(v, "1.2.3");
+    }
+
+    #[test]
+    fn read_version_trims_whitespace() {
+        let mut f = NamedTempFile::new().unwrap();
+        write!(f, "  0.4.1\n\n").unwrap();
+        let v = TxtVersionFile.read_version(f.path()).unwrap();
+        assert_eq!(v, "0.4.1");
+    }
+
+    #[test]
+    fn read_empty_file_fails() {
+        let f = NamedTempFile::new().unwrap();
+        let result = TxtVersionFile.read_version(f.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn write_version_to_txt() {
+        let mut f = NamedTempFile::new().unwrap();
+        writeln!(f, "1.0.0").unwrap();
+        TxtVersionFile.write_version(f.path(), "2.0.0").unwrap();
+        let content = std::fs::read_to_string(f.path()).unwrap();
+        assert_eq!(content, "2.0.0\n");
+    }
+}
+
+impl super::VersionFile for TxtVersionFile {
+    fn read_version(&self, file_path: &Path) -> Result<String> {
+        let content = std::fs::read_to_string(file_path)
+            .with_context(|| format!("failed to read {}", file_path.display()))?;
+        let version = content.trim();
+        if version.is_empty() {
+            anyhow::bail!("no version found in {}", file_path.display());
+        }
+        Ok(version.to_string())
+    }
+
+    fn write_version(&self, file_path: &Path, version: &str) -> Result<()> {
+        std::fs::write(file_path, format!("{version}\n"))
+            .with_context(|| format!("failed to write {}", file_path.display()))?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Closes #62

Adds `txt` format for plain text version files (`VERSION`, `VERSION.txt`). Read trims whitespace, write outputs the version followed by a newline.

- New format handler: `src/formats/txt.rs`
- Auto-detection of `VERSION` and `VERSION.txt` in `ferrflow init`
- JSON Schema updated
- 4 new tests