### PR TITLE
ci: publish @ferrflow/wasm to npm on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,32 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash npm/scripts/publish.sh "${{ steps.version.outputs.value }}"
 
+  publish-wasm:
+    name: Publish @ferrflow/wasm
+    needs: release
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Extract version
+        id: version
+        run: echo "value=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+      - name: Build and publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: bash npm/scripts/publish-wasm.sh "${{ steps.version.outputs.value }}"
+
   update-major-tag:
     name: Update major version tag
     needs: release

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+ferrflow-wasm/pkg/
 
 # Benchmark artifacts
 benchmarks/results/raw/

--- a/npm/scripts/publish-wasm.sh
+++ b/npm/scripts/publish-wasm.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:?Usage: publish-wasm.sh <version>}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+WASM_DIR="${REPO_DIR}/ferrflow-wasm"
+
+echo "Building @ferrflow/wasm@${VERSION}..."
+
+cd "$WASM_DIR"
+wasm-pack build --target bundler --scope ferrflow
+
+cd pkg
+
+# Rename package from @ferrflow/ferrflow-wasm to @ferrflow/wasm
+node -e "
+  const fs = require('fs');
+  const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+  pkg.name = '@ferrflow/wasm';
+  pkg.version = '${VERSION}';
+  pkg.repository = {
+    type: 'git',
+    url: 'git+https://github.com/FerrFlow-Org/FerrFlow.git',
+    directory: 'ferrflow-wasm'
+  };
+  pkg.homepage = 'https://ferrflow.com';
+  fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+"
+
+echo "Publishing @ferrflow/wasm@${VERSION}..."
+npm publish --access public
+
+echo "Published @ferrflow/wasm@${VERSION}"


### PR DESCRIPTION
## Summary
- Add `publish-wasm` job to `release.yml` that builds with `wasm-pack` and publishes `@ferrflow/wasm` to npm
- Add `npm/scripts/publish-wasm.sh` build script (builds, patches package name/version/metadata, publishes)
- Add `ferrflow-wasm/pkg/` to `.gitignore`

Closes #155

## Test plan
- [ ] Verify `wasm-pack build --target bundler --scope ferrflow` compiles successfully
- [ ] Verify `publish-wasm.sh` patches package.json name to `@ferrflow/wasm` and sets correct version
- [ ] Trigger a release and confirm `@ferrflow/wasm` appears on npm