### PR TITLE
feat(cli): add --force-version flag to release command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "2.19.3"
+version = "2.21.0"
 dependencies = [
  "anyhow",
  "cargo-husky",

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ ferrflow release
 # Dry run
 ferrflow release --dry-run
 
+# Force a specific version (skips commit analysis)
+ferrflow release --force-version 2.0.0          # single repo
+ferrflow release --force-version api@3.0.0      # monorepo
+
 # Pre-release
 ferrflow release --channel beta
 

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'Run without creating releases or pushing changes'
     required: false
     default: 'false'
+  force_version:
+    description: 'Force a specific version, skipping commit analysis. Format: VERSION (single repo) or NAME@VERSION (monorepo)'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -55,4 +59,4 @@ runs:
 
     - name: Run FerrFlow release
       shell: bash
-      run: ferrflow ${{ inputs.dry_run == 'true' && '--dry-run' || '' }} release
+      run: ferrflow ${{ inputs.dry_run == 'true' && '--dry-run' || '' }} release ${{ inputs.force_version != '' && format('--force-version {0}', inputs.force_version) || '' }}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,6 +44,10 @@ pub enum Commands {
         /// Allow floating tags to move backward to a lower version
         #[arg(long)]
         force: bool,
+        /// Force a specific version, skipping commit analysis.
+        /// Format: VERSION (single repo) or NAME@VERSION (monorepo)
+        #[arg(long, value_name = "VERSION")]
+        force_version: Option<String>,
         /// Pre-release channel override (e.g. beta, rc, dev)
         #[arg(long)]
         channel: Option<String>,
@@ -112,6 +116,7 @@ impl Cli {
             ),
             Commands::Release {
                 force,
+                force_version,
                 channel,
                 draft,
             } => crate::monorepo::release(
@@ -119,6 +124,7 @@ impl Cli {
                 self.dry_run,
                 self.verbose,
                 force,
+                force_version.as_deref(),
                 channel.as_deref(),
                 draft,
             ),
@@ -199,6 +205,7 @@ mod tests {
             cli.command,
             Commands::Release {
                 force: false,
+                force_version: None,
                 channel: None,
                 draft: false
             }
@@ -220,10 +227,22 @@ mod tests {
                 force,
                 channel,
                 draft,
+                ..
             } => {
                 assert!(force);
                 assert!(draft);
                 assert_eq!(channel.as_deref(), Some("rc"));
+            }
+            _ => panic!("expected Release"),
+        }
+    }
+
+    #[test]
+    fn parse_release_force_version() {
+        let cli = parse(&["ferrflow", "release", "--force-version", "api@2.0.0"]);
+        match cli.command {
+            Commands::Release { force_version, .. } => {
+                assert_eq!(force_version.as_deref(), Some("api@2.0.0"));
             }
             _ => panic!("expected Release"),
         }

--- a/src/monorepo.rs
+++ b/src/monorepo.rs
@@ -75,7 +75,9 @@ pub fn check(
         println!();
     }
 
-    let result = run_release_logic(&root, &config, true, verbose, json, false, channel, false);
+    let result = run_release_logic(
+        &root, &config, true, verbose, json, false, None, channel, false,
+    );
 
     if config.workspace.anonymous_telemetry {
         telemetry::send_event(telemetry::EventType::Check, None, None, None, None);
@@ -89,6 +91,7 @@ pub fn release(
     dry_run: bool,
     verbose: bool,
     force: bool,
+    force_version: Option<&str>,
     channel: Option<&str>,
     draft: bool,
 ) -> Result<()> {
@@ -104,7 +107,15 @@ pub fn release(
     println!();
 
     run_release_logic(
-        &root, &config, dry_run, verbose, false, force, channel, draft,
+        &root,
+        &config,
+        dry_run,
+        verbose,
+        false,
+        force,
+        force_version,
+        channel,
+        draft,
     )
 }
 
@@ -116,6 +127,7 @@ fn run_release_logic(
     verbose: bool,
     json: bool,
     force: bool,
+    force_version: Option<&str>,
     channel: Option<&str>,
     draft: bool,
 ) -> Result<()> {
@@ -192,8 +204,52 @@ fn run_release_logic(
     let mut pkg_outputs: Vec<(String, Vec<String>)> = Vec::new();
     let mut shared_outputs: Vec<String> = Vec::new();
 
+    // Parse --force-version: "VERSION" (single repo) or "NAME@VERSION" (monorepo)
+    let forced: Option<(Option<&str>, &str)> = if let Some(fv) = force_version {
+        if let Some(at_pos) = fv.find('@') {
+            let name = &fv[..at_pos];
+            let version = &fv[at_pos + 1..];
+            if name.is_empty() || version.is_empty() {
+                anyhow::bail!("Invalid --force-version format: expected NAME@VERSION, got {fv:?}");
+            }
+            Some((Some(name), version))
+        } else {
+            if config.is_monorepo() {
+                anyhow::bail!(
+                    "In a monorepo, --force-version requires NAME@VERSION format (e.g. api@1.2.3)"
+                );
+            }
+            Some((None, fv))
+        }
+    } else {
+        None
+    };
+
+    // Validate forced version is valid semver (strip leading 'v' if present)
+    if let Some((_, ver)) = &forced {
+        let clean = ver.strip_prefix('v').unwrap_or(ver);
+        if semver::Version::parse(clean).is_err() {
+            anyhow::bail!("Invalid version in --force-version: {ver:?} is not valid semver");
+        }
+    }
+
     for (pkg_idx, pkg) in config.packages.iter().enumerate() {
         let tag_search_prefix = pkg.tag_prefix(&config.workspace, config.is_monorepo());
+
+        // Check if this package is the target of --force-version
+        let forced_ver_for_pkg = forced.and_then(|(name, ver)| {
+            if let Some(target_name) = name {
+                if pkg.name == target_name {
+                    Some(ver)
+                } else {
+                    None
+                }
+            } else {
+                // Single repo: applies to the first (only) package
+                Some(ver)
+            }
+        });
+
         let mut touched = is_package_touched(pkg, &changed_files, config.is_monorepo());
 
         if !touched && config.workspace.recover_missed_releases && config.is_monorepo() {
@@ -214,60 +270,10 @@ fn run_release_logic(
             }
         }
 
-        if !touched {
+        if !touched && forced_ver_for_pkg.is_none() {
             if verbose && !json {
                 println!(
                     "{} {} — not touched, skipping",
-                    "○".dimmed(),
-                    pkg.name.dimmed()
-                );
-            }
-            continue;
-        }
-
-        let commits = if !prerelease_ctx.is_prerelease() {
-            // For stable releases, get all commits since the last stable tag
-            // (skipping any pre-release tags) for a complete changelog
-            get_commits_since_last_stable_tag(
-                &repo,
-                &tag_search_prefix,
-                config.workspace.orphaned_tag_strategy,
-            )?
-        } else {
-            get_commits_since_last_tag(
-                &repo,
-                &tag_search_prefix,
-                config.workspace.orphaned_tag_strategy,
-            )?
-        };
-
-        if commits.is_empty() {
-            if verbose && !json {
-                println!("{} {} — no new commits", "○".dimmed(), pkg.name.dimmed());
-            }
-            continue;
-        }
-
-        let strategy = pkg.effective_versioning(&config.workspace);
-
-        let bump = commits
-            .iter()
-            .map(|c| determine_bump(&c.message))
-            .max()
-            .unwrap_or(BumpType::None);
-
-        let is_date_or_seq = matches!(
-            strategy,
-            VersioningStrategy::Calver
-                | VersioningStrategy::CalverShort
-                | VersioningStrategy::CalverSeq
-                | VersioningStrategy::Sequential
-        );
-
-        if bump == BumpType::None && !is_date_or_seq {
-            if !json {
-                println!(
-                    "{} {} — no releasable commits",
                     "○".dimmed(),
                     pkg.name.dimmed()
                 );
@@ -287,22 +293,94 @@ fn run_release_logic(
         };
 
         let current_version = read_version(vf, root)?;
-        let base_version = compute_next_version(&current_version, bump, strategy)?;
 
-        let (new_version, is_prerelease) = if prerelease_ctx.is_prerelease() {
-            let tag_prefix = pkg.tag_prefix(&config.workspace, config.is_monorepo());
-            if let Some(resolved) = prerelease_ctx.compute_identifier(
-                &base_version,
-                &tag_prefix,
-                &all_tags,
-                &short_hash,
-            ) {
-                (format!("{base_version}{}", resolved.full_suffix), true)
+        // Determine new version: forced or computed from commits
+        let (new_version, is_prerelease, commits, bump) = if let Some(fv) = forced_ver_for_pkg {
+            let clean = fv.strip_prefix('v').unwrap_or(fv);
+            let commits = if !prerelease_ctx.is_prerelease() {
+                get_commits_since_last_stable_tag(
+                    &repo,
+                    &tag_search_prefix,
+                    config.workspace.orphaned_tag_strategy,
+                )
+                .unwrap_or_default()
+            } else {
+                get_commits_since_last_tag(
+                    &repo,
+                    &tag_search_prefix,
+                    config.workspace.orphaned_tag_strategy,
+                )
+                .unwrap_or_default()
+            };
+            (clean.to_string(), false, commits, BumpType::None)
+        } else {
+            let commits = if !prerelease_ctx.is_prerelease() {
+                get_commits_since_last_stable_tag(
+                    &repo,
+                    &tag_search_prefix,
+                    config.workspace.orphaned_tag_strategy,
+                )?
+            } else {
+                get_commits_since_last_tag(
+                    &repo,
+                    &tag_search_prefix,
+                    config.workspace.orphaned_tag_strategy,
+                )?
+            };
+
+            if commits.is_empty() {
+                if verbose && !json {
+                    println!("{} {} — no new commits", "○".dimmed(), pkg.name.dimmed());
+                }
+                continue;
+            }
+
+            let strategy = pkg.effective_versioning(&config.workspace);
+
+            let bump = commits
+                .iter()
+                .map(|c| determine_bump(&c.message))
+                .max()
+                .unwrap_or(BumpType::None);
+
+            let is_date_or_seq = matches!(
+                strategy,
+                VersioningStrategy::Calver
+                    | VersioningStrategy::CalverShort
+                    | VersioningStrategy::CalverSeq
+                    | VersioningStrategy::Sequential
+            );
+
+            if bump == BumpType::None && !is_date_or_seq {
+                if !json {
+                    println!(
+                        "{} {} — no releasable commits",
+                        "○".dimmed(),
+                        pkg.name.dimmed()
+                    );
+                }
+                continue;
+            }
+
+            let base_version = compute_next_version(&current_version, bump, strategy)?;
+
+            let (new_version, is_prerelease) = if prerelease_ctx.is_prerelease() {
+                let tag_prefix = pkg.tag_prefix(&config.workspace, config.is_monorepo());
+                if let Some(resolved) = prerelease_ctx.compute_identifier(
+                    &base_version,
+                    &tag_prefix,
+                    &all_tags,
+                    &short_hash,
+                ) {
+                    (format!("{base_version}{}", resolved.full_suffix), true)
+                } else {
+                    (base_version, false)
+                }
             } else {
                 (base_version, false)
-            }
-        } else {
-            (base_version, false)
+            };
+
+            (new_version, is_prerelease, commits, bump)
         };
 
         if current_version == new_version {
@@ -312,10 +390,22 @@ fn run_release_logic(
             continue;
         }
 
-        let strategy_label = if is_date_or_seq {
-            format!("{strategy:?}").to_lowercase()
+        let strategy_label = if forced_ver_for_pkg.is_some() {
+            "forced".to_string()
         } else {
-            bump.to_string()
+            let strategy = pkg.effective_versioning(&config.workspace);
+            let is_date_or_seq = matches!(
+                strategy,
+                VersioningStrategy::Calver
+                    | VersioningStrategy::CalverShort
+                    | VersioningStrategy::CalverSeq
+                    | VersioningStrategy::Sequential
+            );
+            if is_date_or_seq {
+                format!("{strategy:?}").to_lowercase()
+            } else {
+                bump.to_string()
+            }
         };
 
         let tag = pkg.tag_for_version(&config.workspace, config.is_monorepo(), &new_version);
@@ -1311,5 +1401,45 @@ mod tests {
         let files: Vec<String> = vec![];
         // Even single-package mode returns true regardless of changed files
         assert!(is_package_touched(&pkg, &files, false));
+    }
+
+    #[test]
+    fn parse_force_version_single_repo() {
+        let fv = "1.2.3";
+        let result: Option<(Option<&str>, &str)> = if let Some(at_pos) = fv.find('@') {
+            let name = &fv[..at_pos];
+            let version = &fv[at_pos + 1..];
+            Some((Some(name), version))
+        } else {
+            Some((None, fv))
+        };
+        assert_eq!(result, Some((None, "1.2.3")));
+    }
+
+    #[test]
+    fn parse_force_version_monorepo() {
+        let fv = "api@2.0.0";
+        let result: Option<(Option<&str>, &str)> = if let Some(at_pos) = fv.find('@') {
+            let name = &fv[..at_pos];
+            let version = &fv[at_pos + 1..];
+            Some((Some(name), version))
+        } else {
+            Some((None, fv))
+        };
+        assert_eq!(result, Some((Some("api"), "2.0.0")));
+    }
+
+    #[test]
+    fn parse_force_version_with_v_prefix() {
+        let fv = "v3.0.0";
+        let clean = fv.strip_prefix('v').unwrap_or(fv);
+        assert!(semver::Version::parse(clean).is_ok());
+    }
+
+    #[test]
+    fn parse_force_version_invalid_semver() {
+        let fv = "not-a-version";
+        let clean = fv.strip_prefix('v').unwrap_or(fv);
+        assert!(semver::Version::parse(clean).is_err());
     }
 }


### PR DESCRIPTION
## Summary
- Add `--force-version` CLI flag to skip commit analysis and release a specific version
- Format: `VERSION` (single repo) or `NAME@VERSION` (monorepo)
- Validates version is valid semver before proceeding
- Still collects commits for changelog generation but doesn't use them for bump determination

Closes #90

## Test plan
- [x] Unit tests for force-version parsing (single repo, monorepo, v-prefix, invalid semver)
- [x] CLI parsing test for `--force-version`
- [x] All 490 existing tests pass
- [x] Clippy clean