### PR TITLE
feat(bench): add benchmarks for git operations, validate, and full check flow

### DIFF
--- a/benches/ferrflow_benchmarks.rs
+++ b/benches/ferrflow_benchmarks.rs
@@ -2,10 +2,13 @@ use std::io::Write;
 
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use ferrflow::changelog::{build_section, update_changelog};
-use ferrflow::config::{Config, FileFormat};
+use ferrflow::config::{Config, FileFormat, OrphanedTagStrategy};
 use ferrflow::conventional_commits::{BumpType, determine_bump};
 use ferrflow::formats::get_handler;
-use ferrflow::git::GitLog;
+use ferrflow::git::{
+    GitLog, collect_all_tags, find_last_tag_name, get_changed_files, get_changed_files_since_tag,
+    get_commits_since_last_tag,
+};
 use tempfile::{NamedTempFile, TempDir};
 
 fn generate_commit_messages(count: usize) -> Vec<String> {
@@ -144,7 +147,12 @@ fn generate_config_json(num_packages: usize) -> String {
 }
 
 fn bench_config_loading(c: &mut Criterion) {
-    for (label, num_pkgs) in [("single", 1), ("mono_10", 10), ("mono_50", 50)] {
+    for (label, num_pkgs) in [
+        ("single", 1),
+        ("mono_10", 10),
+        ("mono_50", 50),
+        ("mono_100", 100),
+    ] {
         c.bench_function(&format!("config_loading/{label}"), |b| {
             let dir = TempDir::new().unwrap();
             let config_path = dir.path().join(".ferrflow");
@@ -161,11 +169,219 @@ fn bench_config_loading(c: &mut Criterion) {
     }
 }
 
+/// Create a git repo with `num_commits` commits and a tag at `tag_at` position.
+/// Returns the TempDir (must be kept alive) and the opened Repository.
+fn create_bench_repo(num_commits: usize, tag_at: usize) -> (TempDir, git2::Repository) {
+    let dir = TempDir::new().unwrap();
+    let repo = git2::Repository::init(dir.path()).unwrap();
+
+    // Configure committer identity
+    let mut config = repo.config().unwrap();
+    config.set_str("user.name", "bench").unwrap();
+    config.set_str("user.email", "bench@test.com").unwrap();
+
+    let sig = git2::Signature::now("bench", "bench@test.com").unwrap();
+    let types = ["feat", "fix", "refactor", "perf", "chore"];
+    let scopes = ["api", "auth", "db"];
+
+    let mut parent_oid: Option<git2::Oid> = None;
+
+    for i in 0..num_commits {
+        let t = types[i % types.len()];
+        let s = scopes[i % scopes.len()];
+        let breaking = if i % 20 == 0 && i > 0 { "!" } else { "" };
+        let msg = format!("{t}({s}){breaking}: change {i}");
+
+        // Create a file change per commit
+        let file_name = format!("src/file_{i}.rs");
+        let file_path = dir.path().join(&file_name);
+        std::fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+        std::fs::write(&file_path, format!("// commit {i}\n")).unwrap();
+
+        let mut index = repo.index().unwrap();
+        index.add_path(std::path::Path::new(&file_name)).unwrap();
+        index.write().unwrap();
+        let tree_oid = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_oid).unwrap();
+
+        let oid = if let Some(parent) = parent_oid {
+            let parent_commit = repo.find_commit(parent).unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, &msg, &tree, &[&parent_commit])
+                .unwrap()
+        } else {
+            repo.commit(Some("HEAD"), &sig, &sig, &msg, &tree, &[])
+                .unwrap()
+        };
+
+        if i == tag_at {
+            let obj = repo.find_object(oid, None).unwrap();
+            repo.tag_lightweight("v1.0.0", &obj, false).unwrap();
+        }
+
+        parent_oid = Some(oid);
+    }
+
+    (dir, repo)
+}
+
+fn bench_git_operations(c: &mut Criterion) {
+    // Benchmark get_commits_since_last_tag with varying history sizes
+    for (label, total_commits, tag_position) in [
+        ("git_commits/100", 100, 0),
+        ("git_commits/1000", 1_000, 0),
+        ("git_commits/5000", 5_000, 0),
+    ] {
+        let (_dir, repo) = create_bench_repo(total_commits, tag_position);
+        c.bench_function(label, |b| {
+            b.iter(|| {
+                black_box(
+                    get_commits_since_last_tag(&repo, "v", OrphanedTagStrategy::Warn).unwrap(),
+                );
+            });
+        });
+    }
+
+    // Benchmark find_last_tag_name
+    for (label, total_commits, tag_position) in [
+        ("git_find_tag/100", 100, 50),
+        ("git_find_tag/1000", 1_000, 500),
+    ] {
+        let (_dir, repo) = create_bench_repo(total_commits, tag_position);
+        c.bench_function(label, |b| {
+            b.iter(|| {
+                black_box(find_last_tag_name(&repo, "v", OrphanedTagStrategy::Warn).unwrap());
+            });
+        });
+    }
+
+    // Benchmark collect_all_tags
+    {
+        let (_dir, repo) = create_bench_repo(100, 50);
+        c.bench_function("git_collect_tags/single_tag", |b| {
+            b.iter(|| {
+                black_box(collect_all_tags(&repo));
+            });
+        });
+    }
+
+    // Benchmark get_changed_files
+    for (label, total_commits) in [
+        ("git_changed_files/100", 100),
+        ("git_changed_files/1000", 1_000),
+    ] {
+        let (_dir, repo) = create_bench_repo(total_commits, 0);
+        c.bench_function(label, |b| {
+            b.iter(|| {
+                black_box(get_changed_files(&repo).unwrap());
+            });
+        });
+    }
+
+    // Benchmark get_changed_files_since_tag
+    for (label, total_commits, tag_position) in [
+        ("git_changed_since_tag/100_commits_50_since", 100, 50),
+        ("git_changed_since_tag/1000_commits_500_since", 1_000, 500),
+    ] {
+        let (_dir, repo) = create_bench_repo(total_commits, tag_position);
+        c.bench_function(label, |b| {
+            b.iter(|| {
+                black_box(
+                    get_changed_files_since_tag(&repo, "v", OrphanedTagStrategy::Warn).unwrap(),
+                );
+            });
+        });
+    }
+}
+
+fn bench_validate(c: &mut Criterion) {
+    // Benchmark config loading + validation (the local part of validate)
+    for (label, num_pkgs) in [
+        ("validate/single", 1),
+        ("validate/mono_50", 50),
+        ("validate/mono_100", 100),
+    ] {
+        c.bench_function(label, |b| {
+            let dir = TempDir::new().unwrap();
+            let config_path = dir.path().join(".ferrflow");
+            std::fs::write(&config_path, generate_config_json(num_pkgs)).unwrap();
+
+            // Create version files so validation passes
+            for i in 1..=num_pkgs {
+                let pkg_dir = dir.path().join(format!("packages/pkg-{i:03}"));
+                std::fs::create_dir_all(&pkg_dir).unwrap();
+                std::fs::write(
+                    pkg_dir.join("package.json"),
+                    r#"{"name":"pkg","version":"1.0.0"}"#,
+                )
+                .unwrap();
+            }
+
+            std::process::Command::new("git")
+                .args(["init", "-q"])
+                .current_dir(dir.path())
+                .output()
+                .unwrap();
+
+            b.iter(|| {
+                let config = Config::load(dir.path(), None).unwrap();
+                for pkg in &config.packages {
+                    for vf in &pkg.versioned_files {
+                        let handler = get_handler(&vf.format);
+                        black_box(handler.read_version(&dir.path().join(&vf.path)).unwrap());
+                    }
+                }
+            });
+        });
+    }
+}
+
+fn bench_full_check_flow(c: &mut Criterion) {
+    // Benchmark the complete check flow: config load + git log + commit parsing + bump determination
+    for (label, num_commits) in [
+        ("full_check_flow/100_commits", 100),
+        ("full_check_flow/1000_commits", 1_000),
+    ] {
+        let (_dir, repo) = create_bench_repo(num_commits, 0);
+
+        // Write a config into the repo dir
+        let config_content = generate_config_json(1);
+        std::fs::write(_dir.path().join(".ferrflow"), &config_content).unwrap();
+
+        // Create version file
+        std::fs::write(
+            _dir.path().join("packages/pkg-001/package.json"),
+            r#"{"name":"pkg-001","version":"1.0.0"}"#,
+        )
+        .unwrap();
+        std::fs::create_dir_all(_dir.path().join("packages/pkg-001")).unwrap();
+        std::fs::write(
+            _dir.path().join("packages/pkg-001/package.json"),
+            r#"{"name":"pkg-001","version":"1.0.0"}"#,
+        )
+        .unwrap();
+
+        c.bench_function(label, |b| {
+            b.iter(|| {
+                let config = Config::load(_dir.path(), None).unwrap();
+                let commits =
+                    get_commits_since_last_tag(&repo, "v", OrphanedTagStrategy::Warn).unwrap();
+                for commit in &commits {
+                    black_box(determine_bump(&commit.message));
+                }
+                black_box((&config, commits.len()));
+            });
+        });
+    }
+}
+
 criterion_group!(
     benches,
     bench_commit_parsing,
     bench_changelog,
     bench_version_files,
-    bench_config_loading
+    bench_config_loading,
+    bench_git_operations,
+    bench_validate,
+    bench_full_check_flow
 );
 criterion_main!(benches);

--- a/benchmarks/fixtures/definitions/mono-100-1k.json
+++ b/benchmarks/fixtures/definitions/mono-100-1k.json
@@ -1,0 +1,22 @@
+{
+  "meta": {
+    "name": "mono-100-1k",
+    "description": "100 packages, 1000 commits"
+  },
+  "generate": {
+    "packages": 100,
+    "commits": 1000
+  },
+  "tool_configs": {
+    "ferrflow": {
+      "ferrflow.json": "{}"
+    },
+    "semantic-release": {
+      ".releaserc.json": "{\"branches\":[\"main\"],\"plugins\":[\"@semantic-release/commit-analyzer\",\"@semantic-release/release-notes-generator\"]}"
+    },
+    "changesets": {
+      ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.1.1/schema.json\",\"changelog\":false,\"commit\":false,\"access\":\"restricted\",\"baseBranch\":\"main\"}",
+      "package.json": "{\"name\":\"benchmark-monorepo\",\"private\":true,\"workspaces\":[\"packages/*\"]}"
+    }
+  }
+}

--- a/benchmarks/fixtures/definitions/mono-50-5k.json
+++ b/benchmarks/fixtures/definitions/mono-50-5k.json
@@ -1,0 +1,22 @@
+{
+  "meta": {
+    "name": "mono-50-5k",
+    "description": "50 packages, 5000 commits — stress test git log parsing"
+  },
+  "generate": {
+    "packages": 50,
+    "commits": 5000
+  },
+  "tool_configs": {
+    "ferrflow": {
+      "ferrflow.json": "{}"
+    },
+    "semantic-release": {
+      ".releaserc.json": "{\"branches\":[\"main\"],\"plugins\":[\"@semantic-release/commit-analyzer\",\"@semantic-release/release-notes-generator\"]}"
+    },
+    "changesets": {
+      ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.1.1/schema.json\",\"changelog\":false,\"commit\":false,\"access\":\"restricted\",\"baseBranch\":\"main\"}",
+      "package.json": "{\"name\":\"benchmark-monorepo\",\"private\":true,\"workspaces\":[\"packages/*\"]}"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add micro-benchmarks for git operations (`get_commits_since_last_tag`, `find_last_tag_name`, `collect_all_tags`, `get_changed_files`, `get_changed_files_since_tag`) with varying repo sizes (100-5000 commits)
- Add `bench_validate` covering config load + version file reads for 1/50/100 packages
- Add `bench_full_check_flow` exercising the complete pipeline: config load → git log → commit parsing → bump determination
- Extend `bench_config_loading` with a 100-package case
- Add two new e2e benchmark fixture definitions: `mono-100-1k` (100 packages, 1000 commits) and `mono-50-5k` (50 packages, 5000 commits)

Closes FerrFlow-Org/Benchmarks#47