### PR TITLE
fix(ci): use release event trigger for publish workflow

### DIFF
--- a/.ferrflow
+++ b/.ferrflow
@@ -3,7 +3,7 @@
   "workspace": {
     "tagTemplate": "v{version}",
     "floatingTags": ["major"],
-    "skipCi": false,
+    "skipCi": true,
     "hooks": {
       "postBump": "node scripts/sync-optional-deps.js"
     }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ permissions:
 jobs:
   test:
     name: Test
-    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -39,7 +38,6 @@ jobs:
 
   coverage:
     name: Coverage
-    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Publish
 
 on:
-  push:
-    tags: ['v[0-9]+.[0-9]+.[0-9]+*']
+  release:
+    types: [created]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Switch `publish.yml` from `on: push: tags` to `on: release: types: [created]`
- The `created` event fires on draft releases, so `ferrflow release --draft` in CI triggers the publish workflow
- `[skip ci]` only affects push events, not release events — no more conflict between skipCi and publishing
- Revert the CI commit-message filter from #283 (no longer needed)
- Re-enable `skipCi: true` to prevent redundant CI runs on release commits

Closes #281