### PR TITLE
feat(npm): add scoped platform packages for binary distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,9 +129,14 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm publish ./npm --access public
+      - name: Extract version
+        id: version
+        run: echo "value=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+      - name: Publish platform packages and wrapper
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash npm/scripts/publish.sh "${{ steps.version.outputs.value }}"
 
   update-major-tag:
     name: Update major version tag

--- a/npm/bin/ferrflow.js
+++ b/npm/bin/ferrflow.js
@@ -8,36 +8,37 @@ import { createRequire } from "module";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 
+const PLATFORMS = {
+  "linux-x64": "@ferrflow/linux-x64",
+  "linux-arm64": "@ferrflow/linux-arm64",
+  "darwin-x64": "@ferrflow/darwin-x64",
+  "darwin-arm64": "@ferrflow/darwin-arm64",
+  "win32-x64": "@ferrflow/win32-x64",
+};
+
 function getBinaryPath() {
-  const platform = process.platform;
-  const arch = process.arch;
+  const key = `${process.platform}-${process.arch}`;
+  const pkg = PLATFORMS[key];
 
-  const platformMap = {
-    "linux-x64": "ferrflow-linux-x64",
-    "linux-arm64": "ferrflow-linux-arm64",
-    "darwin-x64": "ferrflow-darwin-x64",
-    "darwin-arm64": "ferrflow-darwin-arm64",
-    "win32-x64": "ferrflow-windows-x64",
-  };
-
-  const key = `${platform}-${arch}`;
-  const pkgName = platformMap[key];
-
-  if (pkgName) {
+  if (pkg) {
     try {
-      return require.resolve(`${pkgName}/bin/ferrflow`);
+      const ext = process.platform === "win32" ? ".exe" : "";
+      return require.resolve(`${pkg}/bin/ferrflow${ext}`);
     } catch {
       // optional dep not installed
     }
   }
 
   // Fallback: local dev build
-  const ext = platform === "win32" ? ".exe" : "";
+  const ext = process.platform === "win32" ? ".exe" : "";
   const devBuild = join(__dirname, "..", "..", "target", "release", `ferrflow${ext}`);
   if (existsSync(devBuild)) return devBuild;
 
-  // Hope it's in PATH
-  return platform === "win32" ? "ferrflow.exe" : "ferrflow";
+  console.error(
+    `Unsupported platform: ${process.platform}-${process.arch}\n` +
+    "Install ferrflow from https://github.com/FerrFlow-Org/FerrFlow/releases"
+  );
+  process.exit(1);
 }
 
 const binary = getBinaryPath();

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,9 +1,17 @@
 {
+  "name": "ferrflow",
+  "version": "1.0.0",
+  "description": "Universal semantic versioning for monorepos and classic repos",
+  "homepage": "https://ferrflow.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/FerrFlow-Org/FerrFlow.git"
+  },
+  "license": "MIT",
+  "type": "module",
   "bin": {
     "ferrflow": "./bin/ferrflow.js"
   },
-  "description": "Universal semantic versioning for monorepos and classic repos",
-  "homepage": "https://github.com/FerrFlow/FerrFlow",
   "keywords": [
     "semver",
     "versioning",
@@ -11,19 +19,11 @@
     "changelog",
     "release"
   ],
-  "license": "MIT",
-  "name": "ferrflow",
   "optionalDependencies": {
-    "ferrflow-darwin-arm64": "0.1.0",
-    "ferrflow-darwin-x64": "0.1.0",
-    "ferrflow-linux-arm64": "0.1.0",
-    "ferrflow-linux-x64": "0.1.0",
-    "ferrflow-windows-x64": "0.1.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/FerrFlow/FerrFlow.git"
-  },
-  "type": "module",
-  "version": "1.0.0"
+    "@ferrflow/linux-x64": "1.0.0",
+    "@ferrflow/linux-arm64": "1.0.0",
+    "@ferrflow/darwin-x64": "1.0.0",
+    "@ferrflow/darwin-arm64": "1.0.0",
+    "@ferrflow/win32-x64": "1.0.0"
+  }
 }

--- a/npm/platforms/darwin-arm64/package.json
+++ b/npm/platforms/darwin-arm64/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@ferrflow/darwin-arm64",
+  "version": "0.0.0",
+  "description": "FerrFlow macOS arm64 binary",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/FerrFlow-Org/FerrFlow.git"
+  },
+  "license": "MIT",
+  "os": ["darwin"],
+  "cpu": ["arm64"]
+}

--- a/npm/platforms/darwin-x64/package.json
+++ b/npm/platforms/darwin-x64/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@ferrflow/darwin-x64",
+  "version": "0.0.0",
+  "description": "FerrFlow macOS x64 binary",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/FerrFlow-Org/FerrFlow.git"
+  },
+  "license": "MIT",
+  "os": ["darwin"],
+  "cpu": ["x64"]
+}

--- a/npm/platforms/linux-arm64/package.json
+++ b/npm/platforms/linux-arm64/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@ferrflow/linux-arm64",
+  "version": "0.0.0",
+  "description": "FerrFlow Linux arm64 binary",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/FerrFlow-Org/FerrFlow.git"
+  },
+  "license": "MIT",
+  "os": ["linux"],
+  "cpu": ["arm64"]
+}

--- a/npm/platforms/linux-x64/package.json
+++ b/npm/platforms/linux-x64/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@ferrflow/linux-x64",
+  "version": "0.0.0",
+  "description": "FerrFlow Linux x64 binary",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/FerrFlow-Org/FerrFlow.git"
+  },
+  "license": "MIT",
+  "os": ["linux"],
+  "cpu": ["x64"]
+}

--- a/npm/platforms/win32-x64/package.json
+++ b/npm/platforms/win32-x64/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@ferrflow/win32-x64",
+  "version": "0.0.0",
+  "description": "FerrFlow Windows x64 binary",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/FerrFlow-Org/FerrFlow.git"
+  },
+  "license": "MIT",
+  "os": ["win32"],
+  "cpu": ["x64"]
+}

--- a/npm/scripts/publish.sh
+++ b/npm/scripts/publish.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:?Usage: publish.sh <version>}"
+
+# Map: archive name -> platform dir
+declare -A ARCHIVES=(
+  ["ferrflow-linux-x64.tar.gz"]="linux-x64"
+  ["ferrflow-linux-arm64.tar.gz"]="linux-arm64"
+  ["ferrflow-darwin-x64.tar.gz"]="darwin-x64"
+  ["ferrflow-darwin-arm64.tar.gz"]="darwin-arm64"
+  ["ferrflow-windows-x64.zip"]="win32-x64"
+)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+NPM_DIR="$(dirname "$SCRIPT_DIR")"
+WORK_DIR="$(mktemp -d)"
+
+echo "Downloading release binaries for v${VERSION}..."
+
+for archive in "${!ARCHIVES[@]}"; do
+  platform="${ARCHIVES[$archive]}"
+  echo "  ${archive} -> @ferrflow/${platform}"
+
+  gh release download "v${VERSION}" -p "$archive" -D "$WORK_DIR"
+
+  # Prepare platform package
+  pkg_dir="${WORK_DIR}/packages/${platform}"
+  mkdir -p "${pkg_dir}/bin"
+
+  # Extract binary
+  if [[ "$archive" == *.zip ]]; then
+    unzip -q "${WORK_DIR}/${archive}" -d "${pkg_dir}/bin/"
+  else
+    tar xzf "${WORK_DIR}/${archive}" -C "${pkg_dir}/bin/"
+  fi
+
+  # Copy and patch package.json
+  cp "${NPM_DIR}/platforms/${platform}/package.json" "${pkg_dir}/package.json"
+  cd "$pkg_dir"
+  npm version "$VERSION" --no-git-tag-version --allow-same-version
+  npm publish --access public
+  cd - > /dev/null
+done
+
+# Publish main wrapper
+echo "Publishing main package ferrflow@${VERSION}..."
+cd "$NPM_DIR"
+
+# Update version and optionalDependencies versions
+npm version "$VERSION" --no-git-tag-version --allow-same-version
+
+node -e "
+  const pkg = JSON.parse(require('fs').readFileSync('package.json', 'utf8'));
+  for (const dep of Object.keys(pkg.optionalDependencies || {})) {
+    pkg.optionalDependencies[dep] = '${VERSION}';
+  }
+  require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+"
+
+npm publish --access public
+
+echo "Published ferrflow@${VERSION} with all platform packages"
+
+# Cleanup
+rm -rf "$WORK_DIR"


### PR DESCRIPTION
Restructures the npm distribution to use scoped platform packages (`@ferrflow/linux-x64`, `@ferrflow/darwin-arm64`, etc.) following the esbuild pattern.

- Platform packages with `os`/`cpu` fields for automatic selection by npm
- Main wrapper resolves the correct platform binary
- `publish.sh` script downloads release binaries and publishes all packages
- Updated `release.yml` to use the new publish flow
- Removed stale `ferrflow@2.0.0` from npm