### PR TITLE
fix(ci): filter floating tags from publish and dedupe benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,9 @@ jobs:
           fi
           CURRENT_BODY=$(gh release view "$TAG" --json body --jq '.body' 2>/dev/null || echo "")
           BENCH=$(cat "$BENCH_FILE")
-          printf -v NEW_BODY '%s\n\n%s' "$CURRENT_BODY" "$BENCH"
+          # Remove existing Performance section to avoid duplicates
+          CLEAN_BODY=$(echo "$CURRENT_BODY" | sed '/^## Performance$/,$d')
+          printf -v NEW_BODY '%s\n\n%s' "$CLEAN_BODY" "$BENCH"
           gh release edit "$TAG" --notes "$NEW_BODY"
         env:
           GH_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   push:
-    tags: ['v*']
+    tags: ['v[0-9]+.[0-9]+.[0-9]+*']
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Publish workflow now only triggers on semver tags (`v1.2.3`), not floating tags (`v2`)
- Benchmark Performance section is deduplicated when appended to release notes

## Test plan
- Verify pushing floating tag `v2` no longer triggers publish workflow
- Verify release draft has only one Performance section