### PR TITLE
test: expand coverage for formats, changelog, config, and versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,7 +422,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "cargo-husky",

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -284,4 +284,100 @@ mod tests {
         update_changelog(&path, "myapp", "1.0.0", &commits, BumpType::Minor, true).unwrap();
         assert!(!path.exists());
     }
+
+    #[test]
+    fn build_section_breaking_change_in_body() {
+        let commits = vec![GitLog {
+            hash: "abc".to_string(),
+            message: "feat: add endpoint\n\nBREAKING CHANGE: removed old endpoint".to_string(),
+        }];
+        let section = build_section("2.0.0", &commits);
+        assert!(section.contains("### Breaking Changes"));
+    }
+
+    #[test]
+    fn build_section_refactor_chore_excluded() {
+        let commits = make_commits(&[
+            "refactor: clean up",
+            "chore: update deps",
+            "docs: update readme",
+            "ci: fix pipeline",
+            "style: format code",
+            "test: add tests",
+            "build: update config",
+        ]);
+        let section = build_section("1.0.1", &commits);
+        assert!(!section.contains("### Features"));
+        assert!(!section.contains("### Bug Fixes"));
+        assert!(!section.contains("### Breaking Changes"));
+    }
+
+    #[test]
+    fn build_section_scoped_commits() {
+        let commits = make_commits(&["feat(api): add endpoint", "fix(db): connection leak"]);
+        let section = build_section("1.1.0", &commits);
+        assert!(section.contains("- feat(api): add endpoint"));
+        assert!(section.contains("- fix(db): connection leak"));
+    }
+
+    #[test]
+    fn build_section_perf_in_fixes() {
+        let commits = make_commits(&["perf: optimize query"]);
+        let section = build_section("1.0.1", &commits);
+        assert!(section.contains("### Bug Fixes"));
+        assert!(section.contains("- perf: optimize query"));
+    }
+
+    #[test]
+    fn update_changelog_preserves_existing_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("CHANGELOG.md");
+        std::fs::write(
+            &path,
+            "# Changelog\n\n## [1.0.0] - 2025-01-01\n\n- feat: initial release\n",
+        )
+        .unwrap();
+        let commits = make_commits(&["feat: new feature"]);
+        update_changelog(&path, "myapp", "1.1.0", &commits, BumpType::Minor, false).unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("## [1.1.0]"));
+        assert!(content.contains("## [1.0.0]"));
+        assert!(content.contains("- feat: initial release"));
+    }
+
+    #[test]
+    fn update_changelog_empty_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("CHANGELOG.md");
+        std::fs::write(&path, "").unwrap();
+        let commits = make_commits(&["feat: first"]);
+        update_changelog(&path, "myapp", "0.1.0", &commits, BumpType::Minor, false).unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("## [0.1.0]"));
+    }
+
+    #[test]
+    fn build_section_contains_date() {
+        let commits = make_commits(&["feat: something"]);
+        let section = build_section("1.0.0", &commits);
+        let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+        assert!(section.contains(&today));
+    }
+
+    #[test]
+    fn update_changelog_multiple_versions() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("CHANGELOG.md");
+
+        let commits1 = make_commits(&["feat: first"]);
+        update_changelog(&path, "myapp", "0.1.0", &commits1, BumpType::Minor, false).unwrap();
+
+        let commits2 = make_commits(&["feat: second"]);
+        update_changelog(&path, "myapp", "0.2.0", &commits2, BumpType::Minor, false).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let pos1 = content.find("## [0.2.0]").unwrap();
+        let pos2 = content.find("## [0.1.0]").unwrap();
+        assert!(pos1 < pos2, "newer version should come first");
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1556,4 +1556,176 @@ format = "toml"
         };
         assert!(!config.is_monorepo());
     }
