### PR TITLE
feat(formats): add csproj format handler for .NET project files

### DIFF
--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -118,7 +118,7 @@
                 "format": {
                   "type": "string",
                   "description": "File format used to locate and update the version field.",
-                  "enum": ["toml", "json", "xml", "gradle", "gomod", "helm", "txt"]
+                  "enum": ["csproj", "toml", "json", "xml", "gradle", "gomod", "helm", "txt"]
                 }
               },
               "additionalProperties": false

--- a/src/config.rs
+++ b/src/config.rs
@@ -217,6 +217,7 @@ pub struct VersionedFile {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum FileFormat {
+    Csproj,
     #[serde(rename = "gomod")]
     GoMod,
     Gradle,

--- a/src/formats/csproj.rs
+++ b/src/formats/csproj.rs
@@ -1,0 +1,142 @@
+use super::VersionFile;
+use anyhow::{Context, Result};
+use regex::Regex;
+use std::path::Path;
+use std::sync::OnceLock;
+
+pub struct CsprojVersionFile;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_temp(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f
+    }
+
+    const CSPROJ: &str = r#"<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Version>1.0.0</Version>
+    <RootNamespace>MyApp</RootNamespace>
+  </PropertyGroup>
+</Project>"#;
+
+    const CSPROJ_NO_VERSION: &str = r#"<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>"#;
+
+    const CSPROJ_MULTIPLE_PROPERTY_GROUPS: &str = r#"<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Version>2.5.0</Version>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+</Project>"#;
+
+    const CSPROJ_PACKAGE_VERSION: &str = r#"<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Version>3.0.0</Version>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+</Project>"#;
+
+    #[test]
+    fn read_version() {
+        let f = write_temp(CSPROJ);
+        assert_eq!(CsprojVersionFile.read_version(f.path()).unwrap(), "1.0.0");
+    }
+
+    #[test]
+    fn read_no_version_fails() {
+        let f = write_temp(CSPROJ_NO_VERSION);
+        assert!(CsprojVersionFile.read_version(f.path()).is_err());
+    }
+
+    #[test]
+    fn write_version() {
+        let f = write_temp(CSPROJ);
+        CsprojVersionFile.write_version(f.path(), "2.0.0").unwrap();
+        assert_eq!(CsprojVersionFile.read_version(f.path()).unwrap(), "2.0.0");
+    }
+
+    #[test]
+    fn write_preserves_other_content() {
+        let f = write_temp(CSPROJ);
+        CsprojVersionFile.write_version(f.path(), "2.0.0").unwrap();
+        let content = std::fs::read_to_string(f.path()).unwrap();
+        assert!(content.contains("<TargetFramework>net8.0</TargetFramework>"));
+        assert!(content.contains("<RootNamespace>MyApp</RootNamespace>"));
+    }
+
+    #[test]
+    fn write_multiple_property_groups() {
+        let f = write_temp(CSPROJ_MULTIPLE_PROPERTY_GROUPS);
+        CsprojVersionFile.write_version(f.path(), "3.0.0").unwrap();
+        assert_eq!(CsprojVersionFile.read_version(f.path()).unwrap(), "3.0.0");
+    }
+
+    #[test]
+    fn does_not_touch_package_reference_version() {
+        let f = write_temp(CSPROJ_PACKAGE_VERSION);
+        CsprojVersionFile.write_version(f.path(), "4.0.0").unwrap();
+        let content = std::fs::read_to_string(f.path()).unwrap();
+        assert!(content.contains("<Version>4.0.0</Version>"));
+        assert!(content.contains("Version=\"13.0.1\""));
+    }
+
+    #[test]
+    fn write_no_version_fails() {
+        let f = write_temp(CSPROJ_NO_VERSION);
+        assert!(CsprojVersionFile.write_version(f.path(), "1.0.0").is_err());
+    }
+}
+
+static VERSION_RE: OnceLock<Regex> = OnceLock::new();
+
+fn version_re() -> &'static Regex {
+    VERSION_RE.get_or_init(|| Regex::new(r"<Version>([^<]+)</Version>").unwrap())
+}
+
+impl VersionFile for CsprojVersionFile {
+    fn read_version(&self, file_path: &Path) -> Result<String> {
+        let content = std::fs::read_to_string(file_path)
+            .with_context(|| format!("Cannot read {}", file_path.display()))?;
+
+        version_re()
+            .captures(&content)
+            .map(|c| c[1].trim().to_string())
+            .ok_or_else(|| anyhow::anyhow!("No <Version> tag found in {}", file_path.display()))
+    }
+
+    fn write_version(&self, file_path: &Path, version: &str) -> Result<()> {
+        let content = std::fs::read_to_string(file_path)
+            .with_context(|| format!("Cannot read {}", file_path.display()))?;
+
+        let mut count = 0;
+        let new_content = version_re().replace(&content, |_: &regex::Captures| {
+            count += 1;
+            format!("<Version>{version}</Version>")
+        });
+
+        if count == 0 {
+            anyhow::bail!(
+                "No <Version> tag found to update in {}",
+                file_path.display()
+            );
+        }
+
+        std::fs::write(file_path, new_content.as_ref())?;
+        Ok(())
+    }
+}

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -1,3 +1,4 @@
+pub mod csproj;
 pub mod gomod;
 pub mod gradle;
 pub mod helm;
@@ -23,6 +24,7 @@ pub trait VersionFile {
 
 pub fn get_handler(format: &FileFormat) -> Box<dyn VersionFile> {
     match format {
+        FileFormat::Csproj => Box::new(csproj::CsprojVersionFile),
         FileFormat::GoMod => Box::new(gomod::GoModVersionFile),
         FileFormat::Gradle => Box::new(gradle::GradleVersionFile),
         FileFormat::Helm => Box::new(helm::HelmVersionFile),
@@ -54,6 +56,7 @@ mod tests {
     fn get_handler_returns_handler_for_each_format() {
         // Verify get_handler doesn't panic for any format variant
         for format in &[
+            FileFormat::Csproj,
             FileFormat::GoMod,
             FileFormat::Gradle,
             FileFormat::Helm,
@@ -75,6 +78,7 @@ mod tests {
     #[test]
     fn non_gomod_handlers_modify_file() {
         for format in &[
+            FileFormat::Csproj,
             FileFormat::Gradle,
             FileFormat::Helm,
             FileFormat::Json,


### PR DESCRIPTION
Add a `csproj` format handler to read and write `<Version>` tags in .NET project files.

- New `src/formats/csproj.rs` implementing the `VersionFile` trait
- Targets `<Version>` elements (capital V), ignoring `Version` attributes on `<PackageReference>` elements
- Only replaces the first `<Version>` tag (consistent with the xml handler behavior)
- Covers `.csproj` (C#), `.fsproj` (F#), and `.vbproj` (VB.NET) since they share the same structure
- Updated `FileFormat` enum, handler dispatch, schema, and tests

### Config usage

```json
{
  "package": [{
    "versionedFiles": [
      { "path": "src/MyApp/MyApp.csproj", "format": "csproj" }
    ]
  }]
}
```

Closes #30