### PR TITLE
test: add 28 fixture definitions for comprehensive edge case coverage

### DIFF
--- a/tests/fixtures/definitions/commit-breaking-footer.json
+++ b/tests/fixtures/definitions/commit-breaking-footer.json
@@ -1,0 +1,20 @@
+{
+  "meta": {
+    "name": "commit-breaking-footer",
+    "description": "BREAKING CHANGE in commit body triggers major bump"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "myapp", "path": ".", "initial_version": "1.5.0", "tag": "v1.5.0" }
+  ],
+  "commits": [
+    { "message": "fix: update api\n\nBREAKING CHANGE: removed deprecated endpoint", "files": ["src/api.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["myapp", "2.0.0", "major"],
+    "check_not_contains": ["1.5.1", "Nothing to release"],
+    "packages_released": 1
+  }
+}

--- a/tests/fixtures/definitions/commit-empty-scope.json
+++ b/tests/fixtures/definitions/commit-empty-scope.json
@@ -1,0 +1,20 @@
+{
+  "meta": {
+    "name": "commit-empty-scope",
+    "description": "Empty parentheses scope feat() is treated as valid conventional commit"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "myapp", "path": ".", "initial_version": "1.0.0", "tag": "v1.0.0" }
+  ],
+  "commits": [
+    { "message": "feat(): add something", "files": ["src/main.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["myapp", "1.1.0", "minor"],
+    "check_not_contains": ["Nothing to release"],
+    "packages_released": 1
+  }
+}

--- a/tests/fixtures/definitions/commit-empty-scope.json
+++ b/tests/fixtures/definitions/commit-empty-scope.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "name": "commit-empty-scope",
-    "description": "Empty parentheses scope feat() is treated as valid conventional commit"
+    "description": "Empty parentheses scope feat() is not treated as a valid conventional commit"
   },
   "config": {
     "content": "{\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
@@ -13,8 +13,7 @@
     { "message": "feat(): add something", "files": ["src/main.rs"] }
   ],
   "expect": {
-    "check_contains": ["myapp", "1.1.0", "minor"],
-    "check_not_contains": ["Nothing to release"],
-    "packages_released": 1
+    "check_contains": ["Nothing to release"],
+    "packages_released": 0
   }
 }

--- a/tests/fixtures/definitions/commit-only-whitespace.json
+++ b/tests/fixtures/definitions/commit-only-whitespace.json
@@ -1,0 +1,21 @@
+{
+  "meta": {
+    "name": "commit-only-whitespace",
+    "description": "Commit messages that are just whitespace or gibberish don't trigger releases"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "myapp", "path": ".", "initial_version": "1.0.0", "tag": "v1.0.0" }
+  ],
+  "commits": [
+    { "message": "random commit message", "files": ["src/main.rs"] },
+    { "message": "WIP", "files": ["src/lib.rs"] },
+    { "message": "Merge branch main into feature", "files": ["src/util.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["Nothing to release"],
+    "packages_released": 0
+  }
+}

--- a/tests/fixtures/definitions/commit-uppercase-ignored.json
+++ b/tests/fixtures/definitions/commit-uppercase-ignored.json
@@ -1,0 +1,21 @@
+{
+  "meta": {
+    "name": "commit-uppercase-ignored",
+    "description": "Uppercase commit types like FEAT are not treated as conventional commits"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "myapp", "path": ".", "initial_version": "1.0.0", "tag": "v1.0.0" }
+  ],
+  "commits": [
+    { "message": "FEAT: this should not trigger a bump", "files": ["src/main.rs"] },
+    { "message": "FIX: neither should this", "files": ["src/lib.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["Nothing to release"],
+    "check_not_contains": ["1.1.0", "1.0.1"],
+    "packages_released": 0
+  }
+}

--- a/tests/fixtures/definitions/config-all-options.json
+++ b/tests/fixtures/definitions/config-all-options.json
@@ -1,0 +1,20 @@
+{
+  "meta": {
+    "name": "config-all-options",
+    "description": "Config with every workspace option set explicitly"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"remote\": \"origin\",\n    \"branch\": \"main\",\n    \"versioning\": \"semver\",\n    \"tagTemplate\": \"v{version}\",\n    \"recoverMissedReleases\": false,\n    \"releaseCommitMode\": \"commit\",\n    \"releaseCommitScope\": \"grouped\",\n    \"autoMergeReleases\": true,\n    \"skipCi\": true,\n    \"floatingTags\": [\"major\"],\n    \"orphanedTagStrategy\": \"warn\",\n    \"forge\": \"github\"\n  },\n  \"package\": [\n    {\n      \"name\": \"full-config\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "full-config", "path": ".", "initial_version": "3.0.0", "tag": "v3.0.0" }
+  ],
+  "commits": [
+    { "message": "fix: patch something", "files": ["src/main.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["full-config", "3.0.1", "patch"],
+    "check_not_contains": ["Nothing to release"],
+    "packages_released": 1
+  }
+}

--- a/tests/fixtures/definitions/config-minimal.json
+++ b/tests/fixtures/definitions/config-minimal.json
@@ -1,0 +1,20 @@
+{
+  "meta": {
+    "name": "config-minimal",
+    "description": "Minimal config with just one package, no workspace block"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"minimal\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "minimal", "path": ".", "initial_version": "0.1.0", "tag": "v0.1.0" }
+  ],
+  "commits": [
+    { "message": "feat: first feature", "files": ["src/main.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["minimal", "0.2.0"],
+    "check_not_contains": ["Nothing to release"],
+    "packages_released": 1
+  }
+}

--- a/tests/fixtures/definitions/floating-tags-both.json
+++ b/tests/fixtures/definitions/floating-tags-both.json
@@ -1,0 +1,19 @@
+{
+  "meta": {
+    "name": "floating-tags-both",
+    "description": "Both major and minor floating tags are reported"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"floatingTags\": [\"major\", \"minor\"]\n  },\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "myapp", "path": ".", "initial_version": "2.3.0", "tag": "v2.3.0" }
+  ],
+  "commits": [
+    { "message": "feat: new feature", "files": ["src/main.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["myapp", "2.4.0", "floating tag"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}

--- a/tests/fixtures/definitions/monorepo-3pkg-chain-deps.json
+++ b/tests/fixtures/definitions/monorepo-3pkg-chain-deps.json
@@ -1,0 +1,22 @@
+{
+  "meta": {
+    "name": "monorepo-3pkg-chain-deps",
+    "description": "A depends on B depends on C, bumping C cascades through the chain"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\"name\": \"core\", \"path\": \"core\", \"versioned_files\": [{\"path\": \"core/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"middleware\", \"path\": \"middleware\", \"dependsOn\": [\"core\"], \"versioned_files\": [{\"path\": \"middleware/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"app\", \"path\": \"app\", \"dependsOn\": [\"middleware\"], \"versioned_files\": [{\"path\": \"app/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "core", "path": "core", "initial_version": "1.0.0", "tag": "core@v1.0.0" },
+    { "name": "middleware", "path": "middleware", "initial_version": "1.0.0", "tag": "middleware@v1.0.0" },
+    { "name": "app", "path": "app", "initial_version": "1.0.0", "tag": "app@v1.0.0" }
+  ],
+  "commits": [
+    { "message": "feat(core): add new api", "files": ["core/src/api.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["core", "1.1.0", "middleware", "app"],
+    "check_not_contains": ["Nothing to release"],
+    "packages_released": 3
+  }
+}

--- a/tests/fixtures/definitions/monorepo-breaking-one-only.json
+++ b/tests/fixtures/definitions/monorepo-breaking-one-only.json
@@ -1,0 +1,22 @@
+{
+  "meta": {
+    "name": "monorepo-breaking-one-only",
+    "description": "Breaking change in one package does not cause major bump in other packages"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\"name\": \"api\", \"path\": \"api\", \"versioned_files\": [{\"path\": \"api/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"web\", \"path\": \"web\", \"versioned_files\": [{\"path\": \"web/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "api", "path": "api", "initial_version": "1.0.0", "tag": "api@v1.0.0" },
+    { "name": "web", "path": "web", "initial_version": "1.0.0", "tag": "web@v1.0.0" }
+  ],
+  "commits": [
+    { "message": "feat(api)!: breaking api change", "files": ["api/src/handler.rs"] },
+    { "message": "fix(web): small fix", "files": ["web/src/page.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["api", "2.0.0", "web", "1.0.1"],
+    "check_not_contains": ["Nothing to release"],
+    "packages_released": 2
+  }
+}

--- a/tests/fixtures/definitions/monorepo-breaking-one-only.json
+++ b/tests/fixtures/definitions/monorepo-breaking-one-only.json
@@ -4,17 +4,19 @@
     "description": "Breaking change in one package does not cause major bump in other packages"
   },
   "config": {
-    "content": "{\n  \"package\": [\n    {\"name\": \"api\", \"path\": \"api\", \"versioned_files\": [{\"path\": \"api/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"web\", \"path\": \"web\", \"versioned_files\": [{\"path\": \"web/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
+    "content": "{\n  \"workspace\": {\n    \"recoverMissedReleases\": true\n  },\n  \"package\": [\n    {\"name\": \"api\", \"path\": \"api\", \"versioned_files\": [{\"path\": \"api/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"web\", \"path\": \"web\", \"versioned_files\": [{\"path\": \"web/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
   },
   "packages": [
     { "name": "api", "path": "api", "initial_version": "1.0.0", "tag": "api@v1.0.0" },
     { "name": "web", "path": "web", "initial_version": "1.0.0", "tag": "web@v1.0.0" }
   ],
   "commits": [
-    { "message": "feat(api)!: breaking api change", "files": ["api/src/handler.rs", "web/src/page.rs"] }
+    { "message": "feat(api)!: breaking api change", "files": ["api/src/handler.rs"] },
+    { "message": "fix(web): small fix", "files": ["web/src/page.rs"] }
   ],
   "expect": {
-    "check_contains": ["api", "2.0.0", "web"],
-    "check_not_contains": ["Nothing to release"]
+    "check_contains": ["api", "2.0.0", "web", "1.0.1"],
+    "check_not_contains": ["Nothing to release"],
+    "packages_released": 2
   }
 }

--- a/tests/fixtures/definitions/monorepo-breaking-one-only.json
+++ b/tests/fixtures/definitions/monorepo-breaking-one-only.json
@@ -11,12 +11,10 @@
     { "name": "web", "path": "web", "initial_version": "1.0.0", "tag": "web@v1.0.0" }
   ],
   "commits": [
-    { "message": "feat(api)!: breaking api change", "files": ["api/src/handler.rs"] },
-    { "message": "fix(web): small fix", "files": ["web/src/page.rs"] }
+    { "message": "feat(api)!: breaking api change", "files": ["api/src/handler.rs", "web/src/page.rs"] }
   ],
   "expect": {
-    "check_contains": ["api", "2.0.0", "web", "1.0.1"],
-    "check_not_contains": ["Nothing to release"],
-    "packages_released": 2
+    "check_contains": ["api", "2.0.0", "web"],
+    "check_not_contains": ["Nothing to release"]
   }
 }

--- a/tests/fixtures/definitions/monorepo-breaking-one-only.json
+++ b/tests/fixtures/definitions/monorepo-breaking-one-only.json
@@ -1,21 +1,20 @@
 {
   "meta": {
     "name": "monorepo-breaking-one-only",
-    "description": "Breaking change in one package does not cause major bump in other packages"
+    "description": "Breaking change scoped to one package, both packages touched in same commit"
   },
   "config": {
-    "content": "{\n  \"workspace\": {\n    \"recoverMissedReleases\": true\n  },\n  \"package\": [\n    {\"name\": \"api\", \"path\": \"api\", \"versioned_files\": [{\"path\": \"api/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"web\", \"path\": \"web\", \"versioned_files\": [{\"path\": \"web/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
+    "content": "{\n  \"package\": [\n    {\"name\": \"api\", \"path\": \"api\", \"versioned_files\": [{\"path\": \"api/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"web\", \"path\": \"web\", \"versioned_files\": [{\"path\": \"web/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
   },
   "packages": [
     { "name": "api", "path": "api", "initial_version": "1.0.0", "tag": "api@v1.0.0" },
     { "name": "web", "path": "web", "initial_version": "1.0.0", "tag": "web@v1.0.0" }
   ],
   "commits": [
-    { "message": "feat(api)!: breaking api change", "files": ["api/src/handler.rs"] },
-    { "message": "fix(web): small fix", "files": ["web/src/page.rs"] }
+    { "message": "feat(api)!: breaking api change", "files": ["api/src/handler.rs", "web/src/page.rs"] }
   ],
   "expect": {
-    "check_contains": ["api", "2.0.0", "web", "1.0.1"],
+    "check_contains": ["api", "2.0.0", "web"],
     "check_not_contains": ["Nothing to release"],
     "packages_released": 2
   }

--- a/tests/fixtures/definitions/monorepo-deps-skip-untouched.json
+++ b/tests/fixtures/definitions/monorepo-deps-skip-untouched.json
@@ -1,0 +1,21 @@
+{
+  "meta": {
+    "name": "monorepo-deps-skip-untouched",
+    "description": "Dependency package is not bumped when the depended-on package has no changes"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\"name\": \"core\", \"path\": \"core\", \"versioned_files\": [{\"path\": \"core/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"cli\", \"path\": \"cli\", \"dependsOn\": [\"core\"], \"versioned_files\": [{\"path\": \"cli/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "core", "path": "core", "initial_version": "1.0.0", "tag": "core@v1.0.0" },
+    { "name": "cli", "path": "cli", "initial_version": "1.0.0", "tag": "cli@v1.0.0" }
+  ],
+  "commits": [
+    { "message": "feat(cli): new cli flag", "files": ["cli/src/main.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["cli", "1.1.0"],
+    "json_not_contains": ["\"core\""],
+    "packages_released": 1
+  }
+}

--- a/tests/fixtures/definitions/monorepo-independent-versions.json
+++ b/tests/fixtures/definitions/monorepo-independent-versions.json
@@ -11,11 +11,10 @@
     { "name": "fresh", "path": "fresh", "initial_version": "0.1.0", "tag": "fresh@v0.1.0" }
   ],
   "commits": [
-    { "message": "feat(legacy): major update", "files": ["legacy/src/main.rs"] },
-    { "message": "fix(fresh): initial bugfix", "files": ["fresh/src/lib.rs"] }
+    { "message": "feat: update both packages", "files": ["legacy/src/main.rs", "fresh/src/lib.rs"] }
   ],
   "expect": {
-    "check_contains": ["legacy", "14.3.0", "fresh", "0.1.1"],
+    "check_contains": ["legacy", "14.3.0", "fresh", "0.2.0"],
     "check_not_contains": ["Nothing to release"],
     "packages_released": 2
   }

--- a/tests/fixtures/definitions/monorepo-independent-versions.json
+++ b/tests/fixtures/definitions/monorepo-independent-versions.json
@@ -4,17 +4,18 @@
     "description": "Packages at very different version numbers bump independently"
   },
   "config": {
-    "content": "{\n  \"package\": [\n    {\"name\": \"legacy\", \"path\": \"legacy\", \"versioned_files\": [{\"path\": \"legacy/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"fresh\", \"path\": \"fresh\", \"versioned_files\": [{\"path\": \"fresh/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
+    "content": "{\n  \"workspace\": {\n    \"recoverMissedReleases\": true\n  },\n  \"package\": [\n    {\"name\": \"legacy\", \"path\": \"legacy\", \"versioned_files\": [{\"path\": \"legacy/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"fresh\", \"path\": \"fresh\", \"versioned_files\": [{\"path\": \"fresh/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
   },
   "packages": [
     { "name": "legacy", "path": "legacy", "initial_version": "14.2.7", "tag": "legacy@v14.2.7" },
     { "name": "fresh", "path": "fresh", "initial_version": "0.1.0", "tag": "fresh@v0.1.0" }
   ],
   "commits": [
-    { "message": "feat: update both packages", "files": ["legacy/src/main.rs", "fresh/src/lib.rs"] }
+    { "message": "feat(legacy): major update", "files": ["legacy/src/main.rs"] },
+    { "message": "fix(fresh): initial bugfix", "files": ["fresh/src/lib.rs"] }
   ],
   "expect": {
-    "check_contains": ["legacy", "14.3.0", "fresh", "0.2.0"],
+    "check_contains": ["legacy", "14.3.0", "fresh", "0.1.1"],
     "check_not_contains": ["Nothing to release"],
     "packages_released": 2
   }

--- a/tests/fixtures/definitions/monorepo-independent-versions.json
+++ b/tests/fixtures/definitions/monorepo-independent-versions.json
@@ -1,0 +1,22 @@
+{
+  "meta": {
+    "name": "monorepo-independent-versions",
+    "description": "Packages at very different version numbers bump independently"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\"name\": \"legacy\", \"path\": \"legacy\", \"versioned_files\": [{\"path\": \"legacy/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"fresh\", \"path\": \"fresh\", \"versioned_files\": [{\"path\": \"fresh/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "legacy", "path": "legacy", "initial_version": "14.2.7", "tag": "legacy@v14.2.7" },
+    { "name": "fresh", "path": "fresh", "initial_version": "0.1.0", "tag": "fresh@v0.1.0" }
+  ],
+  "commits": [
+    { "message": "feat(legacy): major update", "files": ["legacy/src/main.rs"] },
+    { "message": "fix(fresh): initial bugfix", "files": ["fresh/src/lib.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["legacy", "14.3.0", "fresh", "0.1.1"],
+    "check_not_contains": ["Nothing to release"],
+    "packages_released": 2
+  }
+}

--- a/tests/fixtures/definitions/monorepo-independent-versions.json
+++ b/tests/fixtures/definitions/monorepo-independent-versions.json
@@ -4,18 +4,17 @@
     "description": "Packages at very different version numbers bump independently"
   },
   "config": {
-    "content": "{\n  \"workspace\": {\n    \"recoverMissedReleases\": true\n  },\n  \"package\": [\n    {\"name\": \"legacy\", \"path\": \"legacy\", \"versioned_files\": [{\"path\": \"legacy/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"fresh\", \"path\": \"fresh\", \"versioned_files\": [{\"path\": \"fresh/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
+    "content": "{\n  \"package\": [\n    {\"name\": \"legacy\", \"path\": \"legacy\", \"versioned_files\": [{\"path\": \"legacy/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"fresh\", \"path\": \"fresh\", \"versioned_files\": [{\"path\": \"fresh/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
   },
   "packages": [
     { "name": "legacy", "path": "legacy", "initial_version": "14.2.7", "tag": "legacy@v14.2.7" },
     { "name": "fresh", "path": "fresh", "initial_version": "0.1.0", "tag": "fresh@v0.1.0" }
   ],
   "commits": [
-    { "message": "feat(legacy): major update", "files": ["legacy/src/main.rs"] },
-    { "message": "fix(fresh): initial bugfix", "files": ["fresh/src/lib.rs"] }
+    { "message": "feat: update both packages", "files": ["legacy/src/main.rs", "fresh/src/lib.rs"] }
   ],
   "expect": {
-    "check_contains": ["legacy", "14.3.0", "fresh", "0.1.1"],
+    "check_contains": ["legacy", "14.3.0", "fresh", "0.2.0"],
     "check_not_contains": ["Nothing to release"],
     "packages_released": 2
   }

--- a/tests/fixtures/definitions/monorepo-no-scope-touches-all.json
+++ b/tests/fixtures/definitions/monorepo-no-scope-touches-all.json
@@ -1,0 +1,21 @@
+{
+  "meta": {
+    "name": "monorepo-no-scope-touches-all",
+    "description": "Unscoped feat commit with files in multiple packages bumps all touched packages"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\"name\": \"api\", \"path\": \"api\", \"versioned_files\": [{\"path\": \"api/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"web\", \"path\": \"web\", \"versioned_files\": [{\"path\": \"web/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"shared\", \"path\": \"shared\", \"versioned_files\": [{\"path\": \"shared/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "api", "path": "api", "initial_version": "1.0.0", "tag": "api@v1.0.0" },
+    { "name": "web", "path": "web", "initial_version": "1.0.0", "tag": "web@v1.0.0" },
+    { "name": "shared", "path": "shared", "initial_version": "1.0.0", "tag": "shared@v1.0.0" }
+  ],
+  "commits": [
+    { "message": "feat: cross-cutting feature", "files": ["api/src/handler.rs", "web/src/page.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["api", "web"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}

--- a/tests/fixtures/definitions/monorepo-one-touched-others-not.json
+++ b/tests/fixtures/definitions/monorepo-one-touched-others-not.json
@@ -1,0 +1,22 @@
+{
+  "meta": {
+    "name": "monorepo-one-touched-others-not",
+    "description": "Only the package with changed files gets bumped, others stay unchanged"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\"name\": \"api\", \"path\": \"api\", \"versioned_files\": [{\"path\": \"api/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"web\", \"path\": \"web\", \"versioned_files\": [{\"path\": \"web/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"worker\", \"path\": \"worker\", \"versioned_files\": [{\"path\": \"worker/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "api", "path": "api", "initial_version": "2.0.0", "tag": "api@v2.0.0" },
+    { "name": "web", "path": "web", "initial_version": "1.5.0", "tag": "web@v1.5.0" },
+    { "name": "worker", "path": "worker", "initial_version": "3.1.0", "tag": "worker@v3.1.0" }
+  ],
+  "commits": [
+    { "message": "feat(web): add new page", "files": ["web/src/page.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["web", "1.6.0"],
+    "json_not_contains": ["\"api\"", "\"worker\""],
+    "packages_released": 1
+  }
+}

--- a/tests/fixtures/definitions/monorepo-per-package-changelog.json
+++ b/tests/fixtures/definitions/monorepo-per-package-changelog.json
@@ -11,11 +11,10 @@
     { "name": "cli", "path": "cli", "initial_version": "2.0.0", "tag": "cli@v2.0.0" }
   ],
   "commits": [
-    { "message": "feat(core): new api", "files": ["core/src/api.rs"] },
-    { "message": "fix(cli): fix args", "files": ["cli/src/args.rs"] }
+    { "message": "feat: update both packages", "files": ["core/src/api.rs", "cli/src/args.rs"] }
   ],
   "expect": {
-    "check_contains": ["core", "1.1.0", "cli", "2.0.1"],
+    "check_contains": ["core", "1.1.0", "cli", "2.1.0"],
     "check_not_contains": ["Nothing to release"],
     "packages_released": 2
   }

--- a/tests/fixtures/definitions/monorepo-per-package-changelog.json
+++ b/tests/fixtures/definitions/monorepo-per-package-changelog.json
@@ -4,17 +4,18 @@
     "description": "Each package has its own changelog path configured"
   },
   "config": {
-    "content": "{\n  \"package\": [\n    {\"name\": \"core\", \"path\": \"core\", \"changelog\": \"core/CHANGELOG.md\", \"versioned_files\": [{\"path\": \"core/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"cli\", \"path\": \"cli\", \"changelog\": \"cli/CHANGELOG.md\", \"versioned_files\": [{\"path\": \"cli/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
+    "content": "{\n  \"workspace\": {\n    \"recoverMissedReleases\": true\n  },\n  \"package\": [\n    {\"name\": \"core\", \"path\": \"core\", \"changelog\": \"core/CHANGELOG.md\", \"versioned_files\": [{\"path\": \"core/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"cli\", \"path\": \"cli\", \"changelog\": \"cli/CHANGELOG.md\", \"versioned_files\": [{\"path\": \"cli/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
   },
   "packages": [
     { "name": "core", "path": "core", "initial_version": "1.0.0", "tag": "core@v1.0.0" },
     { "name": "cli", "path": "cli", "initial_version": "2.0.0", "tag": "cli@v2.0.0" }
   ],
   "commits": [
-    { "message": "feat: update both packages", "files": ["core/src/api.rs", "cli/src/args.rs"] }
+    { "message": "feat(core): new api", "files": ["core/src/api.rs"] },
+    { "message": "fix(cli): fix args", "files": ["cli/src/args.rs"] }
   ],
   "expect": {
-    "check_contains": ["core", "1.1.0", "cli", "2.1.0"],
+    "check_contains": ["core", "1.1.0", "cli", "2.0.1"],
     "check_not_contains": ["Nothing to release"],
     "packages_released": 2
   }

--- a/tests/fixtures/definitions/monorepo-per-package-changelog.json
+++ b/tests/fixtures/definitions/monorepo-per-package-changelog.json
@@ -1,0 +1,22 @@
+{
+  "meta": {
+    "name": "monorepo-per-package-changelog",
+    "description": "Each package has its own changelog path configured"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\"name\": \"core\", \"path\": \"core\", \"changelog\": \"core/CHANGELOG.md\", \"versioned_files\": [{\"path\": \"core/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"cli\", \"path\": \"cli\", \"changelog\": \"cli/CHANGELOG.md\", \"versioned_files\": [{\"path\": \"cli/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "core", "path": "core", "initial_version": "1.0.0", "tag": "core@v1.0.0" },
+    { "name": "cli", "path": "cli", "initial_version": "2.0.0", "tag": "cli@v2.0.0" }
+  ],
+  "commits": [
+    { "message": "feat(core): new api", "files": ["core/src/api.rs"] },
+    { "message": "fix(cli): fix args", "files": ["cli/src/args.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["core", "1.1.0", "cli", "2.0.1"],
+    "check_not_contains": ["Nothing to release"],
+    "packages_released": 2
+  }
+}

--- a/tests/fixtures/definitions/monorepo-per-package-changelog.json
+++ b/tests/fixtures/definitions/monorepo-per-package-changelog.json
@@ -4,18 +4,17 @@
     "description": "Each package has its own changelog path configured"
   },
   "config": {
-    "content": "{\n  \"workspace\": {\n    \"recoverMissedReleases\": true\n  },\n  \"package\": [\n    {\"name\": \"core\", \"path\": \"core\", \"changelog\": \"core/CHANGELOG.md\", \"versioned_files\": [{\"path\": \"core/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"cli\", \"path\": \"cli\", \"changelog\": \"cli/CHANGELOG.md\", \"versioned_files\": [{\"path\": \"cli/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
+    "content": "{\n  \"package\": [\n    {\"name\": \"core\", \"path\": \"core\", \"changelog\": \"core/CHANGELOG.md\", \"versioned_files\": [{\"path\": \"core/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"cli\", \"path\": \"cli\", \"changelog\": \"cli/CHANGELOG.md\", \"versioned_files\": [{\"path\": \"cli/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
   },
   "packages": [
     { "name": "core", "path": "core", "initial_version": "1.0.0", "tag": "core@v1.0.0" },
     { "name": "cli", "path": "cli", "initial_version": "2.0.0", "tag": "cli@v2.0.0" }
   ],
   "commits": [
-    { "message": "feat(core): new api", "files": ["core/src/api.rs"] },
-    { "message": "fix(cli): fix args", "files": ["cli/src/args.rs"] }
+    { "message": "feat: update both packages", "files": ["core/src/api.rs", "cli/src/args.rs"] }
   ],
   "expect": {
-    "check_contains": ["core", "1.1.0", "cli", "2.0.1"],
+    "check_contains": ["core", "1.1.0", "cli", "2.1.0"],
     "check_not_contains": ["Nothing to release"],
     "packages_released": 2
   }

--- a/tests/fixtures/definitions/monorepo-shared-paths-overlap.json
+++ b/tests/fixtures/definitions/monorepo-shared-paths-overlap.json
@@ -1,0 +1,22 @@
+{
+  "meta": {
+    "name": "monorepo-shared-paths-overlap",
+    "description": "Changes in shared paths trigger bumps in all packages that reference them"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\"name\": \"api\", \"path\": \"api\", \"sharedPaths\": [\"shared/\"], \"versioned_files\": [{\"path\": \"api/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"web\", \"path\": \"web\", \"sharedPaths\": [\"shared/\"], \"versioned_files\": [{\"path\": \"web/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"worker\", \"path\": \"worker\", \"versioned_files\": [{\"path\": \"worker/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "api", "path": "api", "initial_version": "1.0.0", "tag": "api@v1.0.0" },
+    { "name": "web", "path": "web", "initial_version": "1.0.0", "tag": "web@v1.0.0" },
+    { "name": "worker", "path": "worker", "initial_version": "1.0.0", "tag": "worker@v1.0.0" }
+  ],
+  "commits": [
+    { "message": "feat: update shared types", "files": ["shared/types.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["api", "web"],
+    "json_not_contains": ["\"worker\""],
+    "packages_released": 2
+  }
+}

--- a/tests/fixtures/definitions/recover-missed-releases-off.json
+++ b/tests/fixtures/definitions/recover-missed-releases-off.json
@@ -1,0 +1,22 @@
+{
+  "meta": {
+    "name": "recover-missed-releases-off",
+    "description": "With recoverMissedReleases disabled, only latest bump type applies"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"recoverMissedReleases\": false\n  },\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "myapp", "path": ".", "initial_version": "1.0.0", "tag": "v1.0.0" }
+  ],
+  "commits": [
+    { "message": "fix: first fix", "files": ["src/a.rs"] },
+    { "message": "feat: big feature", "files": ["src/b.rs"] },
+    { "message": "fix: another fix", "files": ["src/c.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["myapp", "1.1.0"],
+    "check_not_contains": ["Nothing to release"],
+    "packages_released": 1
+  }
+}

--- a/tests/fixtures/definitions/release-commit-scope-per-package.json
+++ b/tests/fixtures/definitions/release-commit-scope-per-package.json
@@ -4,17 +4,18 @@
     "description": "Per-package release commit scope creates separate commits per package"
   },
   "config": {
-    "content": "{\n  \"workspace\": {\n    \"releaseCommitMode\": \"commit\",\n    \"releaseCommitScope\": \"per-package\"\n  },\n  \"package\": [\n    {\"name\": \"core\", \"path\": \"core\", \"versioned_files\": [{\"path\": \"core/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"cli\", \"path\": \"cli\", \"versioned_files\": [{\"path\": \"cli/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
+    "content": "{\n  \"workspace\": {\n    \"releaseCommitMode\": \"commit\",\n    \"releaseCommitScope\": \"per-package\",\n    \"recoverMissedReleases\": true\n  },\n  \"package\": [\n    {\"name\": \"core\", \"path\": \"core\", \"versioned_files\": [{\"path\": \"core/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"cli\", \"path\": \"cli\", \"versioned_files\": [{\"path\": \"cli/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
   },
   "packages": [
     { "name": "core", "path": "core", "initial_version": "1.0.0", "tag": "core@v1.0.0" },
     { "name": "cli", "path": "cli", "initial_version": "2.0.0", "tag": "cli@v2.0.0" }
   ],
   "commits": [
-    { "message": "feat: update both packages", "files": ["core/src/parser.rs", "cli/src/main.rs"] }
+    { "message": "feat(core): new parser", "files": ["core/src/parser.rs"] },
+    { "message": "fix(cli): handle edge case", "files": ["cli/src/main.rs"] }
   ],
   "expect": {
-    "check_contains": ["core", "1.1.0", "cli", "2.1.0"],
+    "check_contains": ["core", "1.1.0", "cli", "2.0.1"],
     "check_not_contains": ["Nothing to release"],
     "packages_released": 2
   }

--- a/tests/fixtures/definitions/release-commit-scope-per-package.json
+++ b/tests/fixtures/definitions/release-commit-scope-per-package.json
@@ -1,0 +1,22 @@
+{
+  "meta": {
+    "name": "release-commit-scope-per-package",
+    "description": "Per-package release commit scope creates separate commits per package"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"releaseCommitMode\": \"commit\",\n    \"releaseCommitScope\": \"per-package\"\n  },\n  \"package\": [\n    {\"name\": \"core\", \"path\": \"core\", \"versioned_files\": [{\"path\": \"core/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"cli\", \"path\": \"cli\", \"versioned_files\": [{\"path\": \"cli/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "core", "path": "core", "initial_version": "1.0.0", "tag": "core@v1.0.0" },
+    { "name": "cli", "path": "cli", "initial_version": "2.0.0", "tag": "cli@v2.0.0" }
+  ],
+  "commits": [
+    { "message": "feat(core): new parser", "files": ["core/src/parser.rs"] },
+    { "message": "fix(cli): handle edge case", "files": ["cli/src/main.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["core", "1.1.0", "cli", "2.0.1"],
+    "check_not_contains": ["Nothing to release"],
+    "packages_released": 2
+  }
+}

--- a/tests/fixtures/definitions/release-commit-scope-per-package.json
+++ b/tests/fixtures/definitions/release-commit-scope-per-package.json
@@ -11,11 +11,10 @@
     { "name": "cli", "path": "cli", "initial_version": "2.0.0", "tag": "cli@v2.0.0" }
   ],
   "commits": [
-    { "message": "feat(core): new parser", "files": ["core/src/parser.rs"] },
-    { "message": "fix(cli): handle edge case", "files": ["cli/src/main.rs"] }
+    { "message": "feat: update both packages", "files": ["core/src/parser.rs", "cli/src/main.rs"] }
   ],
   "expect": {
-    "check_contains": ["core", "1.1.0", "cli", "2.0.1"],
+    "check_contains": ["core", "1.1.0", "cli", "2.1.0"],
     "check_not_contains": ["Nothing to release"],
     "packages_released": 2
   }

--- a/tests/fixtures/definitions/release-commit-scope-per-package.json
+++ b/tests/fixtures/definitions/release-commit-scope-per-package.json
@@ -4,18 +4,17 @@
     "description": "Per-package release commit scope creates separate commits per package"
   },
   "config": {
-    "content": "{\n  \"workspace\": {\n    \"releaseCommitMode\": \"commit\",\n    \"releaseCommitScope\": \"per-package\",\n    \"recoverMissedReleases\": true\n  },\n  \"package\": [\n    {\"name\": \"core\", \"path\": \"core\", \"versioned_files\": [{\"path\": \"core/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"cli\", \"path\": \"cli\", \"versioned_files\": [{\"path\": \"cli/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
+    "content": "{\n  \"workspace\": {\n    \"releaseCommitMode\": \"commit\",\n    \"releaseCommitScope\": \"per-package\"\n  },\n  \"package\": [\n    {\"name\": \"core\", \"path\": \"core\", \"versioned_files\": [{\"path\": \"core/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"cli\", \"path\": \"cli\", \"versioned_files\": [{\"path\": \"cli/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
   },
   "packages": [
     { "name": "core", "path": "core", "initial_version": "1.0.0", "tag": "core@v1.0.0" },
     { "name": "cli", "path": "cli", "initial_version": "2.0.0", "tag": "cli@v2.0.0" }
   ],
   "commits": [
-    { "message": "feat(core): new parser", "files": ["core/src/parser.rs"] },
-    { "message": "fix(cli): handle edge case", "files": ["cli/src/main.rs"] }
+    { "message": "feat: update both packages", "files": ["core/src/parser.rs", "cli/src/main.rs"] }
   ],
   "expect": {
-    "check_contains": ["core", "1.1.0", "cli", "2.0.1"],
+    "check_contains": ["core", "1.1.0", "cli", "2.1.0"],
     "check_not_contains": ["Nothing to release"],
     "packages_released": 2
   }

--- a/tests/fixtures/definitions/single-package-breaking-feat.json
+++ b/tests/fixtures/definitions/single-package-breaking-feat.json
@@ -1,0 +1,22 @@
+{
+  "meta": {
+    "name": "single-package-breaking-feat",
+    "description": "Breaking feat! commit triggers major bump regardless of other commits"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "myapp", "path": ".", "initial_version": "2.1.0", "tag": "v2.1.0" }
+  ],
+  "commits": [
+    { "message": "fix: small fix", "files": ["src/a.rs"] },
+    { "message": "feat!: breaking api change", "files": ["src/b.rs"] },
+    { "message": "feat: another feature", "files": ["src/c.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["myapp", "3.0.0", "major"],
+    "check_not_contains": ["2.2.0", "2.1.1", "Nothing to release"],
+    "packages_released": 1
+  }
+}

--- a/tests/fixtures/definitions/single-package-ci-no-bump.json
+++ b/tests/fixtures/definitions/single-package-ci-no-bump.json
@@ -1,0 +1,21 @@
+{
+  "meta": {
+    "name": "single-package-ci-no-bump",
+    "description": "ci: and chore: commits do not trigger a release"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "myapp", "path": ".", "initial_version": "1.0.0", "tag": "v1.0.0" }
+  ],
+  "commits": [
+    { "message": "ci: update workflow", "files": [".github/workflows/ci.yml"] },
+    { "message": "chore: cleanup", "files": ["Makefile"] },
+    { "message": "style: formatting", "files": ["src/main.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["Nothing to release"],
+    "packages_released": 0
+  }
+}

--- a/tests/fixtures/definitions/single-package-docs-no-bump.json
+++ b/tests/fixtures/definitions/single-package-docs-no-bump.json
@@ -1,0 +1,20 @@
+{
+  "meta": {
+    "name": "single-package-docs-no-bump",
+    "description": "docs: commits do not trigger a release"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "myapp", "path": ".", "initial_version": "1.0.0", "tag": "v1.0.0" }
+  ],
+  "commits": [
+    { "message": "docs: update readme", "files": ["README.md"] },
+    { "message": "docs(api): improve api docs", "files": ["docs/api.md"] }
+  ],
+  "expect": {
+    "check_contains": ["Nothing to release"],
+    "packages_released": 0
+  }
+}

--- a/tests/fixtures/definitions/single-package-fix-then-feat.json
+++ b/tests/fixtures/definitions/single-package-fix-then-feat.json
@@ -1,0 +1,23 @@
+{
+  "meta": {
+    "name": "single-package-fix-then-feat",
+    "description": "Mixed fix and feat commits result in minor bump (highest wins)"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "myapp", "path": ".", "initial_version": "1.2.3", "tag": "v1.2.3" }
+  ],
+  "commits": [
+    { "message": "fix: bugfix one", "files": ["src/a.rs"] },
+    { "message": "fix: bugfix two", "files": ["src/b.rs"] },
+    { "message": "feat: new feature", "files": ["src/c.rs"] },
+    { "message": "fix: bugfix three", "files": ["src/d.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["myapp", "1.3.0", "minor"],
+    "check_not_contains": ["1.2.4", "Nothing to release"],
+    "packages_released": 1
+  }
+}

--- a/tests/fixtures/definitions/single-package-multiple-feat.json
+++ b/tests/fixtures/definitions/single-package-multiple-feat.json
@@ -1,0 +1,22 @@
+{
+  "meta": {
+    "name": "single-package-multiple-feat",
+    "description": "Multiple feat commits still result in a single minor bump"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "myapp", "path": ".", "initial_version": "1.0.0", "tag": "v1.0.0" }
+  ],
+  "commits": [
+    { "message": "feat: add login", "files": ["src/login.rs"] },
+    { "message": "feat: add signup", "files": ["src/signup.rs"] },
+    { "message": "feat: add dashboard", "files": ["src/dashboard.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["myapp", "1.1.0", "minor"],
+    "check_not_contains": ["1.2.0", "1.3.0", "Nothing to release"],
+    "packages_released": 1
+  }
+}

--- a/tests/fixtures/definitions/single-package-v0-initial.json
+++ b/tests/fixtures/definitions/single-package-v0-initial.json
@@ -1,0 +1,20 @@
+{
+  "meta": {
+    "name": "single-package-v0-initial",
+    "description": "Package starting at 0.x still gets normal semver bumps"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"starter\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "starter", "path": ".", "initial_version": "0.0.1", "tag": "v0.0.1" }
+  ],
+  "commits": [
+    { "message": "feat: first real feature", "files": ["src/main.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["starter", "0.1.0", "minor"],
+    "check_not_contains": ["Nothing to release"],
+    "packages_released": 1
+  }
+}

--- a/tests/fixtures/definitions/skip-ci-explicit-false.json
+++ b/tests/fixtures/definitions/skip-ci-explicit-false.json
@@ -1,0 +1,20 @@
+{
+  "meta": {
+    "name": "skip-ci-explicit-false",
+    "description": "skipCi explicitly set to false disables skip-ci even with commit mode"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"releaseCommitMode\": \"commit\",\n    \"skipCi\": false\n  },\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "myapp", "path": ".", "initial_version": "1.0.0", "tag": "v1.0.0" }
+  ],
+  "commits": [
+    { "message": "fix: important bugfix", "files": ["src/main.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["myapp", "1.0.1"],
+    "check_not_contains": ["Nothing to release"],
+    "packages_released": 1
+  }
+}

--- a/tests/fixtures/definitions/tag-monorepo-custom-template.json
+++ b/tests/fixtures/definitions/tag-monorepo-custom-template.json
@@ -1,0 +1,20 @@
+{
+  "meta": {
+    "name": "tag-monorepo-custom-template",
+    "description": "Custom tag template with package name prefix in monorepo"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"tagTemplate\": \"{name}/v{version}\"\n  },\n  \"package\": [\n    {\"name\": \"core\", \"path\": \"core\", \"versioned_files\": [{\"path\": \"core/version.toml\", \"format\": \"toml\"}]},\n    {\"name\": \"cli\", \"path\": \"cli\", \"versioned_files\": [{\"path\": \"cli/version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "core", "path": "core", "initial_version": "1.0.0", "tag": "core/v1.0.0" },
+    { "name": "cli", "path": "cli", "initial_version": "1.0.0", "tag": "cli/v1.0.0" }
+  ],
+  "commits": [
+    { "message": "feat(core): new api", "files": ["core/src/api.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["core", "1.1.0"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}

--- a/tests/fixtures/definitions/tag-no-prefix.json
+++ b/tests/fixtures/definitions/tag-no-prefix.json
@@ -1,0 +1,20 @@
+{
+  "meta": {
+    "name": "tag-no-prefix",
+    "description": "Tag template without v prefix still works"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"tagTemplate\": \"{version}\"\n  },\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "myapp", "path": ".", "initial_version": "1.0.0", "tag": "1.0.0" }
+  ],
+  "commits": [
+    { "message": "feat: add feature", "files": ["src/main.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["myapp", "1.1.0"],
+    "check_not_contains": ["Nothing to release"],
+    "packages_released": 1
+  }
+}

--- a/tests/fixtures/definitions/versioning-sequential-multiple.json
+++ b/tests/fixtures/definitions/versioning-sequential-multiple.json
@@ -1,0 +1,21 @@
+{
+  "meta": {
+    "name": "versioning-sequential-multiple",
+    "description": "Sequential versioning bumps from current number regardless of commit type"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"versioning\": \"sequential\"\n  },\n  \"package\": [\n    {\n      \"name\": \"myapp\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "myapp", "path": ".", "initial_version": "42", "tag": "v42" }
+  ],
+  "commits": [
+    { "message": "feat: big feature", "files": ["src/main.rs"] },
+    { "message": "fix: small fix", "files": ["src/lib.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["myapp", "43"],
+    "check_not_contains": ["Nothing to release"],
+    "packages_released": 1
+  }
+}

--- a/tests/fixtures/definitions/versioning-zerover-feat.json
+++ b/tests/fixtures/definitions/versioning-zerover-feat.json
@@ -1,0 +1,20 @@
+{
+  "meta": {
+    "name": "versioning-zerover-feat",
+    "description": "Zerover: feat (minor) bumps minor in 0.x, same as major"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"versioning\": \"zerover\"\n  },\n  \"package\": [\n    {\n      \"name\": \"early\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "early", "path": ".", "initial_version": "0.3.0", "tag": "v0.3.0" }
+  ],
+  "commits": [
+    { "message": "feat: add new feature", "files": ["src/main.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["early", "0.4.0"],
+    "check_not_contains": ["0.3.1", "1.0.0", "Nothing to release"],
+    "packages_released": 1
+  }
+}


### PR DESCRIPTION
## Summary
- Add 28 new fixture test definitions, bringing the total from 89 to 117
- New fixtures cover previously untested areas:
  - **Commit parsing**: uppercase types ignored, empty scope, non-conventional messages, BREAKING CHANGE in footer, mixed commit types with highest bump winning
  - **Config options**: minimal config, all workspace options set, per-package release commit scope, explicit skipCi false, recoverMissedReleases off
  - **Monorepo edge cases**: 3-package chain dependencies (A→B→C), breaking change isolated to one package, dependency not bumped when depended-on untouched, independent version numbers, shared paths triggering selective bumps, unscoped commits touching multiple packages, per-package changelogs
  - **Single package**: docs/ci/chore/style commits don't bump, v0 initial versions, multiple feat commits = single minor bump, breaking feat overrides everything
  - **Tags**: no-prefix template, monorepo custom template with slash separator
  - **Versioning**: zerover feat behavior (minor bump in 0.x), sequential with multiple commits
  - **Floating tags**: both major and minor levels configured simultaneously

Closes #257