### PR TITLE
feat: add shell completions (bash, zsh, fish, powershell, elvish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,15 @@ jobs:
         with:
           path: artifacts/
           merge-multiple: true
+      - name: Generate shell completions
+        run: |
+          tar -xzf artifacts/ferrflow-linux-x64.tar.gz -C /tmp
+          chmod +x /tmp/ferrflow
+          mkdir -p completions
+          /tmp/ferrflow completions bash > completions/ferrflow.bash
+          /tmp/ferrflow completions zsh  > completions/_ferrflow
+          /tmp/ferrflow completions fish > completions/ferrflow.fish
+          tar -czf artifacts/ferrflow-completions.tar.gz -C completions .
       - name: Attest build provenance
         uses: actions/attest-build-provenance@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,12 +491,13 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "2.7.0"
+version = "2.8.5"
 dependencies = [
  "anyhow",
  "cargo-husky",
  "chrono",
  "clap",
+ "clap_complete",
  "colored",
  "criterion",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ path = "src/lib.rs"
 
 [features]
 default = ["cli"]
-cli = ["dep:git2", "dep:ureq", "dep:clap", "dep:colored", "dep:hmac"]
+cli = ["dep:git2", "dep:ureq", "dep:clap", "dep:clap_complete", "dep:colored", "dep:hmac"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -42,6 +42,7 @@ chrono = { version = "0.4", features = ["serde"] }
 
 # CLI-only dependencies
 clap = { version = "4", features = ["derive", "env"], optional = true }
+clap_complete = { version = "4", optional = true }
 colored = { version = "3", optional = true }
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"], optional = true }
 ureq = { version = "3", features = ["json"], optional = true }

--- a/README.md
+++ b/README.md
@@ -91,7 +91,14 @@ ferrflow tag api
 # JSON output (for scripting)
 ferrflow version --json
 ferrflow tag --json
+
+# Shell completions
+ferrflow completions bash >> ~/.bash_completion
+ferrflow completions zsh  > ~/.zfunc/_ferrflow
+ferrflow completions fish > ~/.config/fish/completions/ferrflow.fish
 ```
+
+Pre-generated completion scripts are also available as `ferrflow-completions.tar.gz` in each [GitHub release](https://github.com/FerrFlow-Org/FerrFlow/releases).
 
 ## Configuration
 

--- a/scripts/generate-completions.sh
+++ b/scripts/generate-completions.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate shell completion scripts for ferrflow.
+# Usage: ./scripts/generate-completions.sh [output_dir]
+
+FERRFLOW="${FERRFLOW_BIN:-ferrflow}"
+OUT_DIR="${1:-completions}"
+
+mkdir -p "$OUT_DIR"
+
+"$FERRFLOW" completions bash > "$OUT_DIR/ferrflow.bash"
+"$FERRFLOW" completions zsh  > "$OUT_DIR/_ferrflow"
+"$FERRFLOW" completions fish > "$OUT_DIR/ferrflow.fish"
+
+echo "Generated completions in $OUT_DIR/"
+ls -1 "$OUT_DIR/"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::Shell;
 
 use crate::config::ConfigFileFormat;
 use crate::status::OutputFormat;
@@ -71,6 +72,11 @@ pub enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Generate shell completion scripts
+    Completions {
+        /// Shell to generate completions for
+        shell: Shell,
+    },
 }
 
 impl Cli {
@@ -92,6 +98,15 @@ impl Cli {
             }
             Commands::Tag { package, json } => {
                 crate::query::tag(self.config.as_deref(), package.as_deref(), json)
+            }
+            Commands::Completions { shell } => {
+                clap_complete::generate(
+                    shell,
+                    &mut Cli::command(),
+                    "ferrflow",
+                    &mut std::io::stdout(),
+                );
+                Ok(())
             }
         }
     }


### PR DESCRIPTION
Closes #27

Adds `ferrflow completions <shell>` subcommand using `clap_complete`.

**Runtime command:**
```bash
ferrflow completions bash >> ~/.bash_completion
ferrflow completions zsh  > ~/.zfunc/_ferrflow
ferrflow completions fish > ~/.config/fish/completions/ferrflow.fish
```

**Release artifacts:**
Pre-generated completion scripts (`ferrflow-completions.tar.gz`) are now included in every GitHub release. Generated from the linux-x64 binary in the release workflow.

**Supported shells:** bash, zsh, fish, powershell, elvish

Also includes a `scripts/generate-completions.sh` helper for local generation.