### PR TITLE
fix(ci): handle grep exit code in benchmark append step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
             echo "No benchmark summary found, skipping"
             exit 0
           fi
-          TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
           if [[ -z "$TAG" ]]; then
             echo "No tag found, skipping"
             exit 0


### PR DESCRIPTION
## Summary

- Fix release job crash when no semver tag exists on HEAD: `grep` returns exit code 1 when no match is found, which kills the script under `pipefail`

Closes #206

## Test plan

- [ ] Trigger a CI run on a commit with no release tag and verify the benchmark step exits gracefully