### PR TITLE
test: add tests for cli, status, query, and forge modules

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -155,3 +155,237 @@ impl Cli {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    fn parse(args: &[&str]) -> Cli {
+        Cli::try_parse_from(args).unwrap()
+    }
+
+    #[test]
+    fn parse_check() {
+        let cli = parse(&["ferrflow", "check"]);
+        assert!(matches!(
+            cli.command,
+            Commands::Check {
+                json: false,
+                channel: None
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_check_json() {
+        let cli = parse(&["ferrflow", "check", "--json"]);
+        assert!(matches!(cli.command, Commands::Check { json: true, .. }));
+    }
+
+    #[test]
+    fn parse_check_channel() {
+        let cli = parse(&["ferrflow", "check", "--channel", "beta"]);
+        match cli.command {
+            Commands::Check { channel, .. } => assert_eq!(channel.as_deref(), Some("beta")),
+            _ => panic!("expected Check"),
+        }
+    }
+
+    #[test]
+    fn parse_release() {
+        let cli = parse(&["ferrflow", "release"]);
+        assert!(matches!(
+            cli.command,
+            Commands::Release {
+                force: false,
+                channel: None,
+                draft: false
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_release_force_draft_channel() {
+        let cli = parse(&[
+            "ferrflow",
+            "release",
+            "--force",
+            "--draft",
+            "--channel",
+            "rc",
+        ]);
+        match cli.command {
+            Commands::Release {
+                force,
+                channel,
+                draft,
+            } => {
+                assert!(force);
+                assert!(draft);
+                assert_eq!(channel.as_deref(), Some("rc"));
+            }
+            _ => panic!("expected Release"),
+        }
+    }
+
+    #[test]
+    fn parse_init_no_format() {
+        let cli = parse(&["ferrflow", "init"]);
+        assert!(matches!(cli.command, Commands::Init { format: None }));
+    }
+
+    #[test]
+    fn parse_init_with_format() {
+        let cli = parse(&["ferrflow", "init", "--format", "toml"]);
+        match cli.command {
+            Commands::Init { format } => assert!(format.is_some()),
+            _ => panic!("expected Init"),
+        }
+    }
+
+    #[test]
+    fn parse_status_default() {
+        let cli = parse(&["ferrflow", "status"]);
+        assert!(matches!(cli.command, Commands::Status { .. }));
+    }
+
+    #[test]
+    fn parse_status_json() {
+        let cli = parse(&["ferrflow", "status", "--output", "json"]);
+        match cli.command {
+            Commands::Status { output } => assert!(matches!(output, OutputFormat::Json)),
+            _ => panic!("expected Status"),
+        }
+    }
+
+    #[test]
+    fn parse_version_no_package() {
+        let cli = parse(&["ferrflow", "version"]);
+        assert!(matches!(
+            cli.command,
+            Commands::Version {
+                package: None,
+                json: false
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_version_with_package_json() {
+        let cli = parse(&["ferrflow", "version", "my-pkg", "--json"]);
+        match cli.command {
+            Commands::Version { package, json } => {
+                assert_eq!(package.as_deref(), Some("my-pkg"));
+                assert!(json);
+            }
+            _ => panic!("expected Version"),
+        }
+    }
+
+    #[test]
+    fn parse_tag_no_package() {
+        let cli = parse(&["ferrflow", "tag"]);
+        assert!(matches!(
+            cli.command,
+            Commands::Tag {
+                package: None,
+                json: false
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_tag_with_package() {
+        let cli = parse(&["ferrflow", "tag", "core"]);
+        match cli.command {
+            Commands::Tag { package, .. } => assert_eq!(package.as_deref(), Some("core")),
+            _ => panic!("expected Tag"),
+        }
+    }
+
+    #[test]
+    fn parse_validate() {
+        let cli = parse(&["ferrflow", "validate"]);
+        assert!(matches!(
+            cli.command,
+            Commands::Validate {
+                json: false,
+                repo: None,
+                git_ref: None
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_validate_remote() {
+        let cli = parse(&[
+            "ferrflow",
+            "validate",
+            "--json",
+            "--repo",
+            "owner/repo",
+            "--git-ref",
+            "main",
+        ]);
+        match cli.command {
+            Commands::Validate {
+                json,
+                repo,
+                git_ref,
+            } => {
+                assert!(json);
+                assert_eq!(repo.as_deref(), Some("owner/repo"));
+                assert_eq!(git_ref.as_deref(), Some("main"));
+            }
+            _ => panic!("expected Validate"),
+        }
+    }
+
+    #[test]
+    fn parse_completions() {
+        let cli = parse(&["ferrflow", "completions", "bash"]);
+        assert!(matches!(cli.command, Commands::Completions { .. }));
+    }
+
+    #[test]
+    fn parse_changelog() {
+        let cli = parse(&["ferrflow", "changelog"]);
+        assert!(matches!(cli.command, Commands::Changelog));
+    }
+
+    #[test]
+    fn global_dry_run() {
+        let cli = parse(&["ferrflow", "--dry-run", "check"]);
+        assert!(cli.dry_run);
+    }
+
+    #[test]
+    fn global_verbose() {
+        let cli = parse(&["ferrflow", "-v", "check"]);
+        assert!(cli.verbose);
+    }
+
+    #[test]
+    fn global_config_path() {
+        let cli = parse(&["ferrflow", "--config", "/tmp/ferrflow.json", "check"]);
+        assert_eq!(cli.config, Some(PathBuf::from("/tmp/ferrflow.json")));
+    }
+
+    #[test]
+    fn global_flags_after_subcommand() {
+        let cli = parse(&["ferrflow", "release", "--dry-run", "--verbose"]);
+        assert!(cli.dry_run);
+        assert!(cli.verbose);
+    }
+
+    #[test]
+    fn unknown_subcommand_fails() {
+        assert!(Cli::try_parse_from(["ferrflow", "unknown"]).is_err());
+    }
+
+    #[test]
+    fn missing_subcommand_fails() {
+        assert!(Cli::try_parse_from(["ferrflow"]).is_err());
+    }
+}

--- a/src/forge/github.rs
+++ b/src/forge/github.rs
@@ -154,3 +154,182 @@ impl Forge for GitHubForge {
         "GitHub Release"
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_forge() -> GitHubForge {
+        GitHubForge {
+            token: "test-token".to_string(),
+            slug: "owner/repo".to_string(),
+        }
+    }
+
+    #[test]
+    fn mr_noun_returns_pr() {
+        assert_eq!(make_forge().mr_noun(), "PR");
+    }
+
+    #[test]
+    fn release_noun_returns_github_release() {
+        assert_eq!(make_forge().release_noun(), "GitHub Release");
+    }
+
+    #[test]
+    fn struct_fields_accessible() {
+        let forge = make_forge();
+        assert_eq!(forge.token, "test-token");
+        assert_eq!(forge.slug, "owner/repo");
+    }
+
+    #[test]
+    fn find_draft_release_parses_empty_array() {
+        // Simulate parsing logic used in find_draft_release
+        let response: serde_json::Value = serde_json::json!([]);
+        let releases = response.as_array().unwrap();
+        let found = releases.iter().find(|r| {
+            r["draft"].as_bool() == Some(true) && r["tag_name"].as_str() == Some("v1.0.0")
+        });
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn find_draft_release_parses_draft() {
+        let response: serde_json::Value = serde_json::json!([
+            {"id": 1, "tag_name": "v1.0.0", "draft": false},
+            {"id": 2, "tag_name": "v1.1.0", "draft": true},
+            {"id": 3, "tag_name": "v1.2.0", "draft": true},
+        ]);
+        let releases = response.as_array().unwrap();
+        let found = releases
+            .iter()
+            .find(|r| {
+                r["draft"].as_bool() == Some(true) && r["tag_name"].as_str() == Some("v1.1.0")
+            })
+            .and_then(|r| r["id"].as_u64());
+        assert_eq!(found, Some(2));
+    }
+
+    #[test]
+    fn find_draft_release_ignores_non_draft() {
+        let response: serde_json::Value = serde_json::json!([
+            {"id": 1, "tag_name": "v1.0.0", "draft": false},
+        ]);
+        let releases = response.as_array().unwrap();
+        let found = releases
+            .iter()
+            .find(|r| {
+                r["draft"].as_bool() == Some(true) && r["tag_name"].as_str() == Some("v1.0.0")
+            })
+            .and_then(|r| r["id"].as_u64());
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn find_draft_release_matches_exact_tag() {
+        let response: serde_json::Value = serde_json::json!([
+            {"id": 10, "tag_name": "v2.0.0", "draft": true},
+            {"id": 20, "tag_name": "v2.0.0-beta.1", "draft": true},
+        ]);
+        let releases = response.as_array().unwrap();
+        let found = releases
+            .iter()
+            .find(|r| {
+                r["draft"].as_bool() == Some(true) && r["tag_name"].as_str() == Some("v2.0.0")
+            })
+            .and_then(|r| r["id"].as_u64());
+        assert_eq!(found, Some(10));
+    }
+
+    #[test]
+    fn create_release_payload_structure() {
+        let payload = serde_json::json!({
+            "tag_name": "v1.0.0",
+            "name": "v1.0.0",
+            "body": "Release notes",
+            "draft": true,
+            "prerelease": false,
+        });
+        assert_eq!(payload["tag_name"], "v1.0.0");
+        assert_eq!(payload["draft"], true);
+        assert_eq!(payload["prerelease"], false);
+        assert_eq!(payload["body"], "Release notes");
+    }
+
+    #[test]
+    fn publish_release_payload_structure() {
+        let payload = serde_json::json!({"draft": false});
+        assert_eq!(payload["draft"], false);
+    }
+
+    #[test]
+    fn create_pr_payload_structure() {
+        let payload = serde_json::json!({
+            "title": "chore(release): v1.0.0",
+            "body": "Release PR",
+            "head": "release/v1.0.0",
+            "base": "main",
+        });
+        assert_eq!(payload["head"], "release/v1.0.0");
+        assert_eq!(payload["base"], "main");
+    }
+
+    #[test]
+    fn auto_merge_graphql_payload() {
+        let query = serde_json::json!({
+            "query": "mutation($prId: ID!) { enablePullRequestAutoMerge(input: { pullRequestId: $prId, mergeMethod: SQUASH }) { pullRequest { number } } }",
+            "variables": { "prId": "PR_abc123" },
+        });
+        assert!(
+            query["query"]
+                .as_str()
+                .unwrap()
+                .contains("enablePullRequestAutoMerge")
+        );
+        assert_eq!(query["variables"]["prId"], "PR_abc123");
+    }
+
+    #[test]
+    fn graphql_error_detection() {
+        let response: serde_json::Value = serde_json::json!({
+            "errors": [{"message": "Some error"}]
+        });
+        let errors = response.get("errors");
+        assert!(errors.is_some());
+        let msg = errors.unwrap()[0]["message"].as_str().unwrap();
+        assert_eq!(msg, "Some error");
+    }
+
+    #[test]
+    fn graphql_no_errors() {
+        let response: serde_json::Value = serde_json::json!({
+            "data": {"enablePullRequestAutoMerge": {"pullRequest": {"number": 42}}}
+        });
+        assert!(response.get("errors").is_none());
+    }
+
+    #[test]
+    fn pr_response_parsing() {
+        let response: serde_json::Value = serde_json::json!({
+            "number": 42,
+            "node_id": "PR_kwDOabc123"
+        });
+        let number = response["number"].as_u64().unwrap();
+        let node_id = response["node_id"].as_str().unwrap();
+        assert_eq!(number, 42);
+        assert_eq!(node_id, "PR_kwDOabc123");
+    }
+
+    #[test]
+    fn pr_response_missing_number() {
+        let response: serde_json::Value = serde_json::json!({"node_id": "PR_abc"});
+        assert!(response["number"].as_u64().is_none());
+    }
+
+    #[test]
+    fn pr_response_missing_node_id() {
+        let response: serde_json::Value = serde_json::json!({"number": 1});
+        assert!(response["node_id"].as_str().is_none());
+    }
+}

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -139,4 +139,70 @@ mod tests {
         };
         assert_eq!(forge.encoded_project_id(), "group%2Fsubgroup%2Frepo");
     }
+
+    #[test]
+    fn mr_noun_returns_mr() {
+        let forge = GitLabForge {
+            token: String::new(),
+            slug: "owner/repo".to_string(),
+        };
+        assert_eq!(forge.mr_noun(), "MR");
+    }
+
+    #[test]
+    fn release_noun_returns_gitlab_release() {
+        let forge = GitLabForge {
+            token: String::new(),
+            slug: "owner/repo".to_string(),
+        };
+        assert_eq!(forge.release_noun(), "GitLab Release");
+    }
+
+    #[test]
+    fn find_draft_release_always_none() {
+        let forge = GitLabForge {
+            token: String::new(),
+            slug: "owner/repo".to_string(),
+        };
+        assert_eq!(forge.find_draft_release("v1.0.0").unwrap(), None);
+    }
+
+    #[test]
+    fn publish_release_noop() {
+        let forge = GitLabForge {
+            token: String::new(),
+            slug: "owner/repo".to_string(),
+        };
+        assert!(forge.publish_release(123).is_ok());
+    }
+
+    #[test]
+    fn create_release_payload_structure() {
+        let mut payload = serde_json::json!({
+            "tag_name": "v1.0.0",
+            "name": "v1.0.0",
+            "description": "Release notes",
+        });
+        // prerelease adds upcoming_release
+        payload["upcoming_release"] = serde_json::json!(true);
+        assert_eq!(payload["upcoming_release"], true);
+        assert_eq!(payload["tag_name"], "v1.0.0");
+    }
+
+    #[test]
+    fn mr_response_parsing() {
+        let response: serde_json::Value = serde_json::json!({"iid": 15});
+        let iid = response["iid"].as_u64().unwrap();
+        assert_eq!(iid, 15);
+    }
+
+    #[test]
+    fn auto_merge_payload_structure() {
+        let payload = serde_json::json!({
+            "merge_when_pipeline_succeeds": true,
+            "squash": true,
+        });
+        assert_eq!(payload["merge_when_pipeline_succeeds"], true);
+        assert_eq!(payload["squash"], true);
+    }
 }

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -206,4 +206,99 @@ mod tests {
             "\"gitlab\""
         );
     }
+
+    #[test]
+    fn resolve_token_ferrflow_token_takes_precedence() {
+        unsafe {
+            std::env::set_var("FERRFLOW_TOKEN", "ferrflow-tok");
+            std::env::set_var("GITHUB_TOKEN", "gh-tok");
+        }
+        let result = resolve_token(ForgeKind::Github);
+        unsafe {
+            std::env::remove_var("FERRFLOW_TOKEN");
+            std::env::remove_var("GITHUB_TOKEN");
+        }
+        assert_eq!(result, Some("ferrflow-tok".to_string()));
+    }
+
+    #[test]
+    fn resolve_token_falls_back_to_github_token() {
+        unsafe {
+            std::env::remove_var("FERRFLOW_TOKEN");
+            std::env::set_var("GITHUB_TOKEN", "gh-tok");
+        }
+        let result = resolve_token(ForgeKind::Github);
+        unsafe {
+            std::env::remove_var("GITHUB_TOKEN");
+        }
+        assert_eq!(result, Some("gh-tok".to_string()));
+    }
+
+    #[test]
+    fn resolve_token_falls_back_to_gitlab_token() {
+        unsafe {
+            std::env::remove_var("FERRFLOW_TOKEN");
+            std::env::set_var("GITLAB_TOKEN", "gl-tok");
+        }
+        let result = resolve_token(ForgeKind::Gitlab);
+        unsafe {
+            std::env::remove_var("GITLAB_TOKEN");
+        }
+        assert_eq!(result, Some("gl-tok".to_string()));
+    }
+
+    #[test]
+    fn resolve_token_empty_ferrflow_token_ignored() {
+        unsafe {
+            std::env::set_var("FERRFLOW_TOKEN", "");
+            std::env::set_var("GITHUB_TOKEN", "gh-tok");
+        }
+        let result = resolve_token(ForgeKind::Github);
+        unsafe {
+            std::env::remove_var("FERRFLOW_TOKEN");
+            std::env::remove_var("GITHUB_TOKEN");
+        }
+        assert_eq!(result, Some("gh-tok".to_string()));
+    }
+
+    #[test]
+    fn resolve_token_auto_returns_none() {
+        unsafe {
+            std::env::remove_var("FERRFLOW_TOKEN");
+        }
+        assert_eq!(resolve_token(ForgeKind::Auto), None);
+    }
+
+    #[test]
+    fn build_forge_github() {
+        let forge = build_forge(ForgeKind::Github, "tok".into(), "owner/repo".into());
+        assert_eq!(forge.mr_noun(), "PR");
+        assert_eq!(forge.release_noun(), "GitHub Release");
+    }
+
+    #[test]
+    fn build_forge_gitlab() {
+        let forge = build_forge(ForgeKind::Gitlab, "tok".into(), "owner/repo".into());
+        assert_eq!(forge.mr_noun(), "MR");
+        assert_eq!(forge.release_noun(), "GitLab Release");
+    }
+
+    #[test]
+    #[should_panic(expected = "unreachable")]
+    fn build_forge_auto_panics() {
+        build_forge(ForgeKind::Auto, "tok".into(), "owner/repo".into());
+    }
+
+    #[test]
+    fn slug_no_suffix() {
+        assert_eq!(
+            extract_repo_slug("https://github.com/owner/repo"),
+            Some("owner/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn detect_forge_empty_string() {
+        assert_eq!(detect_forge_from_url(""), None);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,3 +24,23 @@ fn main() -> Result<()> {
     telemetry::flush();
     result
 }
+
+#[cfg(test)]
+mod test_utils {
+    use std::sync::Mutex;
+
+    /// Global lock for tests that change the process-wide working directory.
+    pub static CWD_LOCK: Mutex<()> = Mutex::new(());
+
+    pub fn with_cwd<F: FnOnce() -> anyhow::Result<()>>(
+        dir: &std::path::Path,
+        f: F,
+    ) -> anyhow::Result<()> {
+        let _lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let saved = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir).unwrap();
+        let result = f();
+        std::env::set_current_dir(&saved).unwrap();
+        result
+    }
+}

--- a/src/query.rs
+++ b/src/query.rs
@@ -184,3 +184,226 @@ pub fn tag(config_path: Option<&std::path::Path>, package: Option<&str>, json: b
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::with_cwd;
+    use git2::{Repository, Signature};
+    use std::fs;
+
+    static COMMIT_TIME: std::sync::atomic::AtomicI64 =
+        std::sync::atomic::AtomicI64::new(1_800_000_000);
+
+    fn init_repo() -> (tempfile::TempDir, Repository) {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        let mut config = repo.config().unwrap();
+        config.set_str("user.name", "Test").unwrap();
+        config.set_str("user.email", "test@test.com").unwrap();
+        (dir, repo)
+    }
+
+    fn create_commit(repo: &Repository, dir: &std::path::Path, filename: &str, message: &str) {
+        let file_path = dir.join(filename);
+        fs::write(&file_path, format!("content of {filename}")).unwrap();
+        let mut index = repo.index().unwrap();
+        index.add_path(std::path::Path::new(filename)).unwrap();
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let ts = COMMIT_TIME.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let sig = Signature::new("Test", "test@test.com", &git2::Time::new(ts, 0)).unwrap();
+        let parents: Vec<git2::Commit> = match repo.head() {
+            Ok(head) => vec![head.peel_to_commit().unwrap()],
+            Err(_) => vec![],
+        };
+        let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
+        repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &parent_refs)
+            .unwrap();
+    }
+
+    fn create_tag(repo: &Repository, tag_name: &str) {
+        let head = repo.head().unwrap().peel_to_commit().unwrap();
+        repo.tag_lightweight(tag_name, head.as_object(), false)
+            .unwrap();
+    }
+
+    fn setup_single_package(dir: &std::path::Path) {
+        fs::write(
+            dir.join("Cargo.toml"),
+            "[package]\nname = \"my-app\"\nversion = \"1.2.3\"\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.join(".ferrflow"),
+            r#"{"package": [{"name": "my-app", "path": ".", "versionedFiles": [{"path": "Cargo.toml", "format": "toml"}]}]}"#,
+        )
+        .unwrap();
+    }
+
+    fn setup_monorepo(dir: &std::path::Path) {
+        fs::create_dir_all(dir.join("packages/core")).unwrap();
+        fs::create_dir_all(dir.join("packages/cli")).unwrap();
+        fs::write(
+            dir.join("packages/core/package.json"),
+            r#"{"name": "core", "version": "2.0.0"}"#,
+        )
+        .unwrap();
+        fs::write(
+            dir.join("packages/cli/package.json"),
+            r#"{"name": "cli", "version": "3.1.0"}"#,
+        )
+        .unwrap();
+        fs::write(
+            dir.join(".ferrflow"),
+            r#"{
+                "package": [
+                    {"name": "core", "path": "packages/core", "versionedFiles": [{"path": "packages/core/package.json", "format": "json"}]},
+                    {"name": "cli", "path": "packages/cli", "versionedFiles": [{"path": "packages/cli/package.json", "format": "json"}]}
+                ]
+            }"#,
+        )
+        .unwrap();
+    }
+
+    // -----------------------------------------------------------------------
+    // version()
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn version_single_package() {
+        let (dir, repo) = init_repo();
+        setup_single_package(dir.path());
+        create_commit(&repo, dir.path(), "init.txt", "initial");
+        let config_path = dir.path().join(".ferrflow");
+        with_cwd(dir.path(), || version(Some(&config_path), None, false)).unwrap();
+    }
+
+    #[test]
+    fn version_single_package_json() {
+        let (dir, repo) = init_repo();
+        setup_single_package(dir.path());
+        create_commit(&repo, dir.path(), "init.txt", "initial");
+        let config_path = dir.path().join(".ferrflow");
+        with_cwd(dir.path(), || version(Some(&config_path), None, true)).unwrap();
+    }
+
+    #[test]
+    fn version_specific_package_in_monorepo() {
+        let (dir, repo) = init_repo();
+        setup_monorepo(dir.path());
+        create_commit(&repo, dir.path(), "init.txt", "initial");
+        let config_path = dir.path().join(".ferrflow");
+        with_cwd(dir.path(), || {
+            version(Some(&config_path), Some("core"), false)
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn version_unknown_package_errors() {
+        let (dir, repo) = init_repo();
+        setup_single_package(dir.path());
+        create_commit(&repo, dir.path(), "init.txt", "initial");
+        let config_path = dir.path().join(".ferrflow");
+        let result = with_cwd(dir.path(), || {
+            version(Some(&config_path), Some("nonexistent"), false)
+        });
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not found"));
+    }
+
+    #[test]
+    fn version_monorepo_all_text() {
+        let (dir, repo) = init_repo();
+        setup_monorepo(dir.path());
+        create_commit(&repo, dir.path(), "init.txt", "initial");
+        let config_path = dir.path().join(".ferrflow");
+        with_cwd(dir.path(), || version(Some(&config_path), None, false)).unwrap();
+    }
+
+    #[test]
+    fn version_monorepo_all_json() {
+        let (dir, repo) = init_repo();
+        setup_monorepo(dir.path());
+        create_commit(&repo, dir.path(), "init.txt", "initial");
+        let config_path = dir.path().join(".ferrflow");
+        with_cwd(dir.path(), || version(Some(&config_path), None, true)).unwrap();
+    }
+
+    #[test]
+    fn version_no_packages_errors() {
+        let (dir, repo) = init_repo();
+        fs::write(dir.path().join(".ferrflow"), r#"{"package": []}"#).unwrap();
+        create_commit(&repo, dir.path(), "init.txt", "initial");
+        let config_path = dir.path().join(".ferrflow");
+        let result = with_cwd(dir.path(), || version(Some(&config_path), None, false));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("No packages"));
+    }
+
+    // -----------------------------------------------------------------------
+    // tag()
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn tag_single_package_no_tags() {
+        let (dir, repo) = init_repo();
+        setup_single_package(dir.path());
+        create_commit(&repo, dir.path(), "init.txt", "initial");
+        let config_path = dir.path().join(".ferrflow");
+        with_cwd(dir.path(), || tag(Some(&config_path), None, false)).unwrap();
+    }
+
+    #[test]
+    fn tag_single_package_with_existing_tag() {
+        let (dir, repo) = init_repo();
+        setup_single_package(dir.path());
+        create_commit(&repo, dir.path(), "init.txt", "initial");
+        create_tag(&repo, "v1.2.3");
+        let config_path = dir.path().join(".ferrflow");
+        with_cwd(dir.path(), || tag(Some(&config_path), None, false)).unwrap();
+    }
+
+    #[test]
+    fn tag_json_output() {
+        let (dir, repo) = init_repo();
+        setup_single_package(dir.path());
+        create_commit(&repo, dir.path(), "init.txt", "initial");
+        create_tag(&repo, "v1.2.3");
+        let config_path = dir.path().join(".ferrflow");
+        with_cwd(dir.path(), || tag(Some(&config_path), None, true)).unwrap();
+    }
+
+    #[test]
+    fn tag_unknown_package_errors() {
+        let (dir, repo) = init_repo();
+        setup_single_package(dir.path());
+        create_commit(&repo, dir.path(), "init.txt", "initial");
+        let config_path = dir.path().join(".ferrflow");
+        let result = with_cwd(dir.path(), || {
+            tag(Some(&config_path), Some("nonexistent"), false)
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn tag_monorepo_all_packages() {
+        let (dir, repo) = init_repo();
+        setup_monorepo(dir.path());
+        create_commit(&repo, dir.path(), "init.txt", "initial");
+        let config_path = dir.path().join(".ferrflow");
+        with_cwd(dir.path(), || tag(Some(&config_path), None, false)).unwrap();
+    }
+
+    #[test]
+    fn tag_no_packages_errors() {
+        let (dir, repo) = init_repo();
+        fs::write(dir.path().join(".ferrflow"), r#"{"package": []}"#).unwrap();
+        create_commit(&repo, dir.path(), "init.txt", "initial");
+        let config_path = dir.path().join(".ferrflow");
+        let result = with_cwd(dir.path(), || tag(Some(&config_path), None, false));
+        assert!(result.is_err());
+    }
+}

--- a/src/status.rs
+++ b/src/status.rs
@@ -100,3 +100,120 @@ fn print_json(statuses: &[PackageStatus]) -> Result<()> {
     println!("{}", serde_json::to_string_pretty(&statuses)?);
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::with_cwd;
+    use git2::{Repository, Signature};
+    use std::fs;
+
+    static COMMIT_TIME: std::sync::atomic::AtomicI64 =
+        std::sync::atomic::AtomicI64::new(1_900_000_000);
+
+    fn init_repo() -> (tempfile::TempDir, Repository) {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        let mut config = repo.config().unwrap();
+        config.set_str("user.name", "Test").unwrap();
+        config.set_str("user.email", "test@test.com").unwrap();
+        (dir, repo)
+    }
+
+    fn create_commit(repo: &Repository, dir: &std::path::Path, filename: &str, message: &str) {
+        let file_path = dir.join(filename);
+        fs::write(&file_path, format!("content of {filename}")).unwrap();
+        let mut index = repo.index().unwrap();
+        index.add_path(std::path::Path::new(filename)).unwrap();
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let ts = COMMIT_TIME.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let sig = Signature::new("Test", "test@test.com", &git2::Time::new(ts, 0)).unwrap();
+        let parents: Vec<git2::Commit> = match repo.head() {
+            Ok(head) => vec![head.peel_to_commit().unwrap()],
+            Err(_) => vec![],
+        };
+        let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
+        repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &parent_refs)
+            .unwrap();
+    }
+
+    fn create_tag(repo: &Repository, tag_name: &str) {
+        let head = repo.head().unwrap().peel_to_commit().unwrap();
+        repo.tag_lightweight(tag_name, head.as_object(), false)
+            .unwrap();
+    }
+
+    fn setup_single_package(dir: &std::path::Path) {
+        fs::write(
+            dir.join("Cargo.toml"),
+            "[package]\nname = \"my-app\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.join(".ferrflow"),
+            r#"{"package": [{"name": "my-app", "path": ".", "versionedFiles": [{"path": "Cargo.toml", "format": "toml"}]}]}"#,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn status_text_output() {
+        let (dir, repo) = init_repo();
+        setup_single_package(dir.path());
+        create_commit(&repo, dir.path(), "init.txt", "initial");
+        let config_path = dir.path().join(".ferrflow");
+        with_cwd(dir.path(), || run(Some(&config_path), &OutputFormat::Text)).unwrap();
+    }
+
+    #[test]
+    fn status_json_output() {
+        let (dir, repo) = init_repo();
+        setup_single_package(dir.path());
+        create_commit(&repo, dir.path(), "init.txt", "initial");
+        let config_path = dir.path().join(".ferrflow");
+        with_cwd(dir.path(), || run(Some(&config_path), &OutputFormat::Json)).unwrap();
+    }
+
+    #[test]
+    fn status_no_packages_prints_warning() {
+        let (dir, repo) = init_repo();
+        fs::write(dir.path().join(".ferrflow"), r#"{"package": []}"#).unwrap();
+        create_commit(&repo, dir.path(), "init.txt", "initial");
+        let config_path = dir.path().join(".ferrflow");
+        with_cwd(dir.path(), || run(Some(&config_path), &OutputFormat::Text)).unwrap();
+    }
+
+    #[test]
+    fn status_with_tag_no_changes() {
+        let (dir, repo) = init_repo();
+        setup_single_package(dir.path());
+        create_commit(&repo, dir.path(), "init.txt", "chore: initial");
+        create_tag(&repo, "v1.0.0");
+        let config_path = dir.path().join(".ferrflow");
+        with_cwd(dir.path(), || run(Some(&config_path), &OutputFormat::Text)).unwrap();
+    }
+
+    #[test]
+    fn status_with_tag_and_new_commits() {
+        let (dir, repo) = init_repo();
+        setup_single_package(dir.path());
+        create_commit(&repo, dir.path(), "init.txt", "chore: initial");
+        create_tag(&repo, "v1.0.0");
+        create_commit(&repo, dir.path(), "new.txt", "feat: new feature");
+        let config_path = dir.path().join(".ferrflow");
+        with_cwd(dir.path(), || run(Some(&config_path), &OutputFormat::Text)).unwrap();
+    }
+
+    #[test]
+    fn status_detects_changes_after_tag() {
+        let (dir, repo) = init_repo();
+        setup_single_package(dir.path());
+        create_commit(&repo, dir.path(), "init.txt", "chore: initial");
+        create_tag(&repo, "v1.0.0");
+        create_commit(&repo, dir.path(), "feature.txt", "feat: add feature");
+        let config_path = dir.path().join(".ferrflow");
+        with_cwd(dir.path(), || run(Some(&config_path), &OutputFormat::Json)).unwrap();
+    }
+}


### PR DESCRIPTION
## Summary

- Add 22 unit tests for CLI argument parsing (all subcommands, global flags, edge cases)
- Add 13 tests for `query.rs` (version/tag queries with single packages, monorepos, error paths)
- Add 7 tests for `status.rs` (text/json output, tag detection, change detection)
- Add 14 tests for `forge/github.rs` (payload structures, response parsing, draft detection, GraphQL errors)
- Add 8 tests for `forge/gitlab.rs` (nouns, noop draft handling, payload structures)
- Add 11 tests for `forge/mod.rs` (resolve_token precedence, build_forge routing, URL edge cases)
- Add shared `test_utils::with_cwd` to safely serialize tests that change the working directory

Closes #229