### PR TITLE
fix(ci): add comment to publish trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   release:
-    types: [created]
+    types: [created] # fires on draft releases too
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Document that the release created event fires on draft releases
- Triggers a clean CI run on main after merge