+
+    #[test]
+    fn load_fails_on_invalid_json() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("ferrflow.json"), "{ invalid json").unwrap();
+        assert!(Config::load(dir.path(), None).is_err());
+    }
+
+    #[test]
+    fn load_fails_on_invalid_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("ferrflow.toml"), "[[[invalid").unwrap();
+        assert!(Config::load(dir.path(), None).is_err());
+    }
+
+    #[test]
+    fn load_explicit_nonexistent_file() {
+        let result = Config::load_explicit(std::path::Path::new("/nonexistent/ferrflow.json"));
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("not found") || err.contains("No such file"));
+    }
+
+    #[test]
+    fn load_explicit_unknown_extension_defaults_to_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ferrflow.xyz");
+        std::fs::write(&path, r#"{"package":[{"name":"x","path":"."}]}"#).unwrap();
+        let config = Config::load_explicit(&path).unwrap();
+        assert_eq!(config.packages[0].name, "x");
+    }
+
+    #[test]
+    fn parse_json_ignores_unknown_fields() {
+        let json = r#"{
+            "workspace": { "remote": "origin", "unknown_field": true },
+            "package": [{ "name": "app", "path": ".", "extra": "ignored" }]
+        }"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert_eq!(config.packages[0].name, "app");
+    }
+
+    #[test]
+    fn default_workspace_config_values() {
+        // Default trait gives empty strings; serde defaults give "origin"/"main"
+        let ws = WorkspaceConfig::default();
+        assert_eq!(ws.versioning, VersioningStrategy::Semver);
+        assert!(ws.tag_template.is_none());
+        assert!(!ws.recover_missed_releases);
+        assert_eq!(ws.release_commit_mode, ReleaseCommitMode::Commit);
+        assert!(ws.skip_ci.is_none());
+    }
+
+    #[test]
+    fn serde_default_workspace_values() {
+        // When deserialized from JSON with explicit workspace, serde defaults fill missing fields
+        let json = r#"{"workspace":{"remote":"origin"},"package":[]}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert_eq!(config.workspace.remote, "origin");
+        assert!(config.workspace.telemetry);
+        assert!(config.workspace.auto_merge_releases);
+    }
+
+    #[test]
+    fn file_format_serde_all_variants() {
+        for (s, expected) in [
+            ("json", FileFormat::Json),
+            ("toml", FileFormat::Toml),
+            ("xml", FileFormat::Xml),
+            ("gradle", FileFormat::Gradle),
+            ("gomod", FileFormat::GoMod),
+            ("txt", FileFormat::Txt),
+        ] {
+            let json = format!(r#"{{ "path": "test", "format": "{s}" }}"#);
+            let vf: VersionedFile = serde_json::from_str(&json).unwrap();
+            assert_eq!(vf.format, expected, "failed for format {s}");
+        }
+    }
+
+    #[test]
+    fn tag_prefix_no_version_placeholder() {
+        let ws = WorkspaceConfig::default();
+        let pkg = PackageConfig {
+            name: "app".to_string(),
+            path: ".".to_string(),
+            versioned_files: vec![],
+            changelog: None,
+            shared_paths: vec![],
+            versioning: None,
+            tag_template: Some("release-latest".to_string()),
+        };
+        // When template has no {version}, prefix is the entire template
+        assert_eq!(pkg.tag_prefix(&ws, false), "release-latest");
+    }
+
+    #[test]
+    fn tag_for_version_replaces_placeholders() {
+        let ws = WorkspaceConfig::default();
+        let pkg = PackageConfig {
+            name: "api".to_string(),
+            path: ".".to_string(),
+            versioned_files: vec![],
+            changelog: None,
+            shared_paths: vec![],
+            versioning: None,
+            tag_template: Some("{name}/v{version}".to_string()),
+        };
+        assert_eq!(pkg.tag_for_version(&ws, true, "1.2.3"), "api/v1.2.3");
+    }
+
+    #[test]
+    fn config_default_is_empty() {
+        let config = Config::default();
+        assert!(config.packages.is_empty());
+    }
+
+    #[test]
+    fn load_discovers_json5_config() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("ferrflow.json5"),
+            "{ package: [{ name: \"j5\", path: \".\" }] }",
+        )
+        .unwrap();
+        let config = Config::load(dir.path(), None).unwrap();
+        assert_eq!(config.packages[0].name, "j5");
+    }
+
+    #[test]
+    fn load_with_relative_explicit_path() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("custom.json"),
+            r#"{"package":[{"name":"rel","path":"."}]}"#,
+        )
+        .unwrap();
+        let config = Config::load(dir.path(), Some(std::path::Path::new("custom.json"))).unwrap();
+        assert_eq!(config.packages[0].name, "rel");
+    }
+
+    #[test]
+    fn auto_detect_no_version_files() {
+        let dir = tempfile::tempdir().unwrap();
+        // Empty dir, no recognizable version files
+        let config = Config::auto_detect(dir.path());
+        assert!(config.packages.is_empty());
+    }
+
+    #[test]
+    fn snake_to_camel_multiple_underscores() {
+        assert_eq!(snake_to_camel("a_b_c_d"), "aBCD");
+    }
+
+    #[test]
+    fn snake_to_camel_trailing_underscore() {
+        assert_eq!(snake_to_camel("trailing_"), "trailing");
+    }
+
+    #[test]
+    fn to_camel_case_keys_preserves_non_object_values() {
+        let input = serde_json::json!("string_value");
+        assert_eq!(to_camel_case_keys(input.clone()), input);
+
+        let input = serde_json::json!(42);
+        assert_eq!(to_camel_case_keys(input.clone()), input);
+
+        let input = serde_json::json!(true);
+        assert_eq!(to_camel_case_keys(input.clone()), input);
+
+        let input = serde_json::json!(null);
+        assert_eq!(to_camel_case_keys(input.clone()), input);
+    }
 }

