### PR TITLE
feat: add pre/post-release hooks

### DIFF
--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -58,6 +58,9 @@
         "skipCi": {
           "type": "boolean",
           "description": "Append [skip ci] to the release commit message. Defaults to true in 'commit' mode, false in 'pr' mode."
+        },
+        "hooks": {
+          "$ref": "#/$defs/hooks"
         }
       },
       "additionalProperties": false
@@ -117,10 +120,48 @@
             "type": "string",
             "description": "Tag template for this package. Use {name} for package name and {version} for version. Overrides workspace default.",
             "examples": ["v{version}", "{name}@v{version}", "{name}/v{version}", "release-{version}"]
+          },
+          "hooks": {
+            "$ref": "#/$defs/hooks"
           }
         },
         "additionalProperties": false
       }
+    }
+  },
+  "$defs": {
+    "hooks": {
+      "type": "object",
+      "description": "Shell commands executed at lifecycle points during release.",
+      "properties": {
+        "preBump": {
+          "type": "string",
+          "description": "Run after bump calculation, before writing version files."
+        },
+        "postBump": {
+          "type": "string",
+          "description": "Run after writing version files, before changelog generation."
+        },
+        "preCommit": {
+          "type": "string",
+          "description": "Run after changelog generation, before git commit."
+        },
+        "prePublish": {
+          "type": "string",
+          "description": "Run after commit and tag, before push."
+        },
+        "postPublish": {
+          "type": "string",
+          "description": "Run after push and release creation."
+        },
+        "onFailure": {
+          "type": "string",
+          "description": "Behavior when a hook exits non-zero.",
+          "enum": ["abort", "continue"],
+          "default": "abort"
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,34 @@ use std::path::{Path, PathBuf};
 use crate::telemetry;
 
 // ---------------------------------------------------------------------------
+// Hooks config
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct HooksConfig {
+    #[serde(alias = "preBump")]
+    pub pre_bump: Option<String>,
+    #[serde(alias = "postBump")]
+    pub post_bump: Option<String>,
+    #[serde(alias = "preCommit")]
+    pub pre_commit: Option<String>,
+    #[serde(alias = "prePublish")]
+    pub pre_publish: Option<String>,
+    #[serde(alias = "postPublish")]
+    pub post_publish: Option<String>,
+    #[serde(default, alias = "onFailure")]
+    pub on_failure: Option<OnFailure>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum OnFailure {
+    #[default]
+    Abort,
+    Continue,
+}
+
+// ---------------------------------------------------------------------------
 // Config structs
 // ---------------------------------------------------------------------------
 
@@ -46,6 +74,8 @@ pub struct WorkspaceConfig {
     pub auto_merge_releases: bool,
     #[serde(default, alias = "skipCi")]
     pub skip_ci: Option<bool>,
+    #[serde(default)]
+    pub hooks: Option<HooksConfig>,
 }
 
 impl WorkspaceConfig {
@@ -92,6 +122,8 @@ pub struct PackageConfig {
     pub versioning: Option<VersioningStrategy>,
     #[serde(alias = "tagTemplate")]
     pub tag_template: Option<String>,
+    #[serde(default)]
+    pub hooks: Option<HooksConfig>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Default)]
@@ -214,6 +246,12 @@ const CAMEL_CASE_KEYS: &[&str] = &[
     "release_commit_mode",
     "auto_merge_releases",
     "skip_ci",
+    "pre_bump",
+    "post_bump",
+    "pre_commit",
+    "pre_publish",
+    "post_publish",
+    "on_failure",
 ];
 
 fn to_camel_case_keys(value: serde_json::Value) -> serde_json::Value {
@@ -450,6 +488,7 @@ impl Config {
                     shared_paths: Vec::new(),
                     versioning: None,
                     tag_template: None,
+                    hooks: None,
                 }]
             },
         }
@@ -632,6 +671,7 @@ fn collect_package(path_default: &str, monorepo: bool) -> PackageConfig {
         shared_paths: Vec::new(),
         versioning: None,
         tag_template: None,
+        hooks: None,
     }
 }
 
@@ -829,6 +869,7 @@ format = "toml"
             shared_paths: vec![],
             versioning: None,
             tag_template: None,
+            hooks: None,
         };
         assert_eq!(pkg.effective_versioning(&ws), VersioningStrategy::Calver);
     }
