### PR TITLE
feat(forge): support self-hosted GitHub Enterprise and GitLab instances

### DIFF
--- a/src/forge/github.rs
+++ b/src/forge/github.rs
@@ -5,11 +5,12 @@ use super::{Forge, MergeRequestResult};
 pub struct GitHubForge {
     pub token: String,
     pub slug: String,
+    pub api_base: String,
 }
 
 impl Forge for GitHubForge {
     fn create_release(&self, tag: &str, body: &str, prerelease: bool, draft: bool) -> Result<()> {
-        let url = format!("https://api.github.com/repos/{}/releases", self.slug);
+        let url = format!("{}/repos/{}/releases", self.api_base, self.slug);
 
         let payload = serde_json::json!({
             "tag_name": tag,
@@ -31,7 +32,7 @@ impl Forge for GitHubForge {
     }
 
     fn find_draft_release(&self, tag: &str) -> Result<Option<u64>> {
-        let url = format!("https://api.github.com/repos/{}/releases", self.slug);
+        let url = format!("{}/repos/{}/releases", self.api_base, self.slug);
 
         let response: serde_json::Value = ureq::get(&url)
             .header("Authorization", &format!("Bearer {}", self.token))
@@ -60,8 +61,8 @@ impl Forge for GitHubForge {
 
     fn publish_release(&self, release_id: u64) -> Result<()> {
         let url = format!(
-            "https://api.github.com/repos/{}/releases/{release_id}",
-            self.slug
+            "{}/repos/{}/releases/{release_id}",
+            self.api_base, self.slug
         );
 
         let payload = serde_json::json!({
@@ -86,7 +87,7 @@ impl Forge for GitHubForge {
         title: &str,
         body: &str,
     ) -> Result<MergeRequestResult> {
-        let url = format!("https://api.github.com/repos/{}/pulls", self.slug);
+        let url = format!("{}/repos/{}/pulls", self.api_base, self.slug);
 
         let payload = serde_json::json!({
             "title": title,
@@ -127,7 +128,8 @@ impl Forge for GitHubForge {
             "variables": { "prId": mr.auto_merge_key },
         });
 
-        let response: serde_json::Value = ureq::post("https://api.github.com/graphql")
+        let graphql_url = format!("{}/graphql", self.api_base);
+        let response: serde_json::Value = ureq::post(&graphql_url)
             .header("Authorization", &format!("Bearer {}", self.token))
             .header("User-Agent", "ferrflow")
             .send_json(query)
@@ -163,6 +165,7 @@ mod tests {
         GitHubForge {
             token: "test-token".to_string(),
             slug: "owner/repo".to_string(),
+            api_base: "https://api.github.com".to_string(),
         }
     }
 
@@ -331,5 +334,21 @@ mod tests {
     fn pr_response_missing_node_id() {
         let response: serde_json::Value = serde_json::json!({"number": 1});
         assert!(response["node_id"].as_str().is_none());
+    }
+
+    #[test]
+    fn api_base_github_com() {
+        let forge = make_forge();
+        assert_eq!(forge.api_base, "https://api.github.com");
+    }
+
+    #[test]
+    fn api_base_github_enterprise() {
+        let forge = GitHubForge {
+            token: "tok".to_string(),
+            slug: "owner/repo".to_string(),
+            api_base: "https://github.corp.com/api/v3".to_string(),
+        };
+        assert_eq!(forge.api_base, "https://github.corp.com/api/v3");
     }
 }

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -6,6 +6,7 @@ use super::{Forge, MergeRequestResult};
 pub struct GitLabForge {
     pub token: String,
     pub slug: String,
+    pub api_base: String,
 }
 
 impl GitLabForge {
@@ -24,7 +25,7 @@ impl Forge for GitLabForge {
         }
 
         let project = self.encoded_project_id();
-        let url = format!("https://gitlab.com/api/v4/projects/{project}/releases");
+        let url = format!("{}/projects/{project}/releases", self.api_base);
 
         let mut payload = serde_json::json!({
             "tag_name": tag,
@@ -60,7 +61,7 @@ impl Forge for GitLabForge {
         body: &str,
     ) -> Result<MergeRequestResult> {
         let project = self.encoded_project_id();
-        let url = format!("https://gitlab.com/api/v4/projects/{project}/merge_requests");
+        let url = format!("{}/projects/{project}/merge_requests", self.api_base);
 
         let payload = serde_json::json!({
             "source_branch": head,
@@ -91,8 +92,8 @@ impl Forge for GitLabForge {
     fn enable_auto_merge(&self, mr: &MergeRequestResult) -> Result<()> {
         let project = self.encoded_project_id();
         let url = format!(
-            "https://gitlab.com/api/v4/projects/{project}/merge_requests/{}/merge",
-            mr.id
+            "{}/projects/{project}/merge_requests/{}/merge",
+            self.api_base, mr.id
         );
 
         let payload = serde_json::json!({
@@ -127,6 +128,7 @@ mod tests {
         let forge = GitLabForge {
             token: String::new(),
             slug: "owner/repo".to_string(),
+            api_base: "https://gitlab.com/api/v4".to_string(),
         };
         assert_eq!(forge.encoded_project_id(), "owner%2Frepo");
     }
@@ -136,6 +138,7 @@ mod tests {
         let forge = GitLabForge {
             token: String::new(),
             slug: "group/subgroup/repo".to_string(),
+            api_base: "https://gitlab.com/api/v4".to_string(),
         };
         assert_eq!(forge.encoded_project_id(), "group%2Fsubgroup%2Frepo");
     }
@@ -145,6 +148,7 @@ mod tests {
         let forge = GitLabForge {
             token: String::new(),
             slug: "owner/repo".to_string(),
+            api_base: "https://gitlab.com/api/v4".to_string(),
         };
         assert_eq!(forge.mr_noun(), "MR");
     }
@@ -154,6 +158,7 @@ mod tests {
         let forge = GitLabForge {
             token: String::new(),
             slug: "owner/repo".to_string(),
+            api_base: "https://gitlab.com/api/v4".to_string(),
         };
         assert_eq!(forge.release_noun(), "GitLab Release");
     }
@@ -163,6 +168,7 @@ mod tests {
         let forge = GitLabForge {
             token: String::new(),
             slug: "owner/repo".to_string(),
+            api_base: "https://gitlab.com/api/v4".to_string(),
         };
         assert_eq!(forge.find_draft_release("v1.0.0").unwrap(), None);
     }
@@ -172,6 +178,7 @@ mod tests {
         let forge = GitLabForge {
             token: String::new(),
             slug: "owner/repo".to_string(),
+            api_base: "https://gitlab.com/api/v4".to_string(),
         };
         assert!(forge.publish_release(123).is_ok());
     }
@@ -204,5 +211,15 @@ mod tests {
         });
         assert_eq!(payload["merge_when_pipeline_succeeds"], true);
         assert_eq!(payload["squash"], true);
+    }
+
+    #[test]
+    fn api_base_self_hosted() {
+        let forge = GitLabForge {
+            token: String::new(),
+            slug: "team/project".to_string(),
+            api_base: "https://gitlab.internal/api/v4".to_string(),
+        };
+        assert_eq!(forge.api_base, "https://gitlab.internal/api/v4");
     }
 }

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -36,6 +36,27 @@ pub fn detect_forge_from_url(url: &str) -> Option<ForgeKind> {
     }
 }
 
+/// Extract the hostname from a git remote URL.
+///
+/// Supports HTTPS (`https://host/...`) and SSH (`git@host:...`) formats.
+/// Returns `None` if the URL cannot be parsed.
+pub fn extract_host(url: &str) -> Option<String> {
+    if let Some(rest) = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+    {
+        // https://host/owner/repo.git or https://host:port/owner/repo.git
+        rest.split('/').next().map(|h| h.to_string())
+    } else if url.contains('@') && url.contains(':') {
+        // git@host:owner/repo.git
+        let after_at = url.split('@').nth(1)?;
+        let host = after_at.split(':').next()?;
+        Some(host.to_string())
+    } else {
+        None
+    }
+}
+
 pub fn extract_repo_slug(url: &str) -> Option<String> {
     for host in ["github.com", "gitlab.com"] {
         let after = if url.contains(&format!("{host}/")) {
@@ -79,10 +100,28 @@ pub fn resolve_token(kind: ForgeKind) -> Option<String> {
     }
 }
 
-pub fn build_forge(kind: ForgeKind, token: String, slug: String) -> Box<dyn Forge> {
+pub fn build_forge(kind: ForgeKind, token: String, slug: String, host: String) -> Box<dyn Forge> {
     match kind {
-        ForgeKind::Github => Box::new(github::GitHubForge { token, slug }),
-        ForgeKind::Gitlab => Box::new(gitlab::GitLabForge { token, slug }),
+        ForgeKind::Github => {
+            let api_base = if host == "github.com" {
+                "https://api.github.com".to_string()
+            } else {
+                format!("https://{host}/api/v3")
+            };
+            Box::new(github::GitHubForge {
+                token,
+                slug,
+                api_base,
+            })
+        }
+        ForgeKind::Gitlab => {
+            let api_base = format!("https://{host}/api/v4");
+            Box::new(gitlab::GitLabForge {
+                token,
+                slug,
+                api_base,
+            })
+        }
         ForgeKind::Auto => unreachable!("ForgeKind::Auto must be resolved before building"),
     }
 }
@@ -279,14 +318,24 @@ mod tests {
 
     #[test]
     fn build_forge_github() {
-        let forge = build_forge(ForgeKind::Github, "tok".into(), "owner/repo".into());
+        let forge = build_forge(
+            ForgeKind::Github,
+            "tok".into(),
+            "owner/repo".into(),
+            "github.com".into(),
+        );
         assert_eq!(forge.mr_noun(), "PR");
         assert_eq!(forge.release_noun(), "GitHub Release");
     }
 
     #[test]
     fn build_forge_gitlab() {
-        let forge = build_forge(ForgeKind::Gitlab, "tok".into(), "owner/repo".into());
+        let forge = build_forge(
+            ForgeKind::Gitlab,
+            "tok".into(),
+            "owner/repo".into(),
+            "gitlab.com".into(),
+        );
         assert_eq!(forge.mr_noun(), "MR");
         assert_eq!(forge.release_noun(), "GitLab Release");
     }
@@ -294,7 +343,12 @@ mod tests {
     #[test]
     #[should_panic(expected = "unreachable")]
     fn build_forge_auto_panics() {
-        build_forge(ForgeKind::Auto, "tok".into(), "owner/repo".into());
+        build_forge(
+            ForgeKind::Auto,
+            "tok".into(),
+            "owner/repo".into(),
+            "github.com".into(),
+        );
     }
 
     #[test]
@@ -308,5 +362,72 @@ mod tests {
     #[test]
     fn detect_forge_empty_string() {
         assert_eq!(detect_forge_from_url(""), None);
+    }
+
+    #[test]
+    fn extract_host_github_https() {
+        assert_eq!(
+            extract_host("https://github.com/owner/repo.git"),
+            Some("github.com".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_host_github_ssh() {
+        assert_eq!(
+            extract_host("git@github.com:owner/repo.git"),
+            Some("github.com".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_host_gitlab_https() {
+        assert_eq!(
+            extract_host("https://gitlab.com/owner/repo.git"),
+            Some("gitlab.com".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_host_self_hosted_https() {
+        assert_eq!(
+            extract_host("https://git.company.com/team/project.git"),
+            Some("git.company.com".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_host_self_hosted_ssh() {
+        assert_eq!(
+            extract_host("git@gitlab.internal:team/project.git"),
+            Some("gitlab.internal".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_host_empty() {
+        assert_eq!(extract_host(""), None);
+    }
+
+    #[test]
+    fn build_forge_github_self_hosted() {
+        let forge = build_forge(
+            ForgeKind::Github,
+            "tok".into(),
+            "owner/repo".into(),
+            "github.corp.com".into(),
+        );
+        assert_eq!(forge.mr_noun(), "PR");
+    }
+
+    #[test]
+    fn build_forge_gitlab_self_hosted() {
+        let forge = build_forge(
+            ForgeKind::Gitlab,
+            "tok".into(),
+            "team/project".into(),
+            "gitlab.internal".into(),
+        );
+        assert_eq!(forge.mr_noun(), "MR");
     }
 }

--- a/src/monorepo.rs
+++ b/src/monorepo.rs
@@ -23,6 +23,7 @@ use std::path::Path;
 fn build_forge_instance(repo: &Repository, config: &Config) -> Option<Box<dyn forge::Forge>> {
     let remote_url = get_remote_url(repo, &config.workspace.remote)?;
     let slug = forge::extract_repo_slug(&remote_url)?;
+    let host = forge::extract_host(&remote_url)?;
 
     let kind = match config.workspace.forge {
         ForgeKind::Auto => forge::detect_forge_from_url(&remote_url)?,
@@ -30,7 +31,7 @@ fn build_forge_instance(repo: &Repository, config: &Config) -> Option<Box<dyn fo
     };
 
     let token = forge::resolve_token(kind)?;
-    Some(forge::build_forge(kind, token, slug))
+    Some(forge::build_forge(kind, token, slug, host))
 }
 
 #[derive(serde::Serialize)]


### PR DESCRIPTION
## Summary
- Add `extract_host` to parse the hostname from git remote URLs (HTTPS and SSH)
- Add `api_base` field to `GitHubForge` and `GitLabForge`, replacing all hardcoded API URLs
- GitHub.com uses `https://api.github.com`, GitHub Enterprise uses `https://{host}/api/v3`
- GitLab uses `https://{host}/api/v4` for both gitlab.com and self-hosted instances
- Users with self-hosted forges must set `forge: "gitlab"` or `forge: "github"` explicitly in config since auto-detection only matches known hosts

Closes #298

## Test plan
- [x] All 473 existing tests pass
- [x] New tests for `extract_host` (HTTPS, SSH, self-hosted, empty)
- [x] New tests for `build_forge` with self-hosted hosts
- [x] New tests for `api_base` field on both forge structs