### PR TITLE
fix(ci): revert to tag push trigger with CI filter for release commits

### DIFF
--- a/.ferrflow
+++ b/.ferrflow
@@ -3,7 +3,7 @@
   "workspace": {
     "tagTemplate": "v{version}",
     "floatingTags": ["major"],
-    "skipCi": true,
+    "skipCi": false,
     "hooks": {
       "postBump": "node scripts/sync-optional-deps.js"
     }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   test:
     name: Test
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -38,6 +39,7 @@ jobs:
 
   coverage:
     name: Coverage
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Publish
 
 on:
-  release:
-    types: [created] # fires on draft releases too
+  push:
+    tags: ['v[0-9]+.[0-9]+.[0-9]+*']
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Revert publish.yml from `on: release: types: [created]` back to `on: push: tags` because GitHub does not fire `created` events for draft releases
- Re-add CI filter (`if` condition) on `test` and `coverage` jobs to skip `chore(release):` commits, preventing redundant CI runs
- Set `skipCi: false` so release commits don't contain `[skip ci]` (which would also block the tag-triggered publish workflow)

Closes #281