@@ -847,6 +888,7 @@ format = "toml"
             shared_paths: vec![],
             versioning: Some(VersioningStrategy::Zerover),
             tag_template: None,
+            hooks: None,
         };
         assert_eq!(pkg.effective_versioning(&ws), VersioningStrategy::Zerover);
     }
@@ -864,6 +906,7 @@ format = "toml"
             shared_paths: vec![],
             versioning: None,
             tag_template: tag_template.map(String::from),
+            hooks: None,
         }
     }
 
@@ -1074,6 +1117,7 @@ format = "toml"
                 shared_paths: vec!["shared/".into()],
                 versioning: None,
                 tag_template: Some("{name}@v{version}".into()),
+                hooks: None,
             }],
         };
         let serialized = handler.serialize(&config).unwrap();
@@ -1116,6 +1160,7 @@ format = "toml"
                 shared_paths: vec!["shared/".into()],
                 versioning: None,
                 tag_template: Some("{name}@v{version}".into()),
+                hooks: None,
             }],
         };
         let serialized = handler.serialize(&config).unwrap();
@@ -1646,6 +1691,7 @@ format = "toml"
             shared_paths: vec![],
             versioning: None,
             tag_template: Some("release-latest".to_string()),
+            hooks: None,
         };
         // When template has no {version}, prefix is the entire template
         assert_eq!(pkg.tag_prefix(&ws, false), "release-latest");
@@ -1662,6 +1708,7 @@ format = "toml"
             shared_paths: vec![],
             versioning: None,
             tag_template: Some("{name}/v{version}".to_string()),
+            hooks: None,
         };
         assert_eq!(pkg.tag_for_version(&ws, true, "1.2.3"), "api/v1.2.3");
     }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,0 +1,287 @@
