### PR TITLE
fix(ci): skip CI on release commits instead of using skipCi

### DIFF
--- a/.ferrflow
+++ b/.ferrflow
@@ -3,7 +3,7 @@
   "workspace": {
     "tagTemplate": "v{version}",
     "floatingTags": ["major"],
-    "skipCi": true,
+    "skipCi": false,
     "hooks": {
       "postBump": "node scripts/sync-optional-deps.js"
     }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   test:
     name: Test
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -38,6 +39,7 @@ jobs:
 
   coverage:
     name: Coverage
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Revert `skipCi` to `false` because `[skip ci]` in the commit message also prevents the tag-triggered publish workflow from running
- Add `if` conditions on `test` and `coverage` jobs to skip when the commit message starts with `chore(release):`
- The `release` job already depends on `test` succeeding, so it's transitively skipped too

Closes #281