### PR TITLE
fix(monorepo): replace .unwrap() with proper error handling in package lookup

### DIFF
--- a/src/monorepo.rs
+++ b/src/monorepo.rs
@@ -625,7 +625,7 @@ fn run_release_logic(
                     .packages
                     .iter()
                     .find(|p| &p.name == pkg_name)
-                    .unwrap();
+                    .ok_or_else(|| anyhow::anyhow!("package '{pkg_name}' not found in config"))?;
                 let levels = pkg.effective_floating_tags(&config.workspace);
                 for level in levels {
                     if let Some(truncated) = truncate_version(new_version, *level) {


### PR DESCRIPTION
## Summary
- Replace `.unwrap()` with `.ok_or_else()` in `src/monorepo.rs` for the package lookup in the floating tags loop
- Now returns a descriptive error instead of panicking if a package name from `tags_to_create` is not found in config

Closes #230