### PR TITLE
fix: handle detached HEAD in CI and GitLab auto-merge fallback

### DIFF
--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -96,16 +96,32 @@ impl Forge for GitLabForge {
             self.api_base, mr.id
         );
 
+        // Try merge_when_pipeline_succeeds first (requires an active pipeline)
         let payload = serde_json::json!({
             "merge_when_pipeline_succeeds": true,
             "squash": true,
+        });
+
+        let result = ureq::put(&url)
+            .header("PRIVATE-TOKEN", &self.token)
+            .header("User-Agent", "ferrflow")
+            .send_json(payload);
+
+        if result.is_ok() {
+            return Ok(());
+        }
+
+        // Fallback: merge directly (pipeline may be skipped or absent)
+        let payload = serde_json::json!({
+            "squash": true,
+            "should_remove_source_branch": true,
         });
 
         ureq::put(&url)
             .header("PRIVATE-TOKEN", &self.token)
             .header("User-Agent", "ferrflow")
             .send_json(payload)
-            .with_context(|| format!("Failed to enable auto-merge on MR !{}", mr.id))?;
+            .with_context(|| format!("Failed to merge MR !{}", mr.id))?;
 
         Ok(())
     }

--- a/src/git.rs
+++ b/src/git.rs
@@ -687,13 +687,26 @@ pub fn verify_remote_branch(
     anyhow::bail!("Remote branch '{}' not found after push", branch);
 }
 
+/// Resolve the local refspec source for a branch push.
+/// In CI environments with detached HEAD, `refs/heads/{branch}` may not exist,
+/// so we fall back to pushing HEAD directly.
+fn resolve_push_source(repo: &Repository, branch: &str) -> String {
+    let local_ref = format!("refs/heads/{branch}");
+    if repo.find_reference(&local_ref).is_ok() {
+        local_ref
+    } else {
+        "HEAD".to_string()
+    }
+}
+
 pub fn push_branch(repo: &Repository, remote_name: &str, branch: &str) -> Result<()> {
     let mut remote = get_authenticated_remote(repo, remote_name)?;
 
     let push_errors = Rc::new(RefCell::new(Vec::new()));
     let mut push_options = make_push_options(push_errors.clone());
 
-    let refspec = format!("refs/heads/{branch}:refs/heads/{branch}");
+    let source = resolve_push_source(repo, branch);
+    let refspec = format!("{source}:refs/heads/{branch}");
     remote
         .push(&[&refspec], Some(&mut push_options))
         .with_context(|| format!("Failed to push branch '{branch}'"))?;
@@ -730,7 +743,8 @@ pub fn push(repo: &Repository, remote_name: &str, branch: &str, tags: &[&str]) -
         let mut remote = get_authenticated_remote(repo, remote_name)?;
         let push_errors = Rc::new(RefCell::new(Vec::new()));
         let mut opts = make_push_options(push_errors.clone());
-        let branch_refspec = format!("refs/heads/{branch}:refs/heads/{branch}");
+        let source = resolve_push_source(repo, branch);
+        let branch_refspec = format!("{source}:refs/heads/{branch}");
         remote
             .push(&[&branch_refspec], Some(&mut opts))
             .with_context(|| format!("Failed to push branch '{branch}'"))?;

--- a/src/monorepo.rs
+++ b/src/monorepo.rs
@@ -141,14 +141,17 @@ fn run_release_logic(
         eprintln!("Warning: could not fetch remote tags: {e}");
     }
 
-    // Resolve pre-release channel context
-    let current_branch = std::process::Command::new("git")
-        .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .output()
+    // Resolve pre-release channel context (use libgit2 to avoid requiring git CLI)
+    let current_branch = repo
+        .head()
         .ok()
-        .filter(|o| o.status.success())
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
+        .and_then(|h| {
+            if h.is_branch() {
+                h.shorthand().map(String::from)
+            } else {
+                None
+            }
+        })
         .unwrap_or_else(|| config.workspace.branch.clone());
 
     let prerelease_ctx = PrereleaseContext::resolve(


### PR DESCRIPTION
## Summary
- Fix push failure in CI environments where git checks out in detached HEAD mode (e.g. GitLab CI). The push refspec now uses `HEAD` as source when the local branch ref doesn't exist.
- Replace `git rev-parse --abbrev-ref HEAD` CLI call with libgit2 to resolve current branch, removing dependency on git binary in the Docker image.
- Add fallback in GitLab auto-merge: when `merge_when_pipeline_succeeds` fails (pipeline skipped/absent), merge the MR directly.

## Test plan
- [x] All 877 existing tests pass
- [ ] Deploy updated image to GitLab CI and verify release flow works end-to-end