### PR TITLE
fix(docker): recreate wasm stub before final build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN mkdir src && echo 'fn main() {}' > src/main.rs && echo '' > src/lib.rs \
 # Build for real
 COPY src ./src
 COPY benchmarks ./benchmarks
-RUN cargo build --release --package ferrflow
+RUN mkdir -p ferrflow-wasm/src && echo '' > ferrflow-wasm/src/lib.rs \
+    && cargo build --release --package ferrflow
 
 # Runtime stage
 FROM alpine:3.23


### PR DESCRIPTION
## Summary
- The Docker build has been failing since v2.2.0 because the `ferrflow-wasm/src` directory is removed during the dependency cache step but not recreated before the final build
- Adds a stub `ferrflow-wasm/src/lib.rs` before `cargo build` so the workspace resolves correctly

Closes #182