### PR TITLE
ci: add build provenance attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: Resolve tag
         id: tag
@@ -100,6 +102,10 @@ jobs:
         with:
           path: artifacts/
           merge-multiple: true
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: artifacts/*
       - uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.tag.outputs.name }}
@@ -189,6 +195,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4
@@ -205,6 +213,7 @@ jobs:
         id: version
         run: echo "value=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
       - uses: docker/build-push-action@v7
+        id: docker-push
         with:
           context: .
           push: true
@@ -214,3 +223,9 @@ jobs:
             ghcr.io/ferrflow-org/ferrflow:${{ steps.version.outputs.value }}
             ${{ secrets.DOCKERHUB_USERNAME }}/ferrflow:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/ferrflow:${{ steps.version.outputs.value }}
+      - name: Attest Docker image
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/ferrflow-org/ferrflow
+          subject-digest: ${{ steps.docker-push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
Add `actions/attest-build-provenance` to attest release archives and Docker images. Users can verify artifacts with `gh attestation verify`.