### PR TITLE
chore: remove competitor references from benchmarks and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,7 @@ FerrFlow reads your commit history, determines the right version bump, updates y
 
 ## Why FerrFlow?
 
-Most versioning tools are tied to a specific ecosystem (semantic-release for JS, cargo-release for Rust) or require a Node.js runtime. FerrFlow is a single compiled binary with no runtime dependencies.
-
-| Tool | Monorepo | Multi-language | Runtime |
-|------|----------|---------------|---------|
-| semantic-release | plugins | JS only | Node.js |
-| changesets | manual | JS only | Node.js |
-| knope | limited | partial | none |
-| FerrFlow | native | yes | none |
+A single compiled binary with no runtime dependencies. Native monorepo support, multi-language versioning, and works with any repo layout.
 
 ## Supported version files
 

--- a/benchmarks/fixtures/definitions/mono-100-1k.json
+++ b/benchmarks/fixtures/definitions/mono-100-1k.json
@@ -10,13 +10,6 @@
   "tool_configs": {
     "ferrflow": {
       "ferrflow.json": "{}"
-    },
-    "semantic-release": {
-      ".releaserc.json": "{\"branches\":[\"main\"],\"plugins\":[\"@semantic-release/commit-analyzer\",\"@semantic-release/release-notes-generator\"]}"
-    },
-    "changesets": {
-      ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.1.1/schema.json\",\"changelog\":false,\"commit\":false,\"access\":\"restricted\",\"baseBranch\":\"main\"}",
-      "package.json": "{\"name\":\"benchmark-monorepo\",\"private\":true,\"workspaces\":[\"packages/*\"]}"
     }
   }
 }

--- a/benchmarks/fixtures/definitions/mono-50-5k.json
+++ b/benchmarks/fixtures/definitions/mono-50-5k.json
@@ -10,13 +10,6 @@
   "tool_configs": {
     "ferrflow": {
       "ferrflow.json": "{}"
-    },
-    "semantic-release": {
-      ".releaserc.json": "{\"branches\":[\"main\"],\"plugins\":[\"@semantic-release/commit-analyzer\",\"@semantic-release/release-notes-generator\"]}"
-    },
-    "changesets": {
-      ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.1.1/schema.json\",\"changelog\":false,\"commit\":false,\"access\":\"restricted\",\"baseBranch\":\"main\"}",
-      "package.json": "{\"name\":\"benchmark-monorepo\",\"private\":true,\"workspaces\":[\"packages/*\"]}"
     }
   }
 }

--- a/benchmarks/fixtures/definitions/mono-large.json
+++ b/benchmarks/fixtures/definitions/mono-large.json
@@ -10,13 +10,6 @@
   "tool_configs": {
     "ferrflow": {
       "ferrflow.json": "{}"
-    },
-    "semantic-release": {
-      ".releaserc.json": "{\"branches\":[\"main\"],\"plugins\":[\"@semantic-release/commit-analyzer\",\"@semantic-release/release-notes-generator\"]}"
-    },
-    "changesets": {
-      ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.1.1/schema.json\",\"changelog\":false,\"commit\":false,\"access\":\"restricted\",\"baseBranch\":\"main\"}",
-      "package.json": "{\"name\":\"benchmark-monorepo\",\"private\":true,\"workspaces\":[\"packages/*\"]}"
     }
   }
 }

--- a/benchmarks/fixtures/definitions/mono-medium.json
+++ b/benchmarks/fixtures/definitions/mono-medium.json
@@ -10,13 +10,6 @@
   "tool_configs": {
     "ferrflow": {
       "ferrflow.json": "{}"
-    },
-    "semantic-release": {
-      ".releaserc.json": "{\"branches\":[\"main\"],\"plugins\":[\"@semantic-release/commit-analyzer\",\"@semantic-release/release-notes-generator\"]}"
-    },
-    "changesets": {
-      ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.1.1/schema.json\",\"changelog\":false,\"commit\":false,\"access\":\"restricted\",\"baseBranch\":\"main\"}",
-      "package.json": "{\"name\":\"benchmark-monorepo\",\"private\":true,\"workspaces\":[\"packages/*\"]}"
     }
   }
 }

--- a/benchmarks/fixtures/definitions/mono-small.json
+++ b/benchmarks/fixtures/definitions/mono-small.json
@@ -10,13 +10,6 @@
   "tool_configs": {
     "ferrflow": {
       "ferrflow.json": "{}"
-    },
-    "semantic-release": {
-      ".releaserc.json": "{\"branches\":[\"main\"],\"plugins\":[\"@semantic-release/commit-analyzer\",\"@semantic-release/release-notes-generator\"]}"
-    },
-    "changesets": {
-      ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.1.1/schema.json\",\"changelog\":false,\"commit\":false,\"access\":\"restricted\",\"baseBranch\":\"main\"}",
-      "package.json": "{\"name\":\"benchmark-monorepo\",\"private\":true,\"workspaces\":[\"packages/*\"]}"
     }
   }
 }

--- a/benchmarks/fixtures/definitions/single.json
+++ b/benchmarks/fixtures/definitions/single.json
@@ -10,13 +10,6 @@
   "tool_configs": {
     "ferrflow": {
       "ferrflow.json": "{\"package\":[{\"name\":\"myapp\",\"path\":\".\",\"changelog\":\"CHANGELOG.md\",\"versioned_files\":[{\"path\":\"package.json\",\"format\":\"json\"}]}]}"
-    },
-    "semantic-release": {
-      ".releaserc.json": "{\"branches\":[\"main\"],\"plugins\":[\"@semantic-release/commit-analyzer\",\"@semantic-release/release-notes-generator\"]}"
-    },
-    "changesets": {
-      ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.1.1/schema.json\",\"changelog\":false,\"commit\":false,\"access\":\"restricted\",\"baseBranch\":\"main\"}",
-      "package.json": "{\"name\":\"benchmark\",\"private\":true,\"version\":\"0.1.0\"}"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Remove semantic-release and changesets configs from all 6 benchmark fixture definitions
- Remove competitor comparison table and mentions from README

Closes #