### PR TITLE
fix(docker): resolve workspace build and bump version to 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,7 +422,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "cargo-husky",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "ferrflow"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 description = "Universal semantic versioning for monorepos and classic repos"
 license = "MIT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,22 @@ FROM rustlang/rust:nightly-alpine AS builder
 RUN apk add --no-cache musl-dev openssl-dev openssl-libs-static pkgconfig cmake make
 ENV OPENSSL_NO_VENDOR=1
 WORKDIR /app
-# Cache dependencies
+
+# Cache dependencies — copy all workspace manifests
 COPY Cargo.toml Cargo.lock ./
-RUN mkdir src && echo 'fn main() {}' > src/main.rs \
-    && cargo build --release \
-    && rm -f target/release/ferrflow target/release/deps/ferrflow*
+COPY ferrflow-wasm/Cargo.toml ferrflow-wasm/Cargo.toml
+
+# Create stubs for all crates/bins so cargo resolves the workspace
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && echo '' > src/lib.rs \
+    && mkdir -p benchmarks/fixtures && echo 'fn main() {}' > benchmarks/fixtures/generate.rs \
+    && mkdir -p ferrflow-wasm/src && echo '' > ferrflow-wasm/src/lib.rs \
+    && cargo build --release --package ferrflow \
+    && rm -rf src benchmarks ferrflow-wasm/src
+
 # Build for real
 COPY src ./src
-RUN cargo build --release
+COPY benchmarks ./benchmarks
+RUN cargo build --release --package ferrflow
 
 # Runtime stage
 FROM alpine:3.23


### PR DESCRIPTION
## Summary
- Fix Dockerfile that failed since the workspace was added (`ferrflow-wasm` member + `generate-fixtures` binary)
- Copy all workspace manifests and create stubs for dependency caching
- Build with `--package ferrflow` to skip WASM crate
- Bump version to 1.1.0

Closes #132