### PR TITLE
fix(docker): patch Alpine zlib CVE and add Renovate Docker automerge

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,5 +1,5 @@
 FROM alpine:3.23
-RUN apk add --no-cache ca-certificates
+RUN apk upgrade --no-cache && apk add --no-cache ca-certificates
 ARG TARGETARCH
 COPY ferrflow-${TARGETARCH} /usr/local/bin/ferrflow
 ENTRYPOINT ["ferrflow"]

--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,13 @@
       "automergeType": "pr",
       "automergeStrategy": "squash",
       "groupName": "GitHub Actions"
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "groupName": "Docker images"
     }
   ]
 }


### PR DESCRIPTION
Closes #214

- Add `apk upgrade --no-cache` in `Dockerfile.release` to patch vulnerable Alpine packages (zlib) at build time
- Add Renovate `dockerfile` manager rule to automerge Docker image updates

Ref: https://app.snyk.io/org/bryanfrd/project/22043c6e-30c0-4e63-b3c1-314adeae80a7#issue-SNYK-ALPINE323-ZLIB-15435529