### PR TITLE
fix: publish orphaned draft releases and enable skipCi

### DIFF
--- a/.ferrflow
+++ b/.ferrflow
@@ -3,7 +3,7 @@
   "workspace": {
     "tagTemplate": "v{version}",
     "floatingTags": ["major"],
-    "skipCi": false,
+    "skipCi": true,
     "hooks": {
       "postBump": "node scripts/sync-optional-deps.js"
     }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "2.14.3"
+version = "2.15.1"
 dependencies = [
  "anyhow",
  "cargo-husky",

--- a/src/monorepo.rs
+++ b/src/monorepo.rs
@@ -820,6 +820,54 @@ fn run_release_logic(
                         ),
                     }
                 }
+
+                // Publish orphaned draft releases when no new tags were created.
+                // This handles the case where `ferrflow release` runs after the
+                // tag and release commit already exist (e.g. in a publish workflow).
+                if !draft && !dry_run && tags_to_create.is_empty() {
+                    for pkg in &config.packages {
+                        let Some(vf) = pkg.versioned_files.first() else {
+                            continue;
+                        };
+                        let Ok(version) = read_version(vf, root) else {
+                            continue;
+                        };
+                        let tag =
+                            pkg.tag_for_version(&config.workspace, config.is_monorepo(), &version);
+                        match forge_instance.find_draft_release(&tag) {
+                            Ok(Some(release_id)) => {
+                                match forge_instance.publish_release(release_id) {
+                                    Ok(()) => {
+                                        shared_outputs.push(format!(
+                                            "✓ Published draft {} {}",
+                                            forge_instance.release_noun(),
+                                            tag.cyan()
+                                        ));
+                                    }
+                                    Err(err) => eprintln!(
+                                        "{}",
+                                        format!(
+                                            "  Warning: failed to publish draft for {tag}: {err}"
+                                        )
+                                        .yellow()
+                                    ),
+                                }
+                            }
+                            Ok(None) => {}
+                            Err(err) => {
+                                if verbose {
+                                    eprintln!(
+                                        "{}",
+                                        format!(
+                                            "  Warning: failed to check draft release {tag}: {err}"
+                                        )
+                                        .yellow()
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
             }
 
             if let Ok(summary_path) = std::env::var("GITHUB_STEP_SUMMARY") {


### PR DESCRIPTION
## Summary
- Fix draft releases never being published when `ferrflow release` runs after the tag already exists (e.g. in publish workflows)
- Enable `skipCi: true` to prevent CI from re-triggering on release commits

Closes #281