### PR TITLE
chore(deps): remove unused quick-xml and thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,7 +422,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "2.0.0"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "cargo-husky",
@@ -432,13 +432,11 @@ dependencies = [
  "criterion",
  "git2",
  "json5",
- "quick-xml",
  "regex",
  "semver",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
  "toml_edit",
  "ureq",
 ]
@@ -1016,15 +1014,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-xml"
-version = "0.39.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,26 +1287,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,11 +35,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 json5 = "1.0"
 toml_edit = { version = "0.25", features = ["serde"] }
-quick-xml = "0.39"
 semver = "1"
 regex = "1"
 anyhow = "1"
-thiserror = "2"
 chrono = { version = "0.4", features = ["serde"] }
 
 # CLI-only dependencies


### PR DESCRIPTION
## Summary
- Remove `quick-xml` — XML parsing in `formats/xml.rs` uses regex, not this crate
- Remove `thiserror` — the project uses `anyhow` exclusively for error handling

Closes #165