### PR TITLE
fix(wasm): gate git2 usage in default_branch behind cli feature

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -162,21 +162,28 @@ fn default_remote() -> String {
 }
 
 fn default_branch() -> String {
-    let detected = (|| {
-        let repo = git2::Repository::discover(".").ok()?;
-        let reference = repo.find_reference("refs/remotes/origin/HEAD").ok()?;
-        let target = reference.symbolic_target().map(String::from)?;
-        let branch = target
-            .strip_prefix("refs/remotes/origin/")
-            .unwrap_or(&target);
-        if branch.is_empty() {
-            None
-        } else {
-            Some(branch.to_string())
-        }
-    })();
+    #[cfg(feature = "cli")]
+    {
+        let detected = (|| {
+            let repo = git2::Repository::discover(".").ok()?;
+            let reference = repo.find_reference("refs/remotes/origin/HEAD").ok()?;
+            let target = reference.symbolic_target().map(String::from)?;
+            let branch = target
+                .strip_prefix("refs/remotes/origin/")
+                .unwrap_or(&target);
+            if branch.is_empty() {
+                None
+            } else {
+                Some(branch.to_string())
+            }
+        })();
 
-    detected.unwrap_or_else(|| "main".to_string())
+        if let Some(branch) = detected {
+            return branch;
+        }
+    }
+
+    "main".to_string()
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]


### PR DESCRIPTION
## Summary

- Wrap the `git2` call in `default_branch()` (config.rs) behind `#[cfg(feature = "cli")]` so the WASM build compiles without `git2`
- The `git2` crate is not available for `wasm32-unknown-unknown` and was causing the Publish workflow to fail

Closes #314