### PR TITLE
feat: draft release support for GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         env:
           FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
       - name: Run ferrflow release
-        run: ./target/release/ferrflow ${{ inputs.dry_run == 'true' && '--dry-run' || '' }} release
+        run: ./target/release/ferrflow ${{ inputs.dry_run == 'true' && '--dry-run' || '' }} release --draft
         env:
           FERRFLOW_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}
@@ -239,11 +239,14 @@ jobs:
         uses: actions/attest-build-provenance@v4
         with:
           subject-path: artifacts/*
-      - uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ needs.release.outputs.tag }}
-          files: artifacts/*
-          generate_release_notes: false
+      - name: Upload assets to draft release
+        run: |
+          TAG="${{ needs.release.outputs.tag }}"
+          for file in artifacts/*; do
+            gh release upload "$TAG" "$file" --clobber
+          done
+        env:
+          GH_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}
       - name: Append benchmark results to release
         if: needs.benchmark.result == 'success'
         run: |
@@ -257,6 +260,10 @@ jobs:
           BENCH=$(cat "$BENCH_FILE")
           printf -v NEW_BODY '%s\n\n%s' "$CURRENT_BODY" "$BENCH"
           gh release edit "$TAG" --notes "$NEW_BODY"
+        env:
+          GH_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}
+      - name: Publish draft release
+        run: gh release edit "${{ needs.release.outputs.tag }}" --draft=false
         env:
           GH_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,6 +47,10 @@ pub enum Commands {
         /// Pre-release channel override (e.g. beta, rc, dev)
         #[arg(long)]
         channel: Option<String>,
+        /// Create releases as drafts (GitHub only). A subsequent `ferrflow release`
+        /// without --draft will detect and publish existing drafts automatically.
+        #[arg(long)]
+        draft: bool,
     },
     /// Generate/update CHANGELOG.md only
     Changelog,
@@ -106,12 +110,17 @@ impl Cli {
                 json,
                 channel.as_deref(),
             ),
-            Commands::Release { force, channel } => crate::monorepo::release(
+            Commands::Release {
+                force,
+                channel,
+                draft,
+            } => crate::monorepo::release(
                 self.config.as_deref(),
                 self.dry_run,
                 self.verbose,
                 force,
                 channel.as_deref(),
+                draft,
             ),
             Commands::Changelog => {
                 crate::changelog::generate_only(self.config.as_deref(), self.dry_run)

--- a/src/forge/github.rs
+++ b/src/forge/github.rs
@@ -8,14 +8,14 @@ pub struct GitHubForge {
 }
 
 impl Forge for GitHubForge {
-    fn create_release(&self, tag: &str, body: &str, prerelease: bool) -> Result<()> {
+    fn create_release(&self, tag: &str, body: &str, prerelease: bool, draft: bool) -> Result<()> {
         let url = format!("https://api.github.com/repos/{}/releases", self.slug);
 
         let payload = serde_json::json!({
             "tag_name": tag,
             "name": tag,
             "body": body,
-            "draft": false,
+            "draft": draft,
             "prerelease": prerelease,
         });
 
@@ -26,6 +26,55 @@ impl Forge for GitHubForge {
             .header("User-Agent", "ferrflow")
             .send_json(payload)
             .with_context(|| format!("Failed to create GitHub release for {tag}"))?;
+
+        Ok(())
+    }
+
+    fn find_draft_release(&self, tag: &str) -> Result<Option<u64>> {
+        let url = format!("https://api.github.com/repos/{}/releases", self.slug);
+
+        let response: serde_json::Value = ureq::get(&url)
+            .header("Authorization", &format!("Bearer {}", self.token))
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .header("User-Agent", "ferrflow")
+            .call()
+            .with_context(|| "Failed to list GitHub releases")?
+            .body_mut()
+            .read_json()
+            .with_context(|| "Failed to parse releases response")?;
+
+        let empty = vec![];
+        let releases = response.as_array().unwrap_or(&empty);
+        for release in releases {
+            if release["draft"].as_bool() == Some(true)
+                && release["tag_name"].as_str() == Some(tag)
+                && let Some(id) = release["id"].as_u64()
+            {
+                return Ok(Some(id));
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn publish_release(&self, release_id: u64) -> Result<()> {
+        let url = format!(
+            "https://api.github.com/repos/{}/releases/{release_id}",
+            self.slug
+        );
+
+        let payload = serde_json::json!({
+            "draft": false,
+        });
+
+        ureq::patch(&url)
+            .header("Authorization", &format!("Bearer {}", self.token))
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .header("User-Agent", "ferrflow")
+            .send_json(payload)
+            .with_context(|| format!("Failed to publish GitHub release {release_id}"))?;
 
         Ok(())
     }

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use colored::Colorize;
 
 use super::{Forge, MergeRequestResult};
 
@@ -14,7 +15,14 @@ impl GitLabForge {
 }
 
 impl Forge for GitLabForge {
-    fn create_release(&self, tag: &str, body: &str, prerelease: bool) -> Result<()> {
+    fn create_release(&self, tag: &str, body: &str, prerelease: bool, draft: bool) -> Result<()> {
+        if draft {
+            eprintln!(
+                "{}",
+                "Warning: GitLab does not support draft releases, creating as published".yellow()
+            );
+        }
+
         let project = self.encoded_project_id();
         let url = format!("https://gitlab.com/api/v4/projects/{project}/releases");
 
@@ -33,6 +41,14 @@ impl Forge for GitLabForge {
             .send_json(payload)
             .with_context(|| format!("Failed to create GitLab release for {tag}"))?;
 
+        Ok(())
+    }
+
+    fn find_draft_release(&self, _tag: &str) -> Result<Option<u64>> {
+        Ok(None)
+    }
+
+    fn publish_release(&self, _release_id: u64) -> Result<()> {
         Ok(())
     }
 

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -11,7 +11,9 @@ pub struct MergeRequestResult {
 }
 
 pub trait Forge {
-    fn create_release(&self, tag: &str, body: &str, prerelease: bool) -> Result<()>;
+    fn create_release(&self, tag: &str, body: &str, prerelease: bool, draft: bool) -> Result<()>;
+    fn find_draft_release(&self, tag: &str) -> Result<Option<u64>>;
+    fn publish_release(&self, release_id: u64) -> Result<()>;
     fn create_merge_request(
         &self,
         head: &str,

--- a/src/monorepo.rs
+++ b/src/monorepo.rs
@@ -72,7 +72,7 @@ pub fn check(
         println!();
     }
 
-    let result = run_release_logic(&root, &config, true, verbose, json, false, channel);
+    let result = run_release_logic(&root, &config, true, verbose, json, false, channel, false);
 
     if config.workspace.anonymous_telemetry {
         telemetry::send_event(telemetry::EventType::Check, None, None, None, None);
@@ -87,6 +87,7 @@ pub fn release(
     verbose: bool,
     force: bool,
     channel: Option<&str>,
+    draft: bool,
 ) -> Result<()> {
     let repo = open_repo(&std::env::current_dir()?)?;
     let root = get_repo_root(&repo)?;
@@ -99,9 +100,12 @@ pub fn release(
     }
     println!();
 
-    run_release_logic(&root, &config, dry_run, verbose, false, force, channel)
+    run_release_logic(
+        &root, &config, dry_run, verbose, false, force, channel, draft,
+    )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_release_logic(
     root: &Path,
     config: &Config,
@@ -110,6 +114,7 @@ fn run_release_logic(
     json: bool,
     force: bool,
     channel: Option<&str>,
+    draft: bool,
 ) -> Result<()> {
     if config.packages.is_empty() {
         if json {
@@ -749,16 +754,60 @@ fn run_release_logic(
 
             if let Some(forge_instance) = build_forge_instance(&repo, config) {
                 for (tag_name, _, body, pkg_name, _, _, is_pre) in &tags_to_create {
-                    match forge_instance.create_release(tag_name, body, *is_pre) {
+                    if !draft {
+                        // Check for existing draft release and publish it
+                        match forge_instance.find_draft_release(tag_name) {
+                            Ok(Some(release_id)) => {
+                                match forge_instance.publish_release(release_id) {
+                                    Ok(()) => {
+                                        if let Some((_, lines)) = pkg_outputs
+                                            .iter_mut()
+                                            .rev()
+                                            .find(|(n, _)| n == pkg_name)
+                                        {
+                                            lines.push(format!(
+                                                "  ✓ Published draft {} {}",
+                                                forge_instance.release_noun(),
+                                                tag_name.cyan()
+                                            ));
+                                        }
+                                        continue;
+                                    }
+                                    Err(err) => eprintln!(
+                                        "{}",
+                                        format!(
+                                            "  Warning: failed to publish draft for {tag_name}: {err}"
+                                        )
+                                        .yellow()
+                                    ),
+                                }
+                            }
+                            Ok(None) => {}
+                            Err(err) => {
+                                if verbose {
+                                    eprintln!(
+                                        "{}",
+                                        format!(
+                                            "  Warning: failed to check for draft release {tag_name}: {err}"
+                                        )
+                                        .yellow()
+                                    );
+                                }
+                            }
+                        }
+                    }
+
+                    match forge_instance.create_release(tag_name, body, *is_pre, draft) {
                         Ok(()) => {
                             if let Some((_, lines)) =
                                 pkg_outputs.iter_mut().rev().find(|(n, _)| n == pkg_name)
                             {
-                                lines.push(format!(
-                                    "  ✓ {} {}",
-                                    forge_instance.release_noun(),
-                                    tag_name.cyan()
-                                ));
+                                let noun = forge_instance.release_noun();
+                                if draft {
+                                    lines.push(format!("  ✓ Draft {} {}", noun, tag_name.cyan()));
+                                } else {
+                                    lines.push(format!("  ✓ {} {}", noun, tag_name.cyan()));
+                                }
                             }
                         }
                         Err(err) => eprintln!(


### PR DESCRIPTION
## Summary
- Add `--draft` flag to `ferrflow release` to create GitHub releases as drafts
- When running `ferrflow release` without `--draft`, automatically detect and publish existing draft releases
- GitLab: logs a warning and creates normally (no draft API support)
- Update CI workflow to use draft → build → upload → publish flow

### New CLI usage

```
ferrflow release --draft     # create as draft
ferrflow release             # if draft exists → publish it, otherwise normal release
```

### CI flow

```
release (ferrflow release --draft) → build (5 targets) → upload assets → publish (--draft=false)
```

The release is never visible without its assets attached.

Closes #259
Relates to #218

## Test plan
- [ ] `ferrflow release --draft` creates a draft release on GitHub
- [ ] `ferrflow release` detects and publishes an existing draft
- [ ] `ferrflow release` without prior draft behaves normally (current behavior)
- [ ] GitLab: `--draft` logs a warning, release is created as published
- [ ] CI: assets are uploaded before the release becomes visible
- [ ] 345 unit tests pass