### PR TITLE
chore: sync npm optionalDependencies via post_bump hook

### DIFF
--- a/.ferrflow
+++ b/.ferrflow
@@ -1,7 +1,10 @@
 {
   "$schema": "https://ferrflow.com/schema/ferrflow.json",
   "workspace": {
-    "tagTemplate": "v{version}"
+    "tagTemplate": "v{version}",
+    "hooks": {
+      "postBump": "node scripts/sync-optional-deps.js"
+    }
   },
   "package": [
     {
@@ -11,7 +14,12 @@
       "sharedPaths": ["src/"],
       "versionedFiles": [
         { "path": "Cargo.toml", "format": "toml" },
-        { "path": "npm/package.json", "format": "json" }
+        { "path": "npm/package.json", "format": "json" },
+        { "path": "npm/platforms/linux-x64/package.json", "format": "json" },
+        { "path": "npm/platforms/linux-arm64/package.json", "format": "json" },
+        { "path": "npm/platforms/darwin-x64/package.json", "format": "json" },
+        { "path": "npm/platforms/darwin-arm64/package.json", "format": "json" },
+        { "path": "npm/platforms/win32-x64/package.json", "format": "json" }
       ]
     }
   ]

--- a/scripts/sync-optional-deps.js
+++ b/scripts/sync-optional-deps.js
@@ -1,0 +1,17 @@
+const fs = require("fs");
+const path = require("path");
+
+const version = process.env.FERRFLOW_NEW_VERSION;
+if (!version) {
+  console.error("FERRFLOW_NEW_VERSION is not set");
+  process.exit(1);
+}
+
+const pkgPath = path.join(__dirname, "..", "npm", "package.json");
+const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+
+for (const dep of Object.keys(pkg.optionalDependencies || {})) {
+  pkg.optionalDependencies[dep] = version;
+}
+
+fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");


### PR DESCRIPTION
## Summary
- Add `scripts/sync-optional-deps.js` to update `optionalDependencies` in `npm/package.json` to match `$FERRFLOW_NEW_VERSION`
- Configure a `postBump` workspace hook in `.ferrflow` to run this script during releases
- Add the 5 platform `package.json` files to `versionedFiles` so their `version` field stays in sync

This ensures all npm package versions are committed as part of the release, preventing stale versions that trigger false Renovate PRs (#134, #135, #137, #138, #139).

Closes #142

## Test plan
- [ ] Run `FERRFLOW_NEW_VERSION=x.y.z node scripts/sync-optional-deps.js` and verify `npm/package.json` optionalDependencies are updated
- [ ] Run `ferrflow check` and verify the hook is printed in dry-run output
- [ ] Run a release and verify all 7 `package.json` files are updated in the release commit