### PR TITLE
fix(ci): build ferrflow from source instead of downloading from releases

### DIFF
--- a/.ferrflow
+++ b/.ferrflow
@@ -2,6 +2,7 @@
   "$schema": "https://ferrflow.com/schema/ferrflow.json",
   "workspace": {
     "tagTemplate": "v{version}",
+    "floatingTags": ["major"],
     "hooks": {
       "postBump": "node scripts/sync-optional-deps.js"
     }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,11 +109,16 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.FERRFLOW_TOKEN }}
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
       - name: Configure git
         run: git remote set-url origin https://x-access-token:${{ secrets.FERRFLOW_TOKEN }}@github.com/${{ github.repository }}
-      - uses: FerrFlow-Org/ferrflow@v2
-        with:
-          dry_run: ${{ inputs.dry_run }}
+      - name: Build ferrflow
+        run: cargo build --release
+        env:
+          FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
+      - name: Run ferrflow release
+        run: ./target/release/ferrflow ${{ inputs.dry_run == 'true' && '--dry-run' || '' }} release
         env:
           FERRFLOW_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,35 +201,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: bash npm/scripts/publish-wasm.sh "${{ steps.version.outputs.value }}"
 
-  update-major-tag:
-    name: Update major version tag
-    needs: release
-    runs-on: ubuntu-latest
-    concurrency:
-      group: update-major-tag
-      cancel-in-progress: false
-    permissions:
-      contents: write
-    steps:
-      - name: Resolve tag
-        id: tag
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "name=${{ inputs.tag }}" >> $GITHUB_OUTPUT
-          else
-            echo "name=${{ github.ref_name }}" >> $GITHUB_OUTPUT
-          fi
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ steps.tag.outputs.name }}
-      - name: Move major version tag
-        run: |
-          MAJOR="v$(echo "${TAG#v}" | cut -d. -f1)"
-          git tag -f "$MAJOR"
-          git push origin "refs/tags/$MAJOR" --force
-        env:
-          TAG: ${{ steps.tag.outputs.name }}
-
   publish-docker:
     name: Publish Docker
     needs: release


### PR DESCRIPTION
The release job used `FerrFlow-Org/ferrflow@v2` which downloads the latest release binary. When a new release is created, there's a race condition where the binary assets aren't uploaded yet (404).

- Build ferrflow from source (`cargo build --release`) in the CI release job
- Add `floatingTags: ["major"]` to `.ferrflow` so ferrflow handles the `vX` floating tag natively
- Remove the manual `update-major-tag` job from `release.yml` (redundant with `floatingTags`)

Closes #199