### PR TITLE
fix(npm): set license to MIT and include README in published packages

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -11,7 +11,7 @@
     "changelog",
     "release"
   ],
-  "license": "MPL-2.0",
+  "license": "MIT",
   "name": "ferrflow",
   "optionalDependencies": {
     "@ferrflow/darwin-arm64": "2.15.1",

--- a/npm/platforms/darwin-arm64/package.json
+++ b/npm/platforms/darwin-arm64/package.json
@@ -3,7 +3,7 @@
     "arm64"
   ],
   "description": "FerrFlow macOS arm64 binary",
-  "license": "MPL-2.0",
+  "license": "MIT",
   "name": "@ferrflow/darwin-arm64",
   "os": [
     "darwin"

--- a/npm/platforms/darwin-x64/package.json
+++ b/npm/platforms/darwin-x64/package.json
@@ -3,7 +3,7 @@
     "x64"
   ],
   "description": "FerrFlow macOS x64 binary",
-  "license": "MPL-2.0",
+  "license": "MIT",
   "name": "@ferrflow/darwin-x64",
   "os": [
     "darwin"

--- a/npm/platforms/linux-arm64/package.json
+++ b/npm/platforms/linux-arm64/package.json
@@ -3,7 +3,7 @@
     "arm64"
   ],
   "description": "FerrFlow Linux arm64 binary",
-  "license": "MPL-2.0",
+  "license": "MIT",
   "name": "@ferrflow/linux-arm64",
   "os": [
     "linux"

--- a/npm/platforms/linux-x64/package.json
+++ b/npm/platforms/linux-x64/package.json
@@ -3,7 +3,7 @@
     "x64"
   ],
   "description": "FerrFlow Linux x64 binary",
-  "license": "MPL-2.0",
+  "license": "MIT",
   "name": "@ferrflow/linux-x64",
   "os": [
     "linux"

--- a/npm/platforms/win32-x64/package.json
+++ b/npm/platforms/win32-x64/package.json
@@ -3,7 +3,7 @@
     "x64"
   ],
   "description": "FerrFlow Windows x64 binary",
-  "license": "MPL-2.0",
+  "license": "MIT",
   "name": "@ferrflow/win32-x64",
   "os": [
     "win32"

--- a/npm/scripts/publish.sh
+++ b/npm/scripts/publish.sh
@@ -35,8 +35,10 @@ for archive in "${!ARCHIVES[@]}"; do
     tar xzf "${WORK_DIR}/${archive}" -C "${pkg_dir}/bin/"
   fi
 
-  # Copy and patch package.json
+  # Copy package.json, README, and LICENSE
   cp "${NPM_DIR}/platforms/${platform}/package.json" "${pkg_dir}/package.json"
+  cp "${NPM_DIR}/../README.md" "${pkg_dir}/README.md"
+  cp "${NPM_DIR}/../LICENSE" "${pkg_dir}/LICENSE" 2>/dev/null || true
   cd "$pkg_dir"
   npm version "$VERSION" --no-git-tag-version --allow-same-version
   npm publish --access public
@@ -45,6 +47,8 @@ done
 
 # Publish main wrapper
 echo "Publishing main package ferrflow@${VERSION}..."
+cp "${NPM_DIR}/../README.md" "${NPM_DIR}/README.md"
+cp "${NPM_DIR}/../LICENSE" "${NPM_DIR}/LICENSE" 2>/dev/null || true
 cd "$NPM_DIR"
 
 # Update version and optionalDependencies versions


### PR DESCRIPTION
## Summary
- Change license from MPL-2.0 to MIT in all npm package.json files (wrapper + 5 platform packages)
- Publish script now copies README.md and LICENSE into each package before `npm publish`
- Applies to both platform packages and the main wrapper

Closes #277