### PR TITLE
feat(cli): add --comment flag to post PR/MR preview comments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: 'FerrFlow version to use (e.g. 1.2.3). Defaults to latest.'
     required: false
     default: 'latest'
+  mode:
+    description: 'Action mode: "release" runs the full release pipeline. "preview" posts a PR comment with version bump preview.'
+    required: false
+    default: 'release'
   dry_run:
     description: 'Run without creating releases or pushing changes'
     required: false
@@ -57,6 +61,12 @@ runs:
         chmod +x "$INSTALL_DIR/ferrflow"
         echo "$INSTALL_DIR" >> "$GITHUB_PATH"
 
+    - name: Preview release
+      if: inputs.mode == 'preview'
+      shell: bash
+      run: ferrflow check --comment
+
     - name: Run FerrFlow release
+      if: inputs.mode == 'release'
       shell: bash
       run: ferrflow ${{ inputs.dry_run == 'true' && '--dry-run' || '' }} release ${{ inputs.force_version != '' && format('--force-version {0}', inputs.force_version) || '' }}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,6 +38,9 @@ pub enum Commands {
         /// Pre-release channel override (e.g. beta, rc, dev)
         #[arg(long)]
         channel: Option<String>,
+        /// Post a preview comment on the current PR/MR
+        #[arg(long)]
+        comment: bool,
     },
     /// Bump versions, update changelogs, create tags and push
     Release {
@@ -124,11 +127,16 @@ impl Commands {
 impl Cli {
     pub fn run(self) -> Result<()> {
         match self.command {
-            Commands::Check { json, channel } => crate::monorepo::check(
+            Commands::Check {
+                json,
+                channel,
+                comment,
+            } => crate::monorepo::check(
                 self.config.as_deref(),
                 self.verbose,
                 json,
                 channel.as_deref(),
+                comment,
             ),
             Commands::Release {
                 force,
@@ -194,7 +202,8 @@ mod tests {
             cli.command,
             Commands::Check {
                 json: false,
-                channel: None
+                channel: None,
+                comment: false,
             }
         ));
     }

--- a/src/forge/github.rs
+++ b/src/forge/github.rs
@@ -167,6 +167,60 @@ impl Forge for GitHubForge {
     fn release_noun(&self) -> &'static str {
         "GitHub Release"
     }
+
+    fn find_comment(&self, pr_id: u64, marker: &str) -> Result<Option<u64>> {
+        let url = format!(
+            "{}/repos/{}/issues/{}/comments?per_page=100",
+            self.api_base, self.slug, pr_id
+        );
+        let comments: Vec<serde_json::Value> = ureq::get(&url)
+            .header("Authorization", &format!("Bearer {}", self.token))
+            .header("Accept", "application/vnd.github+json")
+            .header("User-Agent", "ferrflow")
+            .call()
+            .with_context(|| "Failed to list PR comments")?
+            .body_mut()
+            .read_json()
+            .with_context(|| "Failed to parse PR comments")?;
+
+        for comment in comments {
+            if let Some(body) = comment["body"].as_str()
+                && body.contains(marker)
+                && let Some(id) = comment["id"].as_u64()
+            {
+                return Ok(Some(id));
+            }
+        }
+        Ok(None)
+    }
+
+    fn create_comment(&self, pr_id: u64, body: &str) -> Result<()> {
+        let url = format!(
+            "{}/repos/{}/issues/{}/comments",
+            self.api_base, self.slug, pr_id
+        );
+        ureq::post(&url)
+            .header("Authorization", &format!("Bearer {}", self.token))
+            .header("Accept", "application/vnd.github+json")
+            .header("User-Agent", "ferrflow")
+            .send_json(serde_json::json!({ "body": body }))
+            .with_context(|| "Failed to create PR comment")?;
+        Ok(())
+    }
+
+    fn update_comment(&self, _pr_id: u64, comment_id: u64, body: &str) -> Result<()> {
+        let url = format!(
+            "{}/repos/{}/issues/comments/{}",
+            self.api_base, self.slug, comment_id
+        );
+        ureq::patch(&url)
+            .header("Authorization", &format!("Bearer {}", self.token))
+            .header("Accept", "application/vnd.github+json")
+            .header("User-Agent", "ferrflow")
+            .send_json(serde_json::json!({ "body": body }))
+            .with_context(|| "Failed to update PR comment")?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -139,6 +139,64 @@ impl Forge for GitLabForge {
     fn release_noun(&self) -> &'static str {
         "GitLab Release"
     }
+
+    fn find_comment(&self, mr_id: u64, marker: &str) -> Result<Option<u64>> {
+        let url = format!(
+            "{}/projects/{}/merge_requests/{}/notes?per_page=100",
+            self.api_base,
+            self.encoded_project_id(),
+            mr_id
+        );
+        let notes: Vec<serde_json::Value> = ureq::get(&url)
+            .header("PRIVATE-TOKEN", &self.token)
+            .header("User-Agent", "ferrflow")
+            .call()
+            .with_context(|| "Failed to list MR notes")?
+            .body_mut()
+            .read_json()
+            .with_context(|| "Failed to parse MR notes")?;
+
+        for note in notes {
+            if let Some(body) = note["body"].as_str()
+                && body.contains(marker)
+                && let Some(id) = note["id"].as_u64()
+            {
+                return Ok(Some(id));
+            }
+        }
+        Ok(None)
+    }
+
+    fn create_comment(&self, mr_id: u64, body: &str) -> Result<()> {
+        let url = format!(
+            "{}/projects/{}/merge_requests/{}/notes",
+            self.api_base,
+            self.encoded_project_id(),
+            mr_id
+        );
+        ureq::post(&url)
+            .header("PRIVATE-TOKEN", &self.token)
+            .header("User-Agent", "ferrflow")
+            .send_json(serde_json::json!({ "body": body }))
+            .with_context(|| "Failed to create MR note")?;
+        Ok(())
+    }
+
+    fn update_comment(&self, mr_id: u64, comment_id: u64, body: &str) -> Result<()> {
+        let url = format!(
+            "{}/projects/{}/merge_requests/{}/notes/{}",
+            self.api_base,
+            self.encoded_project_id(),
+            mr_id,
+            comment_id
+        );
+        ureq::put(&url)
+            .header("PRIVATE-TOKEN", &self.token)
+            .header("User-Agent", "ferrflow")
+            .send_json(serde_json::json!({ "body": body }))
+            .with_context(|| "Failed to update MR note")?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -24,6 +24,33 @@ pub trait Forge {
     fn enable_auto_merge(&self, mr: &MergeRequestResult) -> Result<()>;
     fn mr_noun(&self) -> &'static str;
     fn release_noun(&self) -> &'static str;
+
+    /// Find a comment on a PR/MR whose body contains the given marker string.
+    fn find_comment(&self, pr_id: u64, marker: &str) -> Result<Option<u64>>;
+
+    /// Create a new comment on a PR/MR.
+    fn create_comment(&self, pr_id: u64, body: &str) -> Result<()>;
+
+    /// Update an existing comment by ID.
+    fn update_comment(&self, pr_id: u64, comment_id: u64, body: &str) -> Result<()>;
+}
+
+/// Detect the PR/MR number from CI environment variables.
+pub fn detect_pr_number() -> Option<u64> {
+    // GitHub Actions: GITHUB_REF is "refs/pull/123/merge" on pull_request events
+    if let Ok(ref_name) = std::env::var("GITHUB_REF")
+        && let Some(num) = ref_name
+            .strip_prefix("refs/pull/")
+            .and_then(|s| s.strip_suffix("/merge"))
+        && let Ok(n) = num.parse()
+    {
+        return Some(n);
+    }
+    // GitLab CI: CI_MERGE_REQUEST_IID is set on merge_request_event pipelines
+    if let Ok(iid) = std::env::var("CI_MERGE_REQUEST_IID") {
+        return iid.parse().ok();
+    }
+    None
 }
 
 pub fn detect_forge_from_url(url: &str) -> Option<ForgeKind> {

--- a/src/monorepo.rs
+++ b/src/monorepo.rs
@@ -37,13 +37,13 @@ fn build_forge_instance(repo: &Repository, config: &Config) -> Option<Box<dyn fo
     Some(forge::build_forge(kind, token, slug, host))
 }
 
-#[derive(serde::Serialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
 struct CheckCommit {
     hash: String,
     message: String,
 }
 
-#[derive(serde::Serialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
 struct CheckPackage {
     name: String,
     current_version: String,
@@ -56,7 +56,7 @@ struct CheckPackage {
     commits: Vec<CheckCommit>,
 }
 
-#[derive(serde::Serialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
 struct CheckResult {
     packages: Vec<CheckPackage>,
 }
@@ -66,6 +66,7 @@ pub fn check(
     verbose: bool,
     json: bool,
     channel: Option<&str>,
+    comment: bool,
 ) -> Result<()> {
     let repo = open_repo(&std::env::current_dir()?)?;
     let root = get_repo_root(&repo)?;
@@ -80,11 +81,83 @@ pub fn check(
         &root, &config, true, verbose, json, false, None, channel, false,
     );
 
+    // Post a preview comment on the PR/MR if requested
+    if comment {
+        post_preview_comment(&repo, &config, &root);
+    }
+
     if config.workspace.anonymous_telemetry {
         telemetry::send_event(telemetry::EventType::Check, None, None, None, None);
     }
 
     result
+}
+
+/// Run `check` in JSON mode silently, parse the result, and post a preview comment.
+fn post_preview_comment(repo: &git2::Repository, config: &Config, root: &Path) {
+    let pr_id = match forge::detect_pr_number() {
+        Some(id) => id,
+        None => return, // Not in a PR context, skip silently
+    };
+
+    let forge_instance = match build_forge_instance(repo, config) {
+        Some(f) => f,
+        None => return, // No forge detected or no token, skip silently
+    };
+
+    // Re-run the check logic in JSON mode to capture structured output
+    let json_result = capture_check_json(root);
+    let body = format_preview_comment(&json_result);
+    let marker = "<!-- ferrflow-preview -->";
+
+    let result = (|| -> anyhow::Result<()> {
+        match forge_instance.find_comment(pr_id, marker)? {
+            Some(comment_id) => forge_instance.update_comment(pr_id, comment_id, &body)?,
+            None => forge_instance.create_comment(pr_id, &body)?,
+        }
+        Ok(())
+    })();
+
+    if let Err(e) = result {
+        eprintln!("Warning: failed to post preview comment: {e}");
+    }
+}
+
+fn capture_check_json(root: &Path) -> Vec<CheckPackage> {
+    let exe = std::env::current_exe().unwrap_or_else(|_| "ferrflow".into());
+    let output = std::process::Command::new(exe)
+        .args(["check", "--json"])
+        .current_dir(root)
+        .output();
+
+    match output {
+        Ok(out) if out.status.success() => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            serde_json::from_str::<CheckResult>(&stdout)
+                .map(|r| r.packages)
+                .unwrap_or_default()
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn format_preview_comment(packages: &[CheckPackage]) -> String {
+    let mut body = String::from("<!-- ferrflow-preview -->\n**FerrFlow Release Preview**\n\n");
+    if packages.is_empty() {
+        body.push_str("No releasable changes detected.");
+        return body;
+    }
+    body.push_str("| Package | Current | Next | Bump |\n");
+    body.push_str("|---------|---------|------|------|\n");
+    for pkg in packages {
+        body.push_str(&format!(
+            "| {} | `{}` | `{}` | {} |\n",
+            pkg.name, pkg.current_version, pkg.next_version, pkg.bump_type
+        ));
+    }
+    let commit_count: usize = packages.iter().map(|p| p.commits.len()).sum();
+    body.push_str(&format!("\nBased on {} commit(s).", commit_count));
+    body
 }
 
 pub fn release(


### PR DESCRIPTION
## Summary

Add a `--comment` flag to `ferrflow check` that posts a release preview comment on the current PR/MR. Works on both GitHub and GitLab.

### How it works

1. `ferrflow check --comment` runs the normal check
2. Detects the forge (GitHub/GitLab) from the remote URL
3. Detects the PR/MR number from CI environment variables (`GITHUB_REF` / `CI_MERGE_REQUEST_IID`)
4. Formats a markdown table with version bumps
5. Posts or updates a comment on the PR/MR (using `<!-- ferrflow-preview -->` marker to find existing comments)

If no PR context is detected or no forge token is available, the flag is silently ignored.

### Comment format

> **FerrFlow Release Preview**
>
> | Package | Current | Next | Bump |
> |---------|---------|------|------|
> | api | `1.5.0` | `1.6.0` | minor |
> | site | `1.8.0` | `1.8.1` | patch |
>
> Based on 3 commit(s).

### Changes

- Extend `Forge` trait with `find_comment`, `create_comment`, `update_comment`
- Implement for both `GitHubForge` and `GitLabForge`
- Add `detect_pr_number()` in `forge/mod.rs`
- Add `--comment` flag to `Commands::Check`
- Add `mode` input to `action.yml` (`release` default, `preview` runs `ferrflow check --comment`)

### Usage

```yaml
# GitHub Actions
- uses: FerrFlow-Org/ferrflow@v3
  with:
    mode: preview

# GitLab CI
ferrflow check --comment
```

Closes #221