### PR TITLE
feat(config): add releaseCommitScope option for per-package commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,22 @@ release_commit_mode = "pr"
 auto_merge_releases = true  # default
 ```
 
+### Release Commit Scope
+
+In monorepo mode, controls whether all package bumps go into a single commit or one commit per package:
+
+```toml
+[workspace]
+release_commit_scope = "grouped"  # default
+```
+
+| Scope | Description |
+|-------|-------------|
+| `grouped` | Single commit for all packages (e.g. `chore(release): api v1.0.0, site v2.1.0`) |
+| `per-package` | One commit per package (e.g. `chore(release): api v1.0.0`, then `chore(release): site v2.1.0`) |
+
+Per-package commits make it easier to revert a single package bump without affecting others. This works with both `commit` and `pr` release modes.
+
 ### Skip CI
 
 By default, release commits in `commit` mode include `[skip ci]` in the message to avoid triggering a CI loop. Override with `skip_ci`:

--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -55,6 +55,12 @@
           "enum": ["commit", "pr", "none"],
           "default": "commit"
         },
+        "releaseCommitScope": {
+          "type": "string",
+          "description": "In monorepo mode, whether to create a single grouped commit for all packages or one commit per package. Only affects behavior when multiple packages are bumped.",
+          "enum": ["grouped", "per-package"],
+          "default": "grouped"
+        },
         "autoMergeReleases": {
           "type": "boolean",
           "description": "Automatically merge release PRs when releaseCommitMode is 'pr'.",

--- a/src/config.rs
+++ b/src/config.rs
@@ -110,6 +110,14 @@ pub enum ReleaseCommitMode {
     None,
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum ReleaseCommitScope {
+    #[default]
+    Grouped,
+    PerPackage,
+}
+
 #[derive(Debug, Deserialize, Serialize, Default)]
 pub struct WorkspaceConfig {
     #[serde(default = "default_remote")]
@@ -126,6 +134,8 @@ pub struct WorkspaceConfig {
     pub recover_missed_releases: bool,
     #[serde(default, alias = "releaseCommitMode")]
     pub release_commit_mode: ReleaseCommitMode,
+    #[serde(default, alias = "releaseCommitScope")]
+    pub release_commit_scope: ReleaseCommitScope,
     #[serde(default = "default_auto_merge", alias = "autoMergeReleases")]
     pub auto_merge_releases: bool,
     #[serde(default, alias = "skipCi")]
@@ -343,6 +353,7 @@ const CAMEL_CASE_KEYS: &[&str] = &[
     "shared_paths",
     "recover_missed_releases",
     "release_commit_mode",
+    "release_commit_scope",
     "auto_merge_releases",
     "skip_ci",
     "pre_bump",
@@ -1847,6 +1858,42 @@ format = "toml"
                 "failed for {s}"
             );
         }
+    }
+
+    #[test]
+    fn parse_release_commit_scopes() {
+        for (s, expected) in [
+            ("grouped", ReleaseCommitScope::Grouped),
+            ("per-package", ReleaseCommitScope::PerPackage),
+        ] {
+            let json =
+                format!(r#"{{ "workspace": {{ "releaseCommitScope": "{s}" }}, "package": [] }}"#);
+            let config: Config = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                config.workspace.release_commit_scope, expected,
+                "failed for {s}"
+            );
+        }
+    }
+
+    #[test]
+    fn release_commit_scope_defaults_to_grouped() {
+        let json = r#"{ "workspace": {}, "package": [] }"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            config.workspace.release_commit_scope,
+            ReleaseCommitScope::Grouped
+        );
+    }
+
+    #[test]
+    fn release_commit_scope_camel_case_alias() {
+        let json = r#"{ "workspace": { "releaseCommitScope": "per-package" }, "package": [] }"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            config.workspace.release_commit_scope,
+            ReleaseCommitScope::PerPackage
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/src/git.rs
+++ b/src/git.rs
@@ -607,21 +607,33 @@ pub fn create_branch_and_commit(
     files: &[&str],
     message: &str,
 ) -> Result<()> {
+    create_branch_and_commits(repo, branch_name, &[(files, message)])
+}
+
+pub fn create_branch_and_commits(
+    repo: &Repository,
+    branch_name: &str,
+    commits: &[(&[&str], &str)],
+) -> Result<()> {
     let head = repo.head()?.peel_to_commit()?;
     repo.branch(branch_name, &head, false)?;
 
     let refname = format!("refs/heads/{branch_name}");
-    let mut index = repo.index()?;
-    for file in files {
-        index.add_path(Path::new(file))?;
-    }
-    index.write()?;
-
-    let tree_id = index.write_tree()?;
-    let tree = repo.find_tree(tree_id)?;
     let sig = signature(repo)?;
+    let mut parent = head;
 
-    repo.commit(Some(&refname), &sig, &sig, message, &tree, &[&head])?;
+    for (files, message) in commits {
+        let mut index = repo.index()?;
+        for file in *files {
+            index.add_path(Path::new(file))?;
+        }
+        index.write()?;
+
+        let tree_id = index.write_tree()?;
+        let tree = repo.find_tree(tree_id)?;
+        let oid = repo.commit(Some(&refname), &sig, &sig, message, &tree, &[&parent])?;
+        parent = repo.find_commit(oid)?;
+    }
     Ok(())
 }
 
@@ -1109,6 +1121,29 @@ mod tests {
             repo.find_branch("release/v1.0.0", git2::BranchType::Local)
                 .is_ok()
         );
+    }
+
+    #[test]
+    fn create_branch_and_commits_multiple() {
+        let (dir, repo) = init_repo();
+        create_commit_in_repo(&repo, dir.path(), "a.txt", "initial");
+
+        fs::write(dir.path().join("pkg1.txt"), "v1").unwrap();
+        fs::write(dir.path().join("pkg2.txt"), "v2").unwrap();
+
+        let commits: Vec<(&[&str], &str)> = vec![
+            (&["pkg1.txt"], "chore(release): pkg1 v1.0.0"),
+            (&["pkg2.txt"], "chore(release): pkg2 v2.0.0"),
+        ];
+        create_branch_and_commits(&repo, "release/multi", &commits).unwrap();
+
+        let branch = repo
+            .find_branch("release/multi", git2::BranchType::Local)
+            .unwrap();
+        let tip = branch.get().peel_to_commit().unwrap();
+        assert_eq!(tip.message().unwrap(), "chore(release): pkg2 v2.0.0");
+        let parent = tip.parent(0).unwrap();
+        assert_eq!(parent.message().unwrap(), "chore(release): pkg1 v1.0.0");
     }
 
     // -----------------------------------------------------------------------

--- a/src/monorepo.rs
+++ b/src/monorepo.rs
@@ -1,14 +1,16 @@
 use crate::changelog::{build_section, update_changelog};
 use crate::config::ReleaseCommitMode;
+use crate::config::ReleaseCommitScope;
 use crate::config::{Config, PackageConfig, VersioningStrategy};
 use crate::conventional_commits::{BumpType, determine_bump};
 use crate::forge::{self, ForgeKind};
 use crate::formats::{get_handler, read_version, write_version};
 use crate::git::{
-    collect_all_tags, create_branch_and_commit, create_commit, create_or_move_tag, create_tag,
-    fetch_tags, force_push_tags, get_changed_files, get_changed_files_since_tag,
-    get_commits_since_last_stable_tag, get_commits_since_last_tag, get_remote_url, get_repo_root,
-    get_tag_message, open_repo, push, push_branch, push_tags, tag_exists,
+    collect_all_tags, create_branch_and_commit, create_branch_and_commits, create_commit,
+    create_or_move_tag, create_tag, fetch_tags, force_push_tags, get_changed_files,
+    get_changed_files_since_tag, get_commits_since_last_stable_tag, get_commits_since_last_tag,
+    get_remote_url, get_repo_root, get_tag_message, open_repo, push, push_branch, push_tags,
+    tag_exists,
 };
 use crate::hooks::{HookContext, HookPoint, resolve_hook, resolve_on_failure, run_hook};
 use crate::prerelease::PrereleaseContext;
@@ -17,7 +19,7 @@ use crate::versioning::{compute_next_version, truncate_version};
 use anyhow::Result;
 use colored::Colorize;
 use git2::Repository;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 fn build_forge_instance(repo: &Repository, config: &Config) -> Option<Box<dyn forge::Forge>> {
@@ -179,6 +181,7 @@ fn run_release_logic(
     let mut any_bumped = false;
     let mut json_packages: Vec<CheckPackage> = Vec::new();
     let mut files_to_commit: Vec<String> = Vec::new();
+    let mut files_per_package: HashMap<String, Vec<String>> = HashMap::new();
     // (tag_name, tag_msg, body, pkg_name, version, commits_count, is_prerelease)
     let mut tags_to_create: Vec<(String, String, String, String, String, i32, bool)> = Vec::new();
     let mut hook_contexts: Vec<(HookContext, usize)> = Vec::new(); // (ctx, pkg_index)
@@ -450,6 +453,10 @@ fn run_release_logic(
                         lines.push(format!("  ✓ Updated {}", vf.path));
                     }
                     files_to_commit.push(vf.path.clone());
+                    files_per_package
+                        .entry(pkg.name.clone())
+                        .or_default()
+                        .push(vf.path.clone());
                 }
             }
 
@@ -464,6 +471,10 @@ fn run_release_logic(
                     false,
                 )?;
                 files_to_commit.push(changelog_rel.clone());
+                files_per_package
+                    .entry(pkg.name.clone())
+                    .or_default()
+                    .push(changelog_rel.clone());
             }
 
             // --- post_bump hook ---
@@ -478,7 +489,12 @@ fn run_release_logic(
                     verbose,
                     root,
                 )?;
+                let len_before = files_to_commit.len();
                 auto_stage_new_files(&repo, &before, &mut files_to_commit);
+                let pkg_files = files_per_package.entry(pkg.name.clone()).or_default();
+                for f in &files_to_commit[len_before..] {
+                    pkg_files.push(f.clone());
+                }
             }
 
             let body = build_section(&new_version, &commits);
@@ -581,6 +597,10 @@ fn run_release_logic(
                             if get_handler(&vf.format).modifies_file() {
                                 lines.push(format!("  ✓ Updated {}", vf.path));
                                 files_to_commit.push(vf.path.clone());
+                                files_per_package
+                                    .entry(pkg.name.clone())
+                                    .or_default()
+                                    .push(vf.path.clone());
                             }
                         }
                         if let Some(changelog_rel) = &pkg.changelog {
@@ -594,6 +614,10 @@ fn run_release_logic(
                                 false,
                             )?;
                             files_to_commit.push(changelog_rel.clone());
+                            files_per_package
+                                .entry(pkg.name.clone())
+                                .or_default()
+                                .push(changelog_rel.clone());
                         }
                     }
                     pkg_outputs.push((pkg.name.clone(), lines));
@@ -646,13 +670,19 @@ fn run_release_logic(
                     root,
                 )?;
                 if !dry_run {
+                    let len_before = files_to_commit.len();
                     auto_stage_new_files(&repo, &before, &mut files_to_commit);
+                    let pkg_files = files_per_package.entry(pkg.name.clone()).or_default();
+                    for f in &files_to_commit[len_before..] {
+                        pkg_files.push(f.clone());
+                    }
                 }
             }
         }
 
         let file_refs: Vec<&str> = files_to_commit.iter().map(String::as_str).collect();
         let mode = config.workspace.release_commit_mode;
+        let scope = config.workspace.release_commit_scope;
 
         // Build the release commit message.
         let release_parts: Vec<String> = tags_to_create
@@ -670,8 +700,21 @@ fn run_release_logic(
         if !dry_run {
             match mode {
                 ReleaseCommitMode::Commit => {
-                    create_commit(&repo, &file_refs, &commit_msg)?;
-                    shared_outputs.push("✓ Committed release changes".to_string());
+                    if scope == ReleaseCommitScope::PerPackage && tags_to_create.len() > 1 {
+                        for (_, _, _, pkg_name, ver, _, _) in &tags_to_create {
+                            if let Some(pkg_files) = files_per_package.get(pkg_name) {
+                                let refs: Vec<&str> =
+                                    pkg_files.iter().map(String::as_str).collect();
+                                let msg = format!("chore(release): {pkg_name} v{ver}{skip_ci}");
+                                create_commit(&repo, &refs, &msg)?;
+                            }
+                        }
+                        shared_outputs
+                            .push("✓ Committed release changes (per-package)".to_string());
+                    } else {
+                        create_commit(&repo, &file_refs, &commit_msg)?;
+                        shared_outputs.push("✓ Committed release changes".to_string());
+                    }
                 }
                 ReleaseCommitMode::Pr => {
                     let branch_name = format!(
@@ -681,7 +724,25 @@ fn run_release_logic(
                             .map(|s| s.replace(' ', "-"))
                             .unwrap_or_else(|| "bump".to_string())
                     );
-                    create_branch_and_commit(&repo, &branch_name, &file_refs, &commit_msg)?;
+                    if scope == ReleaseCommitScope::PerPackage && tags_to_create.len() > 1 {
+                        let commit_list: Vec<(Vec<&str>, String)> = tags_to_create
+                            .iter()
+                            .filter_map(|(_, _, _, pkg_name, ver, _, _)| {
+                                files_per_package.get(pkg_name).map(|pf| {
+                                    let refs: Vec<&str> = pf.iter().map(String::as_str).collect();
+                                    let msg = format!("chore(release): {pkg_name} v{ver}{skip_ci}");
+                                    (refs, msg)
+                                })
+                            })
+                            .collect();
+                        let commit_refs: Vec<(&[&str], &str)> = commit_list
+                            .iter()
+                            .map(|(f, m)| (f.as_slice(), m.as_str()))
+                            .collect();
+                        create_branch_and_commits(&repo, &branch_name, &commit_refs)?;
+                    } else {
+                        create_branch_and_commit(&repo, &branch_name, &file_refs, &commit_msg)?;
+                    }
                     push_branch(&repo, &config.workspace.remote, &branch_name)?;
                     shared_outputs.push(format!("✓ Pushed branch {}", branch_name.cyan()));
 


### PR DESCRIPTION
## Summary
- Add `releaseCommitScope` config option to `workspace` with values `"grouped"` (default) and `"per-package"`
- In `per-package` mode, monorepo releases create one commit per bumped package instead of a single grouped commit
- Works with both `commit` and `pr` release modes
- Add `create_branch_and_commits` helper in git.rs for multi-commit branch creation (PR mode)
- Update JSON schema, README, and site documentation (EN + FR)

Closes #174