--- a/src/conventional_commits.rs
+++ b/src/conventional_commits.rs
@@ -122,4 +122,102 @@ mod tests {
         assert!(BumpType::Minor > BumpType::Patch);
         assert!(BumpType::Patch > BumpType::None);
     }
+
+    #[test]
+    fn test_empty_message() {
+        assert_eq!(determine_bump(""), BumpType::None);
+    }
+
+    #[test]
+    fn test_whitespace_only_message() {
+        assert_eq!(determine_bump("   \n\n  "), BumpType::None);
+    }
+
+    #[test]
+    fn test_non_conventional_message() {
+        assert_eq!(determine_bump("update readme"), BumpType::None);
+        assert_eq!(determine_bump("fixed the thing"), BumpType::None);
+        assert_eq!(determine_bump("WIP"), BumpType::None);
+    }
+
+    #[test]
+    fn test_all_patch_types() {
+        assert_eq!(determine_bump("fix: something"), BumpType::Patch);
+        assert_eq!(determine_bump("perf: something"), BumpType::Patch);
+        assert_eq!(determine_bump("refactor: something"), BumpType::Patch);
+    }
+
+    #[test]
+    fn test_all_none_types() {
+        assert_eq!(determine_bump("chore: something"), BumpType::None);
+        assert_eq!(determine_bump("docs: something"), BumpType::None);
+        assert_eq!(determine_bump("ci: something"), BumpType::None);
+        assert_eq!(determine_bump("style: something"), BumpType::None);
+        assert_eq!(determine_bump("test: something"), BumpType::None);
+        assert_eq!(determine_bump("build: something"), BumpType::None);
+    }
+
+    #[test]
+    fn test_breaking_all_types() {
+        assert_eq!(determine_bump("fix!: breaking fix"), BumpType::Major);
+        assert_eq!(determine_bump("refactor!: breaking"), BumpType::Major);
+        assert_eq!(determine_bump("perf!: breaking"), BumpType::Major);
+        assert_eq!(determine_bump("chore!: breaking"), BumpType::Major);
+        assert_eq!(determine_bump("docs!: breaking"), BumpType::Major);
+        assert_eq!(determine_bump("style!: breaking"), BumpType::Major);
+        assert_eq!(determine_bump("test!: breaking"), BumpType::Major);
+        assert_eq!(determine_bump("build!: breaking"), BumpType::Major);
+        assert_eq!(determine_bump("ci!: breaking"), BumpType::Major);
+    }
+
+    #[test]
+    fn test_breaking_with_scope() {
+        assert_eq!(determine_bump("chore(deps)!: breaking"), BumpType::Major);
+        assert_eq!(determine_bump("build(npm)!: breaking"), BumpType::Major);
+    }
+
+    #[test]
+    fn test_breaking_change_in_body_multiline() {
+        let msg = "feat: add feature\n\nSome description.\n\nBREAKING CHANGE: removed old API";
+        assert_eq!(determine_bump(msg), BumpType::Major);
+    }
+
+    #[test]
+    fn test_parse_subject_multiline() {
+        assert_eq!(
+            parse_subject("first line\nsecond line\nthird line"),
+            "first line"
+        );
+    }
+
+    #[test]
+    fn test_parse_subject_empty() {
+        assert_eq!(parse_subject(""), "");
+    }
+
+    #[test]
+    fn test_bump_type_display() {
+        assert_eq!(format!("{}", BumpType::None), "none");
+        assert_eq!(format!("{}", BumpType::Patch), "patch");
+        assert_eq!(format!("{}", BumpType::Minor), "minor");
+        assert_eq!(format!("{}", BumpType::Major), "major");
+    }
+
+    #[test]
+    fn test_feat_not_in_middle_of_word() {
+        // "featured" should not match feat
+        assert_eq!(determine_bump("featured something"), BumpType::None);
+    }
+
+    #[test]
+    fn test_deep_nested_scope() {
+        assert_eq!(
+            determine_bump("feat(api/auth/jwt): add token"),
+            BumpType::Minor
+        );
+        assert_eq!(
+            determine_bump("fix(ui/modal): close on escape"),
+            BumpType::Patch
+        );
+    }
 }