+use crate::config::{HooksConfig, OnFailure};
+use anyhow::{Result, bail};
+use colored::Colorize;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+// ---------------------------------------------------------------------------
+// Hook points
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy)]
+pub enum HookPoint {
+    PreBump,
+    PostBump,
+    PreCommit,
+    PrePublish,
+    PostPublish,
+}
+
+impl HookPoint {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::PreBump => "pre_bump",
+            Self::PostBump => "post_bump",
+            Self::PreCommit => "pre_commit",
+            Self::PrePublish => "pre_publish",
+            Self::PostPublish => "post_publish",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Hook context (environment variables)
+// ---------------------------------------------------------------------------
+
+pub struct HookContext {
+    pub package: String,
+    pub old_version: String,
+    pub new_version: String,
+    pub bump_type: String,
+    pub tag: String,
+    pub dry_run: bool,
+    pub package_path: String,
+}
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+pub fn resolve_hook(
+    pkg_hooks: Option<&HooksConfig>,
+    ws_hooks: Option<&HooksConfig>,
+    point: HookPoint,
+) -> Option<String> {
+    fn get(h: &HooksConfig, point: HookPoint) -> Option<&String> {
+        match point {
+            HookPoint::PreBump => h.pre_bump.as_ref(),
+            HookPoint::PostBump => h.post_bump.as_ref(),
+            HookPoint::PreCommit => h.pre_commit.as_ref(),
+            HookPoint::PrePublish => h.pre_publish.as_ref(),
+            HookPoint::PostPublish => h.post_publish.as_ref(),
+        }
+    }
+
+    if let Some(pkg) = pkg_hooks
+        && let Some(cmd) = get(pkg, point)
+    {
+        return Some(cmd.clone());
+    }
+
+    if let Some(ws) = ws_hooks
+        && let Some(cmd) = get(ws, point)
+    {
+        return Some(cmd.clone());
+    }
+
+    None
+}
+
+pub fn resolve_on_failure(
+    pkg_hooks: Option<&HooksConfig>,
+    ws_hooks: Option<&HooksConfig>,
+) -> OnFailure {
+    if let Some(pkg) = pkg_hooks
+        && let Some(v) = pkg.on_failure
+    {
+        return v;
+    }
+    if let Some(ws) = ws_hooks
+        && let Some(v) = ws.on_failure
+    {
+        return v;
+    }
+    OnFailure::Abort
+}
+
+// ---------------------------------------------------------------------------
+// Execution
+// ---------------------------------------------------------------------------
+
+pub fn run_hook(
+    point: HookPoint,
+    command: &str,
+    ctx: &HookContext,
+    on_failure: OnFailure,
+    dry_run: bool,
+    verbose: bool,
+    working_dir: &Path,
+) -> Result<()> {
+    if dry_run {
+        println!(
+            "  {} {} {}",
+            "⊙".dimmed(),
+            format!("[{}]", point.label()).dimmed(),
+            command.dimmed()
+        );
+        return Ok(());
+    }
+
+    println!(
+        "  {} {} {}",
+        "▸".cyan(),
+        format!("[{}]", point.label()).cyan(),
+        command
+    );
+
+    let mut cmd = build_command(command);
+    cmd.current_dir(working_dir)
+        .env("FERRFLOW_PACKAGE", &ctx.package)
+        .env("FERRFLOW_OLD_VERSION", &ctx.old_version)
+        .env("FERRFLOW_NEW_VERSION", &ctx.new_version)
+        .env("FERRFLOW_BUMP_TYPE", &ctx.bump_type)
+        .env("FERRFLOW_TAG", &ctx.tag)
+        .env("FERRFLOW_DRY_RUN", ctx.dry_run.to_string())
+        .env("FERRFLOW_PACKAGE_PATH", &ctx.package_path);
+
+    if verbose {
+        let status = cmd
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status()?;
+
+        if !status.success() {
+            return handle_failure(point, command, status.code(), on_failure);
+        }
+    } else {
+        let output = cmd.output()?;
+
+        if !output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if !stdout.is_empty() {
+                eprint!("{stdout}");
+            }
+            if !stderr.is_empty() {
+                eprint!("{stderr}");
+            }
+            return handle_failure(point, command, output.status.code(), on_failure);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn build_command(command: &str) -> Command {
+    let mut cmd = Command::new("sh");
+    cmd.args(["-c", command]);
+    cmd
+}
+
+#[cfg(windows)]
+fn build_command(command: &str) -> Command {
+    let mut cmd = Command::new("cmd");
+    cmd.args(["/C", command]);
+    cmd
+}
+
+fn handle_failure(
+    point: HookPoint,
+    command: &str,
+    code: Option<i32>,
+    on_failure: OnFailure,
+) -> Result<()> {
+    let code_str = code
+        .map(|c| c.to_string())
+        .unwrap_or_else(|| "signal".to_string());
+
+    match on_failure {
+        OnFailure::Abort => {
+            bail!(
+                "hook [{}] failed (exit {}): {}",
+                point.label(),
+                code_str,
+                command
+            );
+        }
+        OnFailure::Continue => {
+            eprintln!(
+                "{}",
+                format!(
+                    "  Warning: hook [{}] failed (exit {}): {}",
+                    point.label(),
+                    code_str,
+                    command
+                )
+                .yellow()
+            );
+            Ok(())
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ws_hooks(pre_bump: Option<&str>, post_publish: Option<&str>) -> HooksConfig {
+        HooksConfig {
+            pre_bump: pre_bump.map(String::from),
+            post_publish: post_publish.map(String::from),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn resolve_falls_back_to_workspace() {
+        let ws = ws_hooks(Some("echo ws"), None);
+        let result = resolve_hook(None, Some(&ws), HookPoint::PreBump);
+        assert_eq!(result.as_deref(), Some("echo ws"));
+    }
+
+    #[test]
+    fn resolve_package_overrides_workspace() {
+        let ws = ws_hooks(Some("echo ws"), None);
+        let pkg = HooksConfig {
+            pre_bump: Some("echo pkg".into()),
+            ..Default::default()
+        };
+        let result = resolve_hook(Some(&pkg), Some(&ws), HookPoint::PreBump);
+        assert_eq!(result.as_deref(), Some("echo pkg"));
+    }
+
+    #[test]
+    fn resolve_returns_none_when_unset() {
+        let ws = ws_hooks(Some("echo ws"), None);
+        let result = resolve_hook(None, Some(&ws), HookPoint::PostBump);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn resolve_no_hooks_at_all() {
+        let result = resolve_hook(None, None, HookPoint::PreBump);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn on_failure_defaults_to_abort() {
+        assert_eq!(resolve_on_failure(None, None), OnFailure::Abort);
+    }
+
+    #[test]
+    fn on_failure_inherits_workspace() {
+        let ws = HooksConfig {
+            on_failure: Some(OnFailure::Continue),
+            ..Default::default()
+        };
+        assert_eq!(resolve_on_failure(None, Some(&ws)), OnFailure::Continue);
+    }
+
+    #[test]
+    fn on_failure_package_overrides_workspace() {
+        let ws = HooksConfig {
+            on_failure: Some(OnFailure::Continue),
+            ..Default::default()
+        };
+        let pkg = HooksConfig {
+            on_failure: Some(OnFailure::Abort),
+            ..Default::default()
+        };
+        assert_eq!(resolve_on_failure(Some(&pkg), Some(&ws)), OnFailure::Abort);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod config;
 mod conventional_commits;
 mod formats;
 mod git;
+mod hooks;
 mod monorepo;
 mod query;
 mod release;

--- a/src/monorepo.rs
+++ b/src/monorepo.rs
@@ -8,11 +8,13 @@ use crate::git::{
     get_changed_files_since_tag, get_commits_since_last_tag, get_repo_root, get_repo_slug,
     open_repo, push, push_branch,
 };
+use crate::hooks::{HookContext, HookPoint, resolve_hook, resolve_on_failure, run_hook};
 use crate::release::{create_github_pr, create_github_release, enable_auto_merge};
 use crate::telemetry;
 use crate::versioning::compute_next_version;
 use anyhow::Result;
 use colored::Colorize;
+use std::collections::HashSet;
 use std::path::Path;
 
 pub fn check(config_path: Option<&Path>, verbose: bool) -> Result<()> {
@@ -79,8 +81,9 @@ fn run_release_logic(root: &Path, config: &Config, dry_run: bool, verbose: bool)
     let mut files_to_commit: Vec<String> = Vec::new();
     // (tag_name, tag_msg, body, pkg_name, version)
     let mut tags_to_create: Vec<(String, String, String, String, String)> = Vec::new();
+    let mut hook_contexts: Vec<(HookContext, usize)> = Vec::new(); // (ctx, pkg_index)
 
-    for pkg in &config.packages {
+    for (pkg_idx, pkg) in config.packages.iter().enumerate() {
         let tag_search_prefix = pkg.tag_prefix(&config.workspace, config.is_monorepo());
         let mut touched = is_package_touched(pkg, &changed_files, config.is_monorepo());
 
@@ -185,8 +188,33 @@ fn run_release_logic(root: &Path, config: &Config, dry_run: bool, verbose: bool)
             }
         }
 
-        if !dry_run {
-            let tag = pkg.tag_for_version(&config.workspace, config.is_monorepo(), &new_version);
+        let tag = pkg.tag_for_version(&config.workspace, config.is_monorepo(), &new_version);
+
+        let hook_ctx = HookContext {
+            package: pkg.name.clone(),
+            old_version: current_version.clone(),
+            new_version: new_version.clone(),
+            bump_type: bump.to_string(),
+            tag: tag.clone(),
+            dry_run,
+            package_path: root
+                .join(pkg.path.trim_start_matches("./"))
+                .to_string_lossy()
+                .into_owned(),
+        };
+
+        let ws_hooks = config.workspace.hooks.as_ref();
+        let pkg_hooks = pkg.hooks.as_ref();
+        let on_failure = resolve_on_failure(pkg_hooks, ws_hooks);
+
+        if dry_run {
+            // Print hooks that would run (dry-run mode).
+            for point in [HookPoint::PreBump, HookPoint::PostBump] {
+                if let Some(cmd) = resolve_hook(pkg_hooks, ws_hooks, point) {
+                    run_hook(point, &cmd, &hook_ctx, on_failure, true, verbose, root)?;
+                }
+            }
+        } else {
             if repo.refname_to_id(&format!("refs/tags/{tag}")).is_ok() {
                 println!(
                     "  {} {} — tag {} already exists, skipping",
@@ -195,6 +223,19 @@ fn run_release_logic(root: &Path, config: &Config, dry_run: bool, verbose: bool)
                     tag.cyan()
                 );
                 continue;
+            }
+
+            // --- pre_bump hook ---
+            if let Some(cmd) = resolve_hook(pkg_hooks, ws_hooks, HookPoint::PreBump) {
+                run_hook(
+                    HookPoint::PreBump,
+                    &cmd,
+                    &hook_ctx,
+                    on_failure,
+                    false,
+                    verbose,
+                    root,
+                )?;
             }
 
             for vf in &pkg.versioned_files {
@@ -218,6 +259,21 @@ fn run_release_logic(root: &Path, config: &Config, dry_run: bool, verbose: bool)
                 files_to_commit.push(changelog_rel.clone());
             }
 
+            // --- post_bump hook ---
+            if let Some(cmd) = resolve_hook(pkg_hooks, ws_hooks, HookPoint::PostBump) {
+                let before = collect_dirty_files(&repo);
+                run_hook(
+                    HookPoint::PostBump,
+                    &cmd,
+                    &hook_ctx,
+                    on_failure,
+                    false,
+                    verbose,
+                    root,
+                )?;
+                auto_stage_new_files(&repo, &before, &mut files_to_commit);
+            }
+
             let body = build_section(&new_version, &commits);
             tags_to_create.push((
                 tag.clone(),
@@ -228,10 +284,34 @@ fn run_release_logic(root: &Path, config: &Config, dry_run: bool, verbose: bool)
             ));
         }
 
+        hook_contexts.push((hook_ctx, pkg_idx));
         any_bumped = true;
     }
 
-    if !dry_run && any_bumped {
+    if any_bumped && !tags_to_create.is_empty() {
+        // --- pre_commit hooks (per released package) ---
+        for (ctx, pkg_idx) in &hook_contexts {
+            let pkg = &config.packages[*pkg_idx];
+            let ws_hooks = config.workspace.hooks.as_ref();
+            let pkg_hooks = pkg.hooks.as_ref();
+            let on_failure = resolve_on_failure(pkg_hooks, ws_hooks);
+            if let Some(cmd) = resolve_hook(pkg_hooks, ws_hooks, HookPoint::PreCommit) {
+                let before = collect_dirty_files(&repo);
+                run_hook(
+                    HookPoint::PreCommit,
+                    &cmd,
+                    ctx,
+                    on_failure,
+                    dry_run,
+                    verbose,
+                    root,
+                )?;
+                if !dry_run {
+                    auto_stage_new_files(&repo, &before, &mut files_to_commit);
+                }
+            }
+        }
+
         let file_refs: Vec<&str> = files_to_commit.iter().map(String::as_str).collect();
         let mode = config.workspace.release_commit_mode;
 
@@ -247,136 +327,198 @@ fn run_release_logic(root: &Path, config: &Config, dry_run: bool, verbose: bool)
         };
         let commit_msg = format!("chore(release): {}{skip_ci}", release_parts.join(", "));
 
-        match mode {
-            ReleaseCommitMode::Commit => {
-                create_commit(&repo, &file_refs, &commit_msg)?;
-                println!("  ✓ Committed release changes");
-            }
-            ReleaseCommitMode::Pr => {
-                let branch_name = format!(
-                    "release/{}",
-                    release_parts
-                        .first()
-                        .map(|s| s.replace(' ', "-"))
-                        .unwrap_or_else(|| "bump".to_string())
-                );
-                create_branch_and_commit(&repo, &branch_name, &file_refs, &commit_msg)?;
-                push_branch(&repo, &config.workspace.remote, &branch_name)?;
-                println!("  ✓ Pushed branch {}", branch_name.cyan());
-
-                if let Ok(token) = std::env::var("GITHUB_TOKEN")
-                    && let Some(slug) = get_repo_slug(&repo, &config.workspace.remote)
-                {
-                    let pr_title = format!("chore(release): {}", release_parts.join(", "));
-                    let pr_body = format!(
-                        "Automated release commit.\n\n{}",
-                        tags_to_create
-                            .iter()
-                            .map(|(tag, _, _, _, _)| format!("- `{tag}`"))
-                            .collect::<Vec<_>>()
-                            .join("\n")
+        if !dry_run {
+            match mode {
+                ReleaseCommitMode::Commit => {
+                    create_commit(&repo, &file_refs, &commit_msg)?;
+                    println!("  ✓ Committed release changes");
+                }
+                ReleaseCommitMode::Pr => {
+                    let branch_name = format!(
+                        "release/{}",
+                        release_parts
+                            .first()
+                            .map(|s| s.replace(' ', "-"))
+                            .unwrap_or_else(|| "bump".to_string())
                     );
-                    match create_github_pr(
-                        &token,
-                        &slug,
-                        &branch_name,
-                        &config.workspace.branch,
-                        &pr_title,
-                        &pr_body,
-                    ) {
-                        Ok(pr_number) => {
-                            println!("  ✓ Created PR #{}", pr_number.to_string().cyan());
-                            if config.workspace.auto_merge_releases {
-                                match enable_auto_merge(&token, &slug, pr_number) {
-                                    Ok(()) => println!("  ✓ Auto-merge enabled"),
-                                    Err(err) => eprintln!(
-                                        "{}",
-                                        format!("  Warning: failed to enable auto-merge: {err}")
+                    create_branch_and_commit(&repo, &branch_name, &file_refs, &commit_msg)?;
+                    push_branch(&repo, &config.workspace.remote, &branch_name)?;
+                    println!("  ✓ Pushed branch {}", branch_name.cyan());
+
+                    if let Ok(token) = std::env::var("GITHUB_TOKEN")
+                        && let Some(slug) = get_repo_slug(&repo, &config.workspace.remote)
+                    {
+                        let pr_title = format!("chore(release): {}", release_parts.join(", "));
+                        let pr_body = format!(
+                            "Automated release commit.\n\n{}",
+                            tags_to_create
+                                .iter()
+                                .map(|(tag, _, _, _, _)| format!("- `{tag}`"))
+                                .collect::<Vec<_>>()
+                                .join("\n")
+                        );
+                        match create_github_pr(
+                            &token,
+                            &slug,
+                            &branch_name,
+                            &config.workspace.branch,
+                            &pr_title,
+                            &pr_body,
+                        ) {
+                            Ok(pr_number) => {
+                                println!("  ✓ Created PR #{}", pr_number.to_string().cyan());
+                                if config.workspace.auto_merge_releases {
+                                    match enable_auto_merge(&token, &slug, pr_number) {
+                                        Ok(()) => println!("  ✓ Auto-merge enabled"),
+                                        Err(err) => eprintln!(
+                                            "{}",
+                                            format!(
+                                                "  Warning: failed to enable auto-merge: {err}"
+                                            )
                                             .yellow()
-                                    ),
+                                        ),
+                                    }
                                 }
                             }
+                            Err(err) => eprintln!(
+                                "{}",
+                                format!("  Warning: failed to create PR: {err}").yellow()
+                            ),
                         }
-                        Err(err) => eprintln!(
-                            "{}",
-                            format!("  Warning: failed to create PR: {err}").yellow()
-                        ),
                     }
                 }
+                ReleaseCommitMode::None => {}
             }
-            ReleaseCommitMode::None => {}
+
+            // Tags are always created on the current HEAD.
+            for (tag_name, tag_msg, _, _, _) in &tags_to_create {
+                create_tag(&repo, tag_name, tag_msg)?;
+                println!("  ✓ Created tag {}", tag_name.cyan());
+            }
         }
 
-        // Tags are always created on the current HEAD (before the release commit for PR mode).
-        for (tag_name, tag_msg, _, _, _) in &tags_to_create {
-            create_tag(&repo, tag_name, tag_msg)?;
-            println!("  ✓ Created tag {}", tag_name.cyan());
-        }
-
-        // Push tags (and branch for commit mode).
-        let tag_refs: Vec<&str> = tags_to_create
-            .iter()
-            .map(|(t, _, _, _, _)| t.as_str())
-            .collect();
-        match mode {
-            ReleaseCommitMode::Commit => {
-                push(
-                    &repo,
-                    &config.workspace.remote,
-                    &config.workspace.branch,
-                    &tag_refs,
+        // --- pre_publish hooks (per released package) ---
+        for (ctx, pkg_idx) in &hook_contexts {
+            let pkg = &config.packages[*pkg_idx];
+            let ws_hooks = config.workspace.hooks.as_ref();
+            let pkg_hooks = pkg.hooks.as_ref();
+            let on_failure = resolve_on_failure(pkg_hooks, ws_hooks);
+            if let Some(cmd) = resolve_hook(pkg_hooks, ws_hooks, HookPoint::PrePublish) {
+                run_hook(
+                    HookPoint::PrePublish,
+                    &cmd,
+                    ctx,
+                    on_failure,
+                    dry_run,
+                    verbose,
+                    root,
                 )?;
-                println!(
-                    "  ✓ Pushed to {}/{}",
-                    config.workspace.remote, config.workspace.branch
-                );
             }
-            ReleaseCommitMode::Pr | ReleaseCommitMode::None => {
-                // Only push tags, branch was already pushed (or nothing to push).
-                if !tag_refs.is_empty() {
+        }
+
+        if !dry_run {
+            // Push tags (and branch for commit mode).
+            let tag_refs: Vec<&str> = tags_to_create
+                .iter()
+                .map(|(t, _, _, _, _)| t.as_str())
+                .collect();
+            match mode {
+                ReleaseCommitMode::Commit => {
                     push(
                         &repo,
                         &config.workspace.remote,
                         &config.workspace.branch,
                         &tag_refs,
                     )?;
-                    println!("  ✓ Pushed tags");
+                    println!(
+                        "  ✓ Pushed to {}/{}",
+                        config.workspace.remote, config.workspace.branch
+                    );
+                }
+                ReleaseCommitMode::Pr | ReleaseCommitMode::None => {
+                    if !tag_refs.is_empty() {
+                        push(
+                            &repo,
+                            &config.workspace.remote,
+                            &config.workspace.branch,
+                            &tag_refs,
+                        )?;
+                        println!("  ✓ Pushed tags");
+                    }
                 }
             }
-        }
 
-        if config.workspace.telemetry {
-            for (_, _, _, pkg_name, version) in &tags_to_create {
-                telemetry::send_event("release", Some(pkg_name), Some(version), None);
-            }
-        }
-
-        if let Ok(token) = std::env::var("GITHUB_TOKEN")
-            && let Some(slug) = get_repo_slug(&repo, &config.workspace.remote)
-        {
-            for (tag_name, _, body, _, _) in &tags_to_create {
-                match create_github_release(&token, &slug, tag_name, body) {
-                    Ok(()) => println!("  ✓ GitHub Release {}", tag_name.cyan()),
-                    Err(err) => eprintln!(
-                        "{}",
-                        format!("  Warning: failed to create GitHub Release for {tag_name}: {err}")
-                            .yellow()
-                    ),
+            if config.workspace.telemetry {
+                for (_, _, _, pkg_name, version) in &tags_to_create {
+                    telemetry::send_event("release", Some(pkg_name), Some(version), None);
                 }
             }
-        }
 
-        if let Ok(summary_path) = std::env::var("GITHUB_STEP_SUMMARY") {
-            use std::io::Write;
-            if let Ok(mut file) = std::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(&summary_path)
+            if let Ok(token) = std::env::var("GITHUB_TOKEN")
+                && let Some(slug) = get_repo_slug(&repo, &config.workspace.remote)
             {
-                let _ = writeln!(file, "## Released\n");
                 for (tag_name, _, body, _, _) in &tags_to_create {
-                    let _ = writeln!(file, "### {tag_name}\n");
-                    let _ = writeln!(file, "{body}");
+                    match create_github_release(&token, &slug, tag_name, body) {
+                        Ok(()) => println!("  ✓ GitHub Release {}", tag_name.cyan()),
+                        Err(err) => eprintln!(
+                            "{}",
+                            format!(
+                                "  Warning: failed to create GitHub Release for {tag_name}: {err}"
+                            )
+                            .yellow()
+                        ),
+                    }
+                }
+            }
+
+            if let Ok(summary_path) = std::env::var("GITHUB_STEP_SUMMARY") {
+                use std::io::Write;
+                if let Ok(mut file) = std::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(&summary_path)
+                {
+                    let _ = writeln!(file, "## Released\n");
+                    for (tag_name, _, body, _, _) in &tags_to_create {
+                        let _ = writeln!(file, "### {tag_name}\n");
+                        let _ = writeln!(file, "{body}");
+                    }
+                }
+            }
+        }
+
+        // --- post_publish hooks (per released package) ---
+        for (ctx, pkg_idx) in &hook_contexts {
+            let pkg = &config.packages[*pkg_idx];
+            let ws_hooks = config.workspace.hooks.as_ref();
+            let pkg_hooks = pkg.hooks.as_ref();
+            let on_failure = resolve_on_failure(pkg_hooks, ws_hooks);
+            if let Some(cmd) = resolve_hook(pkg_hooks, ws_hooks, HookPoint::PostPublish) {
+                run_hook(
+                    HookPoint::PostPublish,
+                    &cmd,
+                    ctx,
+                    on_failure,
+                    dry_run,
+                    verbose,
+                    root,
+                )?;
+            }
+        }
+    } else if dry_run && any_bumped {
+        // Dry-run: print pre_commit/pre_publish/post_publish hooks.
+        for (ctx, pkg_idx) in &hook_contexts {
+            let pkg = &config.packages[*pkg_idx];
+            let ws_hooks = config.workspace.hooks.as_ref();
+            let pkg_hooks = pkg.hooks.as_ref();
+            let on_failure = resolve_on_failure(pkg_hooks, ws_hooks);
+            for point in [
+                HookPoint::PreCommit,
+                HookPoint::PrePublish,
+                HookPoint::PostPublish,
+            ] {
+                if let Some(cmd) = resolve_hook(pkg_hooks, ws_hooks, point) {
+                    run_hook(point, &cmd, ctx, on_failure, true, verbose, root)?;
                 }
             }
         }
@@ -387,6 +529,41 @@ fn run_release_logic(root: &Path, config: &Config, dry_run: bool, verbose: bool)
     }
 
     Ok(())
+}
+
+/// Collect the set of dirty (modified/new) file paths in the working tree.
+fn collect_dirty_files(repo: &git2::Repository) -> HashSet<String> {
+    let mut files = HashSet::new();
+    if let Ok(statuses) = repo.statuses(None) {
+        for entry in statuses.iter() {
+            let status = entry.status();
+            if status.intersects(
+                git2::Status::WT_MODIFIED
+                    | git2::Status::WT_NEW
+                    | git2::Status::WT_TYPECHANGE
+                    | git2::Status::INDEX_NEW
+                    | git2::Status::INDEX_MODIFIED,
+            ) && let Some(path) = entry.path()
+            {
+                files.insert(path.to_string());
+            }
+        }
+    }
+    files
+}
+
+/// Auto-stage files that became dirty after a hook ran.
+fn auto_stage_new_files(
+    repo: &git2::Repository,
+    before: &HashSet<String>,
+    files_to_commit: &mut Vec<String>,
+) {
+    let after = collect_dirty_files(repo);
+    for path in after.difference(before) {
+        if !files_to_commit.contains(path) {
+            files_to_commit.push(path.clone());
+        }
+    }
 }
 
 fn is_package_touched(pkg: &PackageConfig, changed_files: &[String], is_monorepo: bool) -> bool {
@@ -435,6 +612,7 @@ mod tests {
             shared_paths: shared.iter().map(|s| s.to_string()).collect(),
             versioning: None,
             tag_template: None,
+            hooks: None,
         }
     }
 


### PR DESCRIPTION
## Summary

- Add lifecycle hooks (`pre_bump`, `post_bump`, `pre_commit`, `pre_publish`, `post_publish`) that run shell commands at key points during the release process
- Hooks are configurable at workspace and package level (package hooks override workspace hooks)
- Each hook receives `FERRFLOW_*` environment variables (package name, old/new version, bump type, tag, dry-run flag, package path)
- Support `on_failure` setting (`abort` or `continue`) with package-level inheritance from workspace
- Files modified by `post_bump` or `pre_commit` hooks are automatically staged in the release commit
- `--dry-run` prints hooks without executing them, `--verbose` streams hook output live

Closes #32

## Test plan

- [ ] `cargo build` compiles without errors
- [ ] `cargo test` — all 226 tests pass (including 7 new hook resolution/on_failure tests)
- [ ] `cargo clippy` — no warnings
- [ ] Verify dry-run prints hooks without executing
- [ ] Verify hooks execute in correct lifecycle order
- [ ] Verify environment variables are injected correctly
- [ ] Verify `on_failure = "abort"` cancels release on hook failure
- [ ] Verify `on_failure = "continue"` prints warning and proceeds
- [ ] Verify package-level hooks override workspace hooks
- [ ] Verify files modified by `post_bump`/`pre_commit` hooks are auto-staged