### PR TITLE
ci: merge release pipeline into CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
         description: 'Tag to build (e.g. v0.6.0)'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build ${{ matrix.target }}


### PR DESCRIPTION
## Summary
- Move build matrix (5 targets), asset upload, and all publish jobs from `release.yml` into `ci.yml`
- Release assets are now available immediately after the release is created, no more waiting for a second workflow
- `release.yml` is kept as manual-only (`workflow_dispatch`) for rebuilding assets on a specific tag
- The release job outputs the tag name, downstream jobs are conditionally triggered via `needs.release.outputs.released`

Closes #218

## Flow

```
test ─┬─ benchmark ─┬─ release ─── build (5 targets) ─── upload ─┬─ publish-crate
      │              │                                             ├─ publish-npm
      │              │                                             ├─ publish-wasm
      │              │                                             └─ publish-docker
coverage             │
micro-bench ─────────┘
```

## Test plan
- [ ] Push to main with no version bump: release job runs, detects no tag, build/publish jobs are skipped
- [ ] Push to main with a bump: full pipeline runs, assets are in the release before publish jobs start
- [ ] Manual `workflow_dispatch` on release.yml still works for rebuilding assets