### PR TITLE
feat(formats): support Helm Chart.yaml versioning

### DIFF
--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -98,7 +98,7 @@
                 "format": {
                   "type": "string",
                   "description": "File format used to locate and update the version field.",
-                  "enum": ["toml", "json", "xml", "gradle", "gomod", "txt"]
+                  "enum": ["toml", "json", "xml", "gradle", "gomod", "helm", "txt"]
                 }
               },
               "additionalProperties": false

--- a/src/config.rs
+++ b/src/config.rs
@@ -188,6 +188,7 @@ pub enum FileFormat {
     #[serde(rename = "gomod")]
     GoMod,
     Gradle,
+    Helm,
     Json,
     Toml,
     Txt,
@@ -433,6 +434,12 @@ impl Config {
             versioned_files.push(VersionedFile {
                 path: path.to_string(),
                 format: FileFormat::Gradle,
+            });
+        }
+        if root.join("Chart.yaml").exists() {
+            versioned_files.push(VersionedFile {
+                path: "Chart.yaml".to_string(),
+                format: FileFormat::Helm,
             });
         }
         if root.join("go.mod").exists() {

--- a/src/formats/helm.rs
+++ b/src/formats/helm.rs
@@ -1,0 +1,142 @@
+use super::VersionFile;
+use anyhow::{Context, Result};
+use std::path::Path;
+
+pub struct HelmVersionFile;
+
+impl VersionFile for HelmVersionFile {
+    fn read_version(&self, file_path: &Path) -> Result<String> {
+        let content = std::fs::read_to_string(file_path)
+            .with_context(|| format!("Cannot read {}", file_path.display()))?;
+
+        for line in content.lines() {
+            if let Some(v) = line.strip_prefix("version:") {
+                let v = v.trim().trim_matches('"').trim_matches('\'');
+                if !v.is_empty() {
+                    return Ok(v.to_string());
+                }
+            }
+        }
+
+        anyhow::bail!("No `version` field found in {}", file_path.display())
+    }
+
+    fn write_version(&self, file_path: &Path, version: &str) -> Result<()> {
+        let content = std::fs::read_to_string(file_path)
+            .with_context(|| format!("Cannot read {}", file_path.display()))?;
+
+        let mut lines: Vec<String> = Vec::new();
+        let mut found_version = false;
+
+        for line in content.lines() {
+            if line.starts_with("version:") {
+                lines.push(format!("version: {version}"));
+                found_version = true;
+            } else if line.starts_with("appVersion:") {
+                // Preserve quoting style: appVersion is typically quoted
+                let old = line.strip_prefix("appVersion:").unwrap().trim();
+                if old.starts_with('"') {
+                    lines.push(format!("appVersion: \"{version}\""));
+                } else if old.starts_with('\'') {
+                    lines.push(format!("appVersion: '{version}'"));
+                } else {
+                    lines.push(format!("appVersion: \"{version}\""));
+                }
+            } else {
+                lines.push(line.to_string());
+            }
+        }
+
+        if !found_version {
+            anyhow::bail!("No `version` field found in {}", file_path.display());
+        }
+
+        let mut out = lines.join("\n");
+        if content.ends_with('\n') {
+            out.push('\n');
+        }
+
+        std::fs::write(file_path, out)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_temp(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f
+    }
+
+    const CHART_YAML: &str = "\
+apiVersion: v2
+name: my-app
+description: A Helm chart
+type: application
+version: 1.2.3
+appVersion: \"1.2.3\"
+";
+
+    #[test]
+    fn read_version() {
+        let f = write_temp(CHART_YAML);
+        assert_eq!(HelmVersionFile.read_version(f.path()).unwrap(), "1.2.3");
+    }
+
+    #[test]
+    fn read_version_no_app_version() {
+        let f = write_temp("apiVersion: v2\nversion: 0.1.0\n");
+        assert_eq!(HelmVersionFile.read_version(f.path()).unwrap(), "0.1.0");
+    }
+
+    #[test]
+    fn read_version_missing_fails() {
+        let f = write_temp("apiVersion: v2\nname: test\n");
+        assert!(HelmVersionFile.read_version(f.path()).is_err());
+    }
+
+    #[test]
+    fn write_updates_both_fields() {
+        let f = write_temp(CHART_YAML);
+        HelmVersionFile.write_version(f.path(), "2.0.0").unwrap();
+        let content = std::fs::read_to_string(f.path()).unwrap();
+        assert!(content.contains("version: 2.0.0"));
+        assert!(content.contains("appVersion: \"2.0.0\""));
+        assert!(content.contains("name: my-app"));
+    }
+
+    #[test]
+    fn write_preserves_single_quote_style() {
+        let f = write_temp("version: 1.0.0\nappVersion: '1.0.0'\n");
+        HelmVersionFile.write_version(f.path(), "2.0.0").unwrap();
+        let content = std::fs::read_to_string(f.path()).unwrap();
+        assert!(content.contains("appVersion: '2.0.0'"));
+    }
+
+    #[test]
+    fn write_without_app_version() {
+        let f = write_temp("apiVersion: v2\nversion: 1.0.0\n");
+        HelmVersionFile.write_version(f.path(), "3.0.0").unwrap();
+        let content = std::fs::read_to_string(f.path()).unwrap();
+        assert!(content.contains("version: 3.0.0"));
+        assert!(!content.contains("appVersion"));
+    }
+
+    #[test]
+    fn write_no_version_fails() {
+        let f = write_temp("apiVersion: v2\nname: test\n");
+        assert!(HelmVersionFile.write_version(f.path(), "1.0.0").is_err());
+    }
+
+    #[test]
+    fn roundtrip() {
+        let f = write_temp(CHART_YAML);
+        HelmVersionFile.write_version(f.path(), "5.0.0").unwrap();
+        assert_eq!(HelmVersionFile.read_version(f.path()).unwrap(), "5.0.0");
+    }
+}

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -1,5 +1,6 @@
 pub mod gomod;
 pub mod gradle;
+pub mod helm;
 pub mod json;
 pub mod toml_format;
 pub mod txt;
@@ -24,6 +25,7 @@ pub fn get_handler(format: &FileFormat) -> Box<dyn VersionFile> {
     match format {
         FileFormat::GoMod => Box::new(gomod::GoModVersionFile),
         FileFormat::Gradle => Box::new(gradle::GradleVersionFile),
+        FileFormat::Helm => Box::new(helm::HelmVersionFile),
         FileFormat::Json => Box::new(json::JsonVersionFile),
         FileFormat::Toml => Box::new(toml_format::TomlVersionFile),
         FileFormat::Txt => Box::new(txt::TxtVersionFile),
@@ -54,6 +56,7 @@ mod tests {
         for format in &[
             FileFormat::GoMod,
             FileFormat::Gradle,
+            FileFormat::Helm,
             FileFormat::Json,
             FileFormat::Toml,
             FileFormat::Txt,
@@ -73,6 +76,7 @@ mod tests {
     fn non_gomod_handlers_modify_file() {
         for format in &[
             FileFormat::Gradle,
+            FileFormat::Helm,
             FileFormat::Json,
             FileFormat::Toml,
             FileFormat::Txt,


### PR DESCRIPTION
## Summary
- Add `helm` format handler that reads/writes `version` in `Chart.yaml` and keeps `appVersion` in sync when present
- Auto-detect `Chart.yaml` during config discovery
- Preserve quoting style on `appVersion` (double or single quotes)

Closes #29

## Test plan
- [x] Unit tests: read, write, roundtrip, missing version, appVersion sync, quote preservation (8 tests)
- [x] All 234 existing tests pass
- [ ] Integration: add `Chart.yaml` to a test repo with `format = "helm"` and verify bump