--- a/src/formats/gomod.rs
+++ b/src/formats/gomod.rs
@@ -50,3 +50,21 @@ impl VersionFile for GoModVersionFile {
         false
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn write_version_is_noop() {
+        let handler = GoModVersionFile;
+        handler.write_version(Path::new("go.mod"), "1.0.0").unwrap();
+    }
+
+    #[test]
+    fn modifies_file_returns_false() {
+        let handler = GoModVersionFile;
+        assert!(!handler.modifies_file());
+    }
+}

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -42,3 +42,166 @@ pub fn write_version(vf: &VersionedFile, repo_root: &Path, version: &str) -> Res
     let handler = get_handler(&vf.format);
     handler.write_version(&path, version)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{FileFormat, VersionedFile};
+
+    #[test]
+    fn get_handler_returns_handler_for_each_format() {
+        // Verify get_handler doesn't panic for any format variant
+        for format in &[
+            FileFormat::GoMod,
+            FileFormat::Gradle,
+            FileFormat::Json,
+            FileFormat::Toml,
+            FileFormat::Txt,
+            FileFormat::Xml,
+        ] {
+            let _ = get_handler(format);
+        }
+    }
+
+    #[test]
+    fn gomod_handler_does_not_modify_file() {
+        let handler = get_handler(&FileFormat::GoMod);
+        assert!(!handler.modifies_file());
+    }
+
+    #[test]
+    fn non_gomod_handlers_modify_file() {
+        for format in &[
+            FileFormat::Gradle,
+            FileFormat::Json,
+            FileFormat::Toml,
+            FileFormat::Txt,
+            FileFormat::Xml,
+        ] {
+            let handler = get_handler(format);
+            assert!(
+                handler.modifies_file(),
+                "expected modifies_file=true for {:?}",
+                format
+            );
+        }
+    }
+
+    #[test]
+    fn read_version_json() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{"name":"test","version":"3.2.1"}"#,
+        )
+        .unwrap();
+        let vf = VersionedFile {
+            path: "package.json".to_string(),
+            format: FileFormat::Json,
+        };
+        assert_eq!(read_version(&vf, dir.path()).unwrap(), "3.2.1");
+    }
+
+    #[test]
+    fn write_then_read_json() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{"name":"test","version":"1.0.0"}"#,
+        )
+        .unwrap();
+        let vf = VersionedFile {
+            path: "package.json".to_string(),
+            format: FileFormat::Json,
+        };
+        write_version(&vf, dir.path(), "2.0.0").unwrap();
+        assert_eq!(read_version(&vf, dir.path()).unwrap(), "2.0.0");
+    }
+
+    #[test]
+    fn read_version_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"test\"\nversion = \"0.5.0\"\n",
+        )
+        .unwrap();
+        let vf = VersionedFile {
+            path: "Cargo.toml".to_string(),
+            format: FileFormat::Toml,
+        };
+        assert_eq!(read_version(&vf, dir.path()).unwrap(), "0.5.0");
+    }
+
+    #[test]
+    fn read_version_txt() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("VERSION"), "4.1.0\n").unwrap();
+        let vf = VersionedFile {
+            path: "VERSION".to_string(),
+            format: FileFormat::Txt,
+        };
+        assert_eq!(read_version(&vf, dir.path()).unwrap(), "4.1.0");
+    }
+
+    #[test]
+    fn write_then_read_txt() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("VERSION"), "1.0.0\n").unwrap();
+        let vf = VersionedFile {
+            path: "VERSION".to_string(),
+            format: FileFormat::Txt,
+        };
+        write_version(&vf, dir.path(), "1.1.0").unwrap();
+        assert_eq!(read_version(&vf, dir.path()).unwrap(), "1.1.0");
+    }
+
+    #[test]
+    fn read_version_xml() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("pom.xml"),
+            "<project><version>2.3.4</version></project>",
+        )
+        .unwrap();
+        let vf = VersionedFile {
+            path: "pom.xml".to_string(),
+            format: FileFormat::Xml,
+        };
+        assert_eq!(read_version(&vf, dir.path()).unwrap(), "2.3.4");
+    }
+
+    #[test]
+    fn read_version_nonexistent_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let vf = VersionedFile {
+            path: "nope.json".to_string(),
+            format: FileFormat::Json,
+        };
+        assert!(read_version(&vf, dir.path()).is_err());
+    }
+
+    #[test]
+    fn read_version_gradle() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("build.gradle"), "version = '1.2.3'\n").unwrap();
+        let vf = VersionedFile {
+            path: "build.gradle".to_string(),
+            format: FileFormat::Gradle,
+        };
+        assert_eq!(read_version(&vf, dir.path()).unwrap(), "1.2.3");
+    }
+
+    #[test]
+    fn path_joining_works() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("sub");
+        std::fs::create_dir_all(&sub).unwrap();
+        std::fs::write(sub.join("VERSION"), "5.0.0\n").unwrap();
+        let vf = VersionedFile {
+            path: "sub/VERSION".to_string(),
+            format: FileFormat::Txt,
+        };
+        assert_eq!(read_version(&vf, dir.path()).unwrap(), "5.0.0");
+    }
+}

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -225,4 +225,94 @@ mod tests {
             "11"
         );
     }
+
+    #[test]
+    fn test_bump_invalid_version() {
+        assert!(bump_version("not_a_version", BumpType::Patch).is_err());
+    }
+
+    #[test]
+    fn test_bump_empty_version() {
+        assert!(bump_version("", BumpType::Patch).is_err());
+    }
+
+    #[test]
+    fn test_bump_pre_release_version() {
+        // semver crate parses pre-release; patch bump increments patch but keeps pre-release
+        let result = bump_version("1.0.0-alpha.1", BumpType::Patch).unwrap();
+        // Pre-release is preserved in the version string
+        assert!(result.starts_with("1.0.1"));
+    }
+
+    #[test]
+    fn test_zerover_none_keeps_version() {
+        assert_eq!(bump_zerover("0.5.2", BumpType::None).unwrap(), "0.5.2");
+    }
+
+    #[test]
+    fn test_zerover_minor_same_as_major() {
+        // In zerover, both major and minor bump the minor
+        let from_major = bump_zerover("0.5.0", BumpType::Major).unwrap();
+        let from_minor = bump_zerover("0.5.0", BumpType::Minor).unwrap();
+        assert_eq!(from_major, from_minor);
+    }
+
+    #[test]
+    fn test_zerover_clamps_non_zero_major() {
+        // Even if input has major > 0, zerover forces it to 0
+        assert_eq!(bump_zerover("2.5.0", BumpType::Patch).unwrap(), "0.5.1");
+    }
+
+    #[test]
+    fn test_zerover_invalid_version() {
+        assert!(bump_zerover("garbage", BumpType::Patch).is_err());
+    }
+
+    #[test]
+    fn test_sequential_from_semver_fallback() {
+        // When given a semver string, sequential uses patch as sequence
+        assert_eq!(bump_sequential("1.2.42").unwrap(), "43");
+    }
+
+    #[test]
+    fn test_sequential_from_garbage() {
+        // When given garbage, defaults to 0, then increments to 1
+        assert_eq!(bump_sequential("abc").unwrap(), "1");
+    }
+
+    #[test]
+    fn test_sequential_large_number() {
+        assert_eq!(bump_sequential("999999").unwrap(), "1000000");
+    }
+
+    #[test]
+    fn test_sequential_with_v_prefix() {
+        assert_eq!(bump_sequential("v42").unwrap(), "43");
+    }
+
+    #[test]
+    fn test_compute_next_version_calver() {
+        let v = compute_next_version("0.0.0", BumpType::Minor, VersioningStrategy::Calver).unwrap();
+        assert_eq!(v.split('.').count(), 3);
+        let year: u32 = v.split('.').next().unwrap().parse().unwrap();
+        assert!(year >= 2026);
+    }
+
+    #[test]
+    fn test_compute_next_version_calver_short() {
+        let v = compute_next_version("0.0.0", BumpType::Minor, VersioningStrategy::CalverShort)
+            .unwrap();
+        let year: u32 = v.split('.').next().unwrap().parse().unwrap();
+        assert!(year < 100);
+    }
+
+    #[test]
+    fn test_compute_next_version_calver_seq() {
+        let v = compute_next_version("2020.1.5", BumpType::Minor, VersioningStrategy::CalverSeq)
+            .unwrap();
+        let parts: Vec<&str> = v.split('.').collect();
+        assert_eq!(parts.len(), 3);
+        // Different year/month, so seq resets to 1
+        assert_eq!(parts[2], "1");
+    }
 }


### PR DESCRIPTION
Add 66 new tests across 6 modules:

- **formats/mod.rs**: 12 tests — handler routing, read/write with temp files, path joining, error on missing files
- **formats/gomod.rs**: 2 tests — write_version noop, modifies_file returns false
- **changelog.rs**: 7 tests — breaking change in body, refactor/chore excluded, scoped commits, multiple versions ordering
- **config.rs**: 18 tests — invalid JSON/TOML, unknown extension fallback, serde defaults, FileFormat variants, tag edge cases
- **conventional_commits.rs**: 13 tests — empty/whitespace input, all bump types, all breaking types, Display impl, nested scopes
- **versioning.rs**: 14 tests — invalid version, pre-release, zerover edge cases, sequential fallbacks, calver variants