### PR TITLE
feat(cli): send error telemetry with command name and error code

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -105,6 +105,22 @@ pub enum Commands {
     },
 }
 
+impl Commands {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Commands::Check { .. } => "check",
+            Commands::Release { .. } => "release",
+            Commands::Changelog => "changelog",
+            Commands::Init { .. } => "init",
+            Commands::Status { .. } => "status",
+            Commands::Version { .. } => "version",
+            Commands::Tag { .. } => "tag",
+            Commands::Validate { .. } => "validate",
+            Commands::Completions { .. } => "completions",
+        }
+    }
+}
+
 impl Cli {
     pub fn run(self) -> Result<()> {
         match self.command {
@@ -406,5 +422,20 @@ mod tests {
     #[test]
     fn missing_subcommand_fails() {
         assert!(Cli::try_parse_from(["ferrflow"]).is_err());
+    }
+
+    #[test]
+    fn command_names() {
+        assert_eq!(parse(&["ferrflow", "check"]).command.name(), "check");
+        assert_eq!(parse(&["ferrflow", "release"]).command.name(), "release");
+        assert_eq!(
+            parse(&["ferrflow", "changelog"]).command.name(),
+            "changelog"
+        );
+        assert_eq!(parse(&["ferrflow", "init"]).command.name(), "init");
+        assert_eq!(parse(&["ferrflow", "status"]).command.name(), "status");
+        assert_eq!(parse(&["ferrflow", "version"]).command.name(), "version");
+        assert_eq!(parse(&["ferrflow", "tag"]).command.name(), "tag");
+        assert_eq!(parse(&["ferrflow", "validate"]).command.name(), "validate");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,11 +20,27 @@ use cli::Cli;
 
 fn main() {
     let cli = Cli::parse();
+    let command_name = cli.command.name();
     let result = cli.run();
-    telemetry::flush();
 
     if let Err(err) = result {
         let code = err.downcast_ref::<error_code::ErrorCode>().copied();
+
+        let error_code_str = code.map(|c| c.to_string());
+        let mut metadata = serde_json::Map::new();
+        metadata.insert("command".into(), command_name.into());
+        if let Some(ref code_str) = error_code_str {
+            metadata.insert("error_code".into(), code_str.clone().into());
+        }
+        telemetry::send_event(
+            telemetry::EventType::Error,
+            Some(serde_json::Value::Object(metadata)),
+            None,
+            None,
+            None,
+        );
+
+        telemetry::flush();
 
         if let Some(code) = code {
             let msgs: Vec<String> = err
@@ -45,6 +61,8 @@ fn main() {
 
         std::process::exit(1);
     }
+
+    telemetry::flush();
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Send a telemetry `error` event when any command fails, including the command name and error code in metadata
- Add `Commands::name()` method to extract the subcommand name as a static string
- Error events are sent before displaying the error to the user, so telemetry flush captures them
- Payload example: `{"event_type": "error", "metadata": {"command": "release", "error_code": "E2004"}}`

Closes #172