### PR TITLE
feat: add ferrflow-wasm crate for browser-side usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,6 +444,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ferrflow-wasm"
+version = "0.1.0"
+dependencies = [
+ "ferrflow",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[workspace]
+members = [".", "ferrflow-wasm"]
+resolver = "3"
+
 [package]
 name = "ferrflow"
 version = "1.0.0"
@@ -22,21 +26,27 @@ path = "benchmarks/fixtures/generate.rs"
 name = "ferrflow"
 path = "src/lib.rs"
 
+[features]
+default = ["cli"]
+cli = ["dep:git2", "dep:ureq", "dep:clap", "dep:colored"]
+
 [dependencies]
-clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 json5 = "1.0"
 toml_edit = { version = "0.25", features = ["serde"] }
 quick-xml = "0.39"
-git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
 semver = "1"
 regex = "1"
 anyhow = "1"
 thiserror = "2"
 chrono = { version = "0.4", features = ["serde"] }
-colored = "3"
-ureq = { version = "3", features = ["json"] }
+
+# CLI-only dependencies
+clap = { version = "4", features = ["derive", "env"], optional = true }
+colored = { version = "3", optional = true }
+git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"], optional = true }
+ureq = { version = "3", features = ["json"], optional = true }
 
 [dev-dependencies]
 cargo-husky = { version = "1", default-features = false, features = ["user-hooks"] }

--- a/ferrflow-wasm/Cargo.toml
+++ b/ferrflow-wasm/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ferrflow-wasm"
+version = "0.1.0"
+edition = "2024"
+description = "FerrFlow core functions compiled to WebAssembly"
+license = "MIT"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+ferrflow = { path = "..", default-features = false }
+wasm-bindgen = "0.2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/ferrflow-wasm/src/lib.rs
+++ b/ferrflow-wasm/src/lib.rs
@@ -1,0 +1,100 @@
+use wasm_bindgen::prelude::*;
+
+use ferrflow::changelog::{self, GitLog};
+use ferrflow::config::{self, Config, ConfigFormatHandler};
+use ferrflow::conventional_commits;
+use ferrflow::versioning;
+
+#[wasm_bindgen]
+pub fn determine_bump(message: &str) -> String {
+    conventional_commits::determine_bump(message).to_string()
+}
+
+#[wasm_bindgen]
+pub fn compute_next_version(current: &str, bump: &str, strategy: &str) -> Result<String, JsError> {
+    let bump_type = match bump {
+        "major" => ferrflow::conventional_commits::BumpType::Major,
+        "minor" => ferrflow::conventional_commits::BumpType::Minor,
+        "patch" => ferrflow::conventional_commits::BumpType::Patch,
+        _ => ferrflow::conventional_commits::BumpType::None,
+    };
+
+    let strategy_type = match strategy {
+        "calver" => ferrflow::config::VersioningStrategy::Calver,
+        "calver-short" => ferrflow::config::VersioningStrategy::CalverShort,
+        "calver-seq" => ferrflow::config::VersioningStrategy::CalverSeq,
+        "sequential" => ferrflow::config::VersioningStrategy::Sequential,
+        "zerover" => ferrflow::config::VersioningStrategy::Zerover,
+        _ => ferrflow::config::VersioningStrategy::Semver,
+    };
+
+    versioning::compute_next_version(current, bump_type, strategy_type)
+        .map_err(|e| JsError::new(&e.to_string()))
+}
+
+#[wasm_bindgen]
+pub fn build_changelog_section(version: &str, commits_json: &str) -> Result<String, JsError> {
+    let raw: Vec<CommitInput> =
+        serde_json::from_str(commits_json).map_err(|e| JsError::new(&e.to_string()))?;
+
+    let commits: Vec<GitLog> = raw
+        .into_iter()
+        .map(|c| GitLog {
+            hash: c.hash.unwrap_or_else(|| "0000000".to_string()),
+            message: c.message,
+        })
+        .collect();
+
+    Ok(changelog::build_section(version, &commits))
+}
+
+#[wasm_bindgen]
+pub fn validate_config(config_json: &str) -> String {
+    match serde_json::from_str::<Config>(config_json) {
+        Ok(config) => {
+            let mut errors: Vec<String> = Vec::new();
+
+            if config.packages.is_empty() {
+                errors.push("At least one package is required".to_string());
+            }
+
+            for (i, pkg) in config.packages.iter().enumerate() {
+                if pkg.name.is_empty() {
+                    errors.push(format!("Package {} has no name", i + 1));
+                }
+                if pkg.path.is_empty() {
+                    errors.push(format!("Package '{}' has no path", pkg.name));
+                }
+            }
+
+            if errors.is_empty() {
+                r#"{"valid":true}"#.to_string()
+            } else {
+                serde_json::json!({ "valid": false, "errors": errors }).to_string()
+            }
+        }
+        Err(e) => serde_json::json!({ "valid": false, "errors": [e.to_string()] }).to_string(),
+    }
+}
+
+#[wasm_bindgen]
+pub fn serialize_config(config_json: &str, format: &str) -> Result<String, JsError> {
+    let config: Config =
+        serde_json::from_str(config_json).map_err(|e| JsError::new(&e.to_string()))?;
+
+    let handler: &dyn ConfigFormatHandler = match format {
+        "toml" => config::format_handler(config::ConfigFileFormat::Toml),
+        "json5" => config::format_handler(config::ConfigFileFormat::Json5),
+        _ => config::format_handler(config::ConfigFileFormat::Json),
+    };
+
+    handler
+        .serialize(&config)
+        .map_err(|e| JsError::new(&e.to_string()))
+}
+
+#[derive(serde::Deserialize)]
+struct CommitInput {
+    message: String,
+    hash: Option<String>,
+}

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -1,14 +1,22 @@
-use crate::config::Config;
-use crate::conventional_commits::{BumpType, determine_bump, parse_subject};
-use crate::formats::read_version;
-use crate::git::{GitLog, get_commits_since_last_tag, get_repo_root, open_repo};
-use crate::versioning::bump_version;
+#[cfg(feature = "cli")]
+use crate::conventional_commits::determine_bump;
+use crate::conventional_commits::{BumpType, parse_subject};
 use anyhow::Result;
 use chrono::Local;
-use colored::Colorize;
 use std::path::Path;
 
+pub struct GitLog {
+    pub hash: String,
+    pub message: String,
+}
+
+#[cfg(feature = "cli")]
 pub fn generate_only(config_path: Option<&Path>, dry_run: bool) -> Result<()> {
+    use crate::config::Config;
+    use crate::formats::read_version;
+    use crate::git::{get_commits_since_last_tag, get_repo_root, open_repo};
+    use crate::versioning::bump_version;
+    use colored::Colorize;
     let repo = open_repo(&std::env::current_dir()?)?;
     let root = get_repo_root(&repo)?;
     let config = Config::load(&root, config_path)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, Result};
-use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
+#[cfg(feature = "cli")]
 use crate::telemetry;
 
 // ---------------------------------------------------------------------------
@@ -166,7 +166,8 @@ pub enum FileFormat {
 // Config file format enum (for CLI --format flag)
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Copy, ValueEnum)]
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 pub enum ConfigFileFormat {
     Json,
     Json5,
@@ -460,9 +461,10 @@ impl Config {
 }
 
 // ---------------------------------------------------------------------------
-// Interactive helpers
+// Interactive helpers & init command (CLI only)
 // ---------------------------------------------------------------------------
 
+#[cfg(feature = "cli")]
 fn prompt(question: &str, default: &str) -> String {
     use std::io::Write;
     if default.is_empty() {
@@ -481,6 +483,7 @@ fn prompt(question: &str, default: &str) -> String {
     }
 }
 
+#[cfg(feature = "cli")]
 fn prompt_bool(question: &str, default: bool) -> bool {
     let hint = if default { "Y/n" } else { "y/N" };
     let answer = prompt(&format!("{question} [{hint}]"), "");
@@ -491,8 +494,10 @@ fn prompt_bool(question: &str, default: bool) -> bool {
     }
 }
 
+#[cfg(feature = "cli")]
 const ALLOWED_FORMATS: &[&str] = &["toml", "json", "xml", "gradle", "gomod", "txt"];
 
+#[cfg(feature = "cli")]
 fn prompt_format(indent: bool) -> String {
     let question = if indent {
         "  Version file format [toml/json/xml/gradle/gomod/txt]"
@@ -512,8 +517,10 @@ fn prompt_format(indent: bool) -> String {
     }
 }
 
+#[cfg(feature = "cli")]
 const ALLOWED_CONFIG_FORMATS: &[&str] = &["json", "json5", "toml", "dotfile"];
 
+#[cfg(feature = "cli")]
 fn prompt_config_format() -> ConfigFileFormat {
     let question = "Config file format [json/json5/toml/dotfile]";
     loop {
@@ -534,6 +541,7 @@ fn prompt_config_format() -> ConfigFileFormat {
     }
 }
 
+#[cfg(feature = "cli")]
 fn default_version_file(format: &str) -> &'static str {
     match format {
         "json" => "package.json",
@@ -545,6 +553,7 @@ fn default_version_file(format: &str) -> &'static str {
     }
 }
 
+#[cfg(feature = "cli")]
 fn parse_file_format(s: &str) -> FileFormat {
     match s {
         "json" => FileFormat::Json,
@@ -556,6 +565,7 @@ fn parse_file_format(s: &str) -> FileFormat {
     }
 }
 
+#[cfg(feature = "cli")]
 fn collect_package(path_default: &str, monorepo: bool) -> PackageConfig {
     let dir_name = std::env::current_dir()
         .ok()
@@ -625,10 +635,7 @@ fn collect_package(path_default: &str, monorepo: bool) -> PackageConfig {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Init command
-// ---------------------------------------------------------------------------
-
+#[cfg(feature = "cli")]
 pub fn init(format: Option<ConfigFileFormat>) -> Result<()> {
     // Check if any config file already exists
     for handler in CONFIG_FORMATS {

--- a/src/git.rs
+++ b/src/git.rs
@@ -2,10 +2,7 @@ use anyhow::{Context, Result};
 use git2::{Cred, CredentialType, PushOptions, RemoteCallbacks, Repository, Sort};
 use std::path::{Path, PathBuf};
 
-pub struct GitLog {
-    pub hash: String,
-    pub message: String,
-}
+pub use crate::changelog::GitLog;
 
 pub fn open_repo(path: &Path) -> Result<Repository> {
     Repository::discover(path).with_context(|| format!("Not a git repository: {}", path.display()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,9 @@ pub mod changelog;
 pub mod config;
 pub mod conventional_commits;
 pub mod formats;
-pub mod git;
-pub mod telemetry;
 pub mod versioning;
+
+#[cfg(feature = "cli")]
+pub mod git;
+#[cfg(feature = "cli")]
+pub mod telemetry;


### PR DESCRIPTION
## Summary

- Convert the repo to a Cargo workspace with two members: `ferrflow` (existing) and `ferrflow-wasm` (new)
- Add `cli` feature flag to `ferrflow` crate, gating `git2`, `ureq`, `clap`, `colored` and their dependent modules (`git`, `telemetry`, `init`)
- Create `ferrflow-wasm` crate that wraps core functions via `wasm-bindgen`: `determine_bump`, `compute_next_version`, `build_changelog_section`, `validate_config`, `serialize_config`
- Move `GitLog` struct to `changelog.rs` (always available) and re-export from `git.rs`

Closes #126

## Test plan

- [x] All 147 existing tests pass
- [x] `cargo check --no-default-features --lib` compiles clean
- [x] `cargo check -p ferrflow-wasm` compiles clean
- [x] Binary build (`cargo build -p ferrflow`) works unchanged