### PR TITLE
chore(npm): sync optionalDependencies to v1.2.0

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -15,10 +15,10 @@
   "name": "ferrflow",
   "optionalDependencies": {
     "@ferrflow/darwin-arm64": "1.2.0",
-    "@ferrflow/darwin-x64": "1.0.0",
-    "@ferrflow/linux-arm64": "1.0.0",
+    "@ferrflow/darwin-x64": "1.2.0",
+    "@ferrflow/linux-arm64": "1.2.0",
     "@ferrflow/linux-x64": "1.2.0",
-    "@ferrflow/win32-x64": "1.0.0"
+    "@ferrflow/win32-x64": "1.2.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Sync all 5 platform package versions in optionalDependencies to 1.2.0. Supersedes #134, #135, #137, #139.