### PR TITLE
fix(ci): wait for GitHub release propagation before appending benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,14 @@ jobs:
             echo "No tag found, skipping"
             exit 0
           fi
+          # Wait for GitHub release to be available (API propagation delay)
+          for i in 1 2 3 4 5; do
+            if gh release view "$TAG" --json tagName >/dev/null 2>&1; then
+              break
+            fi
+            echo "Waiting for release $TAG to propagate... ($i/5)"
+            sleep 3
+          done
           CURRENT_BODY=$(gh release view "$TAG" --json body --jq '.body' 2>/dev/null || echo "")
           BENCH=$(cat benchmark-summary/release-summary.md)
           printf -v NEW_BODY '%s\n\n%s' "$CURRENT_BODY" "$BENCH"


### PR DESCRIPTION
## Summary

- Add retry loop (5 attempts, 3s delay) before `gh release view` / `gh release edit` in the benchmark append step
- Fixes "release not found" error caused by GitHub API propagation delay after `ferrflow release` creates the release

## Context

The "Append benchmark results to release" step in `ci.yml` runs immediately after `ferrflow release`, but the GitHub Release API hasn't propagated yet. This caused the step to fail with `release not found` on every release since the benchmark append was added (visible on v2.8.1, v2.8.0, v2.7.1).