### PR TITLE
refactor: rename telemetry config to anonymous_telemetry

### DIFF
--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -23,9 +23,14 @@
           "description": "Main branch name.",
           "default": "main"
         },
+        "anonymous_telemetry": {
+          "type": "boolean",
+          "description": "Send anonymous usage statistics to improve FerrFlow. No identifying data is collected.",
+          "default": true
+        },
         "telemetry": {
           "type": "boolean",
-          "description": "Send anonymous usage statistics to improve FerrFlow.",
+          "description": "Deprecated: use anonymous_telemetry instead.",
           "default": true
         },
         "versioning": {

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,8 +60,8 @@ pub struct WorkspaceConfig {
     pub remote: String,
     #[serde(default = "default_branch")]
     pub branch: String,
-    #[serde(default = "default_telemetry")]
-    pub telemetry: bool,
+    #[serde(default = "default_telemetry", alias = "telemetry")]
+    pub anonymous_telemetry: bool,
     #[serde(default)]
     pub versioning: VersioningStrategy,
     #[serde(alias = "tagTemplate")]
@@ -727,7 +727,7 @@ pub fn init(format: Option<ConfigFileFormat>) -> Result<()> {
     println!("Created {filename}");
     println!("Run: ferrflow check");
 
-    if config.workspace.telemetry {
+    if config.workspace.anonymous_telemetry {
         telemetry::send_event(telemetry::EventType::Init, None, None, None, None);
     }
 
@@ -1667,7 +1667,7 @@ format = "toml"
         let json = r#"{"workspace":{"remote":"origin"},"package":[]}"#;
         let config: Config = serde_json::from_str(json).unwrap();
         assert_eq!(config.workspace.remote, "origin");
-        assert!(config.workspace.telemetry);
+        assert!(config.workspace.anonymous_telemetry);
         assert!(config.workspace.auto_merge_releases);
     }
 

--- a/src/monorepo.rs
+++ b/src/monorepo.rs
@@ -27,7 +27,7 @@ pub fn check(config_path: Option<&Path>, verbose: bool) -> Result<()> {
 
     let result = run_release_logic(&root, &config, true, verbose);
 
-    if config.workspace.telemetry {
+    if config.workspace.anonymous_telemetry {
         telemetry::send_event(telemetry::EventType::Check, None, None, None, None);
     }
 
@@ -274,7 +274,7 @@ fn run_release_logic(root: &Path, config: &Config, dry_run: bool, verbose: bool)
                 auto_stage_new_files(&repo, &before, &mut files_to_commit);
             }
 
-            if config.workspace.telemetry {
+            if config.workspace.anonymous_telemetry {
                 telemetry::send_event(
                     telemetry::EventType::VersionBump,
                     Some(&pkg.name),
@@ -459,7 +459,7 @@ fn run_release_logic(root: &Path, config: &Config, dry_run: bool, verbose: bool)
                 }
             }
 
-            if config.workspace.telemetry {
+            if config.workspace.anonymous_telemetry {
                 for (_, _, _, pkg_name, version, commit_count) in &tags_to_create {
                     telemetry::send_event(
                         telemetry::EventType::Release,

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -30,7 +30,12 @@ struct EventPayload {
 }
 
 fn is_enabled() -> bool {
-    check_enabled(std::env::var("FERRFLOW_TELEMETRY").ok().as_deref())
+    check_enabled(
+        std::env::var("FERRFLOW_ANONYMOUS_TELEMETRY")
+            .or_else(|_| std::env::var("FERRFLOW_TELEMETRY"))
+            .ok()
+            .as_deref(),
+    )
 }
 
 fn check_enabled(val: Option<&str>) -> bool {


### PR DESCRIPTION
Closes #177

## Summary
- Rename `telemetry` config field to `anonymous_telemetry` in `WorkspaceConfig`
- Keep `telemetry` as a serde alias for backward compatibility
- Rename env var to `FERRFLOW_ANONYMOUS_TELEMETRY` (falls back to `FERRFLOW_TELEMETRY`)
- Update JSON schema with new field name, keep deprecated `telemetry` entry

## Test plan
- [x] All 465 existing tests pass
- [x] Clippy clean
- [ ] Verify existing configs with `telemetry` field still work via serde alias
- [ ] Verify `FERRFLOW_TELEMETRY` env var still works as fallback