### PR TITLE
fix(telemetry): send package_name and package_version in release events

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -817,7 +817,7 @@ pub fn init(format: Option<ConfigFileFormat>) -> Result<()> {
     println!("Run: ferrflow check");
 
     if config.workspace.anonymous_telemetry {
-        telemetry::send_event(telemetry::EventType::Init, None, None);
+        telemetry::send_event(telemetry::EventType::Init, None, None, None, None);
     }
 
     Ok(())

--- a/src/monorepo.rs
+++ b/src/monorepo.rs
@@ -75,7 +75,7 @@ pub fn check(
     let result = run_release_logic(&root, &config, true, verbose, json, false, channel);
 
     if config.workspace.anonymous_telemetry {
-        telemetry::send_event(telemetry::EventType::Check, None, None);
+        telemetry::send_event(telemetry::EventType::Check, None, None, None, None);
     }
 
     result
@@ -499,6 +499,8 @@ fn run_release_logic(
                 telemetry::EventType::VersionBump,
                 None,
                 Some(commits.len() as i32),
+                None,
+                None,
             );
         }
 
@@ -788,8 +790,14 @@ fn run_release_logic(
         }
 
         if config.workspace.anonymous_telemetry {
-            for (_, _, _, _, _, commit_count, _) in &tags_to_create {
-                telemetry::send_event(telemetry::EventType::Release, None, Some(*commit_count));
+            for (_, _, _, pkg_name, version, commit_count, _) in &tags_to_create {
+                telemetry::send_event(
+                    telemetry::EventType::Release,
+                    None,
+                    Some(*commit_count),
+                    Some(pkg_name.clone()),
+                    Some(version.clone()),
+                );
             }
         }
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -30,6 +30,10 @@ pub enum EventType {
 struct EventPayload {
     event_type: EventType,
     #[serde(skip_serializing_if = "Option::is_none")]
+    package_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    package_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     metadata: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     repo_hash: Option<String>,
@@ -110,6 +114,8 @@ pub fn send_event(
     event_type: EventType,
     metadata: Option<serde_json::Value>,
     commits_count: Option<i32>,
+    package_name: Option<String>,
+    package_version: Option<String>,
 ) {
     if !is_enabled() {
         return;
@@ -117,6 +123,8 @@ pub fn send_event(
 
     let payload = EventPayload {
         event_type,
+        package_name,
+        package_version,
         metadata,
         repo_hash: get_repo_hash(),
         commits_count,
@@ -213,11 +221,15 @@ mod tests {
     fn payload_skips_none_fields() {
         let payload = EventPayload {
             event_type: EventType::Check,
+            package_name: None,
+            package_version: None,
             metadata: None,
             repo_hash: None,
             commits_count: None,
         };
         let json = serde_json::to_value(&payload).unwrap();
+        assert!(!json.as_object().unwrap().contains_key("package_name"));
+        assert!(!json.as_object().unwrap().contains_key("package_version"));
         assert!(!json.as_object().unwrap().contains_key("metadata"));
         assert!(!json.as_object().unwrap().contains_key("repo_hash"));
         assert!(!json.as_object().unwrap().contains_key("commits_count"));
@@ -227,12 +239,16 @@ mod tests {
     fn payload_includes_present_fields() {
         let payload = EventPayload {
             event_type: EventType::Release,
+            package_name: Some("my-pkg".into()),
+            package_version: Some("1.2.3".into()),
             metadata: None,
             repo_hash: Some("abc123".into()),
             commits_count: Some(42),
         };
         let json = serde_json::to_value(&payload).unwrap();
         assert_eq!(json["event_type"], "release");
+        assert_eq!(json["package_name"], "my-pkg");
+        assert_eq!(json["package_version"], "1.2.3");
         assert_eq!(json["repo_hash"], "abc123");
         assert_eq!(json["commits_count"], 42);
     }


### PR DESCRIPTION
## Summary
- Add `package_name` and `package_version` fields to the telemetry `EventPayload`
- Populate them when sending release events from `monorepo.rs`
- Other event types (check, init, version_bump) send `None` for these fields

The API already accepts these fields but they were never sent, resulting in `NULL` values in the database. The landing page stats query counts `DISTINCT (package_name, package_version)`, which undercounts releases when these are all `NULL`.

Closes #251

## Test plan
- [ ] All 345 unit tests pass
- [ ] Verify release events include package_name and package_version in the JSON payload
- [ ] Confirm stats endpoint returns accurate release count after deploying