### PR TITLE
fix(release): target current branch for pre-release commits and PRs

### DIFF
--- a/src/monorepo.rs
+++ b/src/monorepo.rs
@@ -160,6 +160,14 @@ fn run_release_logic(
 
     let all_tags = collect_all_tags(&repo);
 
+    // For pre-releases, commit/push/PR target the current branch (e.g. develop),
+    // not the configured stable branch (e.g. main).
+    let target_branch = if prerelease_ctx.is_prerelease() {
+        current_branch.clone()
+    } else {
+        config.workspace.branch.clone()
+    };
+
     let changed_files = get_changed_files(&repo)?;
 
     if verbose && !json && !changed_files.is_empty() {
@@ -564,7 +572,7 @@ fn run_release_logic(
                         );
                         match forge_instance.create_merge_request(
                             &branch_name,
-                            &config.workspace.branch,
+                            &target_branch,
                             &pr_title,
                             &pr_body,
                         ) {
@@ -693,15 +701,10 @@ fn run_release_logic(
                 .collect();
             match mode {
                 ReleaseCommitMode::Commit => {
-                    push(
-                        &repo,
-                        &config.workspace.remote,
-                        &config.workspace.branch,
-                        &tag_refs,
-                    )?;
+                    push(&repo, &config.workspace.remote, &target_branch, &tag_refs)?;
                     println!(
                         "  ✓ Pushed and verified on {}/{}",
-                        config.workspace.remote, config.workspace.branch
+                        config.workspace.remote, target_branch
                     );
                 }
                 ReleaseCommitMode::Pr | ReleaseCommitMode::None => {


### PR DESCRIPTION
## Summary

Closes a bug introduced in #228 where pre-release commits and PRs always targeted `workspace.branch` (typically `main`) instead of the current branch.

When running `ferrflow release --channel beta` on `develop`, the release commit was pushed to `main` and the release PR targeted `main` as base. Now it correctly targets the current branch (`develop`).

### Changes

- Added `target_branch` variable: uses current branch for pre-releases, `workspace.branch` for stable releases
- Updated `ReleaseCommitMode::Commit` push to use `target_branch`
- Updated `ReleaseCommitMode::Pr` merge request base to use `target_branch`

## Test plan

- [x] 711 tests passing, clippy clean
- [ ] Manual: `ferrflow release --channel beta` on a non-main branch targets that branch