### PR TITLE
fix(ci): use option_env for HMAC secret and add it to benchmark jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
         with:
           type: micro
           ferrflow-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
 
   benchmark:
     name: Benchmark
@@ -82,6 +84,8 @@ jobs:
         with:
           type: full
           ferrflow-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
 
   release:
     name: Release

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -7,8 +7,8 @@ type HmacSha256 = Hmac<sha2::Sha256>;
 
 const DEFAULT_API_URL: &str = "https://api.ferrflow.com";
 
-fn hmac_secret() -> &'static str {
-    option_env!("FERRFLOW_HMAC_SECRET").unwrap_or(env!("FERRFLOW_HMAC_SECRET"))
+fn hmac_secret() -> Option<&'static str> {
+    option_env!("FERRFLOW_HMAC_SECRET")
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]
@@ -102,19 +102,21 @@ pub fn send_event(
             .as_secs()
             .to_string();
 
-        let message = format!("{timestamp}.{body}");
-        let mut mac = HmacSha256::new_from_slice(hmac_secret().as_bytes())
-            .expect("HMAC accepts any key length");
-        mac.update(message.as_bytes());
-        let signature = hex::encode(mac.finalize().into_bytes());
-
         let agent = ureq::Agent::new_with_defaults();
-        let _ = agent
-            .post(&url)
-            .header("Content-Type", "application/json")
-            .header("X-Timestamp", &timestamp)
-            .header("X-Signature", &signature)
-            .send(body.as_bytes());
+        let mut req = agent.post(&url).header("Content-Type", "application/json");
+
+        if let Some(secret) = hmac_secret() {
+            let message = format!("{timestamp}.{body}");
+            let mut mac =
+                HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC accepts any key length");
+            mac.update(message.as_bytes());
+            let signature = hex::encode(mac.finalize().into_bytes());
+            req = req
+                .header("X-Timestamp", &timestamp)
+                .header("X-Signature", &signature);
+        }
+
+        let _ = req.send(body.as_bytes());
     });
 }
 


### PR DESCRIPTION
## Summary
- Replace `env!("FERRFLOW_HMAC_SECRET")` with `option_env!("FERRFLOW_HMAC_SECRET")` so compilation no longer requires the secret at build time
- When the secret is absent, HMAC signing is skipped and requests are sent unsigned
- Add `FERRFLOW_HMAC_SECRET` env to the micro-bench and benchmark CI jobs so signed builds still work in CI

## Test plan
- [x] All 465 tests pass
- [x] Clippy clean
- [x] Compiles without `FERRFLOW_HMAC_SECRET` set
- [ ] CI benchmark jobs should now pass