### PR TITLE
fix: use CI env vars for branch detection in detached HEAD

### DIFF
--- a/src/monorepo.rs
+++ b/src/monorepo.rs
@@ -141,7 +141,7 @@ fn run_release_logic(
         eprintln!("Warning: could not fetch remote tags: {e}");
     }
 
-    // Resolve pre-release channel context (use libgit2 to avoid requiring git CLI)
+    // Resolve pre-release channel context (use libgit2, with CI env fallback for detached HEAD)
     let current_branch = repo
         .head()
         .ok()
@@ -152,6 +152,8 @@ fn run_release_logic(
                 None
             }
         })
+        .or_else(|| std::env::var("CI_COMMIT_BRANCH").ok())
+        .or_else(|| std::env::var("GITHUB_REF_NAME").ok())
         .unwrap_or_else(|| config.workspace.branch.clone());
 
     let prerelease_ctx = PrereleaseContext::resolve(


### PR DESCRIPTION
## Summary
- When in detached HEAD (CI), fall back to `CI_COMMIT_BRANCH` (GitLab) or `GITHUB_REF_NAME` (GitHub) to correctly detect the current branch for pre-release targeting.

Follows up on #303 which was merged but missed this edge case.

## Test plan
- [x] All 877 tests pass