### PR TITLE
perf(ci): use pre-built binaries for Docker publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,6 +222,21 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ steps.tag.outputs.name }}
+      - name: Download Linux artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: artifacts/
+          pattern: ferrflow-linux-*
+          merge-multiple: true
+      - name: Prepare binaries
+        run: |
+          mkdir -p docker-context
+          tar -xzf artifacts/ferrflow-linux-x64.tar.gz -C docker-context/
+          mv docker-context/ferrflow docker-context/ferrflow-amd64
+          tar -xzf artifacts/ferrflow-linux-arm64.tar.gz -C docker-context/
+          mv docker-context/ferrflow docker-context/ferrflow-arm64
+          chmod +x docker-context/ferrflow-*
+          cp Dockerfile.release docker-context/Dockerfile
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v4
         with:
@@ -240,7 +255,7 @@ jobs:
       - uses: docker/build-push-action@v7
         id: docker-push
         with:
-          context: .
+          context: docker-context
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,6 @@
+FROM alpine:3.23
+RUN apk add --no-cache ca-certificates
+ARG TARGETARCH
+COPY ferrflow-${TARGETARCH} /usr/local/bin/ferrflow
+ENTRYPOINT ["ferrflow"]
+CMD ["--help"]


### PR DESCRIPTION
Closes #201

## Summary

- Add `Dockerfile.release` that copies pre-built static binaries instead of compiling Rust from source
- Update `publish-docker` job to download Linux artifacts from the `build` job and use them directly
- No more QEMU cross-compilation: `TARGETARCH` selects the right binary per platform
- Fix benchmark results not appending to release notes (race condition: GitHub API propagation delay after `ferrflow release` creates the release)

## Before / After

| | Before | After |
|--|--------|-------|
| Docker publish | ~37 min (Rust compile via QEMU for amd64+arm64) | ~1-2 min (COPY pre-built binary) |
| Total release | ~40 min | ~7 min |
| Benchmark in release | Broken (race condition) | Retries up to 5x with 3s delay |

The existing `Dockerfile` is kept for local development builds.