### PR TITLE
feat(cli): add ErrorCode infrastructure for structured error output

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,0 +1,48 @@
+# FerrFlow Error Reference
+
+This file is the source-of-truth registry for all FerrFlow error codes.
+Each code is stable: once assigned, it is never reused for a different error.
+
+## Configuration Errors (E1000--E1099)
+
+_Codes will be assigned in a future release._
+
+## Validation Errors (E1100--E1199)
+
+_Codes will be assigned in a future release._
+
+## Git Operation Errors (E2000--E2099)
+
+_Codes will be assigned in a future release._
+
+## GitHub API Errors (E3000--E3099)
+
+_Codes will be assigned in a future release._
+
+## GitLab API Errors (E3100--E3199)
+
+_Codes will be assigned in a future release._
+
+## Version File Errors (E4000--E4799)
+
+_Codes will be assigned in a future release._
+
+## Pre-release Errors (E5000--E5099)
+
+_Codes will be assigned in a future release._
+
+## Versioning Errors (E5010--E5019)
+
+_Codes will be assigned in a future release._
+
+## Hook Errors (E6000--E6099)
+
+_Codes will be assigned in a future release._
+
+## Query Errors (E7000--E7099)
+
+_Codes will be assigned in a future release._
+
+## Monorepo Errors (E8000--E8099)
+
+_Codes will be assigned in a future release._

--- a/src/error_code.rs
+++ b/src/error_code.rs
@@ -1,0 +1,96 @@
+use std::fmt;
+
+/// A stable error code that can be attached to any `anyhow::Error` as context.
+///
+/// Error codes follow the pattern `E{NNNN}` where the first digit(s) indicate
+/// the domain and the remaining digits identify the specific error.
+///
+/// Ranges:
+/// - E1000–E1099: Configuration
+/// - E1100–E1199: Validation
+/// - E2000–E2099: Git operations
+/// - E3000–E3099: GitHub API
+/// - E3100–E3199: GitLab API
+/// - E4000–E4099: Version files (general)
+/// - E4100–E4199: TOML version files
+/// - E4200–E4299: JSON version files
+/// - E4300–E4399: Helm/YAML version files
+/// - E4400–E4499: XML/CSProj version files
+/// - E4500–E4599: Gradle version files
+/// - E4600–E4699: Go mod version files
+/// - E4700–E4799: Text version files
+/// - E5000–E5099: Pre-release / channels
+/// - E5010–E5019: Versioning
+/// - E6000–E6099: Hooks
+/// - E7000–E7099: Query / package lookup
+/// - E8000–E8099: Monorepo operations
+#[derive(Debug, Clone, Copy)]
+pub struct ErrorCode(pub u16);
+
+impl fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "E{:04}", self.0)
+    }
+}
+
+impl std::error::Error for ErrorCode {}
+
+impl ErrorCode {
+    /// Returns the documentation URL for this error code.
+    pub fn doc_url(&self) -> String {
+        format!(
+            "https://ferrflow.com/docs/reference/errors#{}",
+            self.to_string().to_lowercase()
+        )
+    }
+}
+
+/// Extension trait to attach an `ErrorCode` as context to any `anyhow::Result`.
+#[allow(dead_code)]
+pub trait ErrorCodeExt<T> {
+    fn error_code(self, code: ErrorCode) -> anyhow::Result<T>;
+}
+
+impl<T> ErrorCodeExt<T> for anyhow::Result<T> {
+    fn error_code(self, code: ErrorCode) -> anyhow::Result<T> {
+        self.map_err(|e| e.context(code))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_formats_with_leading_zeros() {
+        assert_eq!(ErrorCode(1).to_string(), "E0001");
+        assert_eq!(ErrorCode(42).to_string(), "E0042");
+        assert_eq!(ErrorCode(1001).to_string(), "E1001");
+        assert_eq!(ErrorCode(9999).to_string(), "E9999");
+    }
+
+    #[test]
+    fn doc_url_uses_lowercase() {
+        let url = ErrorCode(1001).doc_url();
+        assert_eq!(url, "https://ferrflow.com/docs/reference/errors#e1001");
+    }
+
+    #[test]
+    fn error_code_ext_attaches_code() {
+        let err: anyhow::Result<()> = Err(anyhow::anyhow!("something broke"));
+        let err = err.error_code(ErrorCode(2001));
+        let err = err.unwrap_err();
+
+        // ErrorCode is the outermost context, so downcast_ref on the error itself works
+        let code = err.downcast_ref::<ErrorCode>().copied();
+        assert!(code.is_some());
+        assert_eq!(code.unwrap().0, 2001);
+    }
+
+    #[test]
+    fn error_without_code_returns_none() {
+        let err = anyhow::anyhow!("plain error");
+        let code = err.downcast_ref::<ErrorCode>().copied();
+        assert!(code.is_none());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod changelog;
 pub mod config;
 pub mod conventional_commits;
+pub mod error_code;
 pub mod formats;
 pub mod prerelease;
 pub mod versioning;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod changelog;
 mod cli;
 mod config;
 mod conventional_commits;
+mod error_code;
 mod forge;
 mod formats;
 mod git;
@@ -14,15 +15,36 @@ mod telemetry;
 mod validate;
 mod versioning;
 
-use anyhow::Result;
 use clap::Parser;
 use cli::Cli;
 
-fn main() -> Result<()> {
+fn main() {
     let cli = Cli::parse();
     let result = cli.run();
     telemetry::flush();
-    result
+
+    if let Err(err) = result {
+        let code = err.downcast_ref::<error_code::ErrorCode>().copied();
+
+        if let Some(code) = code {
+            let msgs: Vec<String> = err
+                .chain()
+                .filter(|c| c.downcast_ref::<error_code::ErrorCode>().is_none())
+                .map(|c| c.to_string())
+                .collect();
+
+            eprintln!("error[{}]: {}", code, msgs[0]);
+            for msg in &msgs[1..] {
+                eprintln!("  {msg}");
+            }
+            eprintln!();
+            eprintln!("  For help: {}", code.doc_url());
+        } else {
+            eprintln!("Error: {err:?}");
+        }
+
+        std::process::exit(1);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Add `src/error_code.rs` with `ErrorCode` struct, `Display`/`Error` impls, `doc_url()`, and `ErrorCodeExt` trait for chaining `.error_code(CODE)` on any `anyhow::Result`
- Update `main()` to extract error codes from the anyhow chain and display formatted output with doc links
- Add `docs/errors.md` as the error code registry with empty domain sections
- WASM-compatible (not behind `cli` feature)

Output when an error has a code:
```
error[E2001]: Failed to push branch 'main'
  cannot push non-fastforwardable reference

  For help: https://ferrflow.com/docs/reference/errors#e2001
```

Errors without a code continue to display normally (incremental migration).

Closes #335