### PR TITLE
fix(release): use highest-semver git tag as version source of truth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "2.23.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "cargo-husky",

--- a/src/git.rs
+++ b/src/git.rs
@@ -257,6 +257,88 @@ pub fn find_last_tag_name(
     Ok(find_last_tag(repo, prefix, strategy)?.map(|t| t.name))
 }
 
+/// Find the tag with the highest semver version among **stable** tags matching
+/// the given prefix. Used as the source of truth for the current version when
+/// cutting a release — this prevents drift between a package's versioned file
+/// (e.g. `Cargo.toml`) and its git tags.
+///
+/// Differs from [`find_last_tag`] in two ways:
+///   - Compares by semver (`2.0.0` > `10.0.0` is `false`), not by tag-commit time.
+///   - Pre-release tags are skipped; they are never the authoritative baseline
+///     for a stable release.
+///
+/// Returns `(tag_name, bare_version_string)` — the prefix and any leading `v`
+/// are stripped from the second item, e.g. `("api@v2.1.0", "2.1.0")`.
+///
+/// Respects [`OrphanedTagStrategy`] for tags not reachable from HEAD: the
+/// `Warn` strategy skips them, `TreeHash` / `Message` try to rematch onto the
+/// current branch before accepting the tag.
+pub fn find_highest_semver_tag(
+    repo: &Repository,
+    prefix: &str,
+    strategy: OrphanedTagStrategy,
+) -> Result<Option<(String, String)>> {
+    let head = repo.head()?.peel_to_commit()?.id();
+    let highest: RefCell<Option<(String, semver::Version)>> = RefCell::new(None);
+
+    repo.tag_foreach(|oid, name| {
+        let name = String::from_utf8_lossy(name);
+        let tag_name = name.trim_start_matches("refs/tags/");
+        if !tag_name.starts_with(prefix)
+            || is_prerelease_tag(tag_name, prefix)
+            || is_floating_tag(tag_name, prefix)
+        {
+            return true;
+        }
+
+        // Strip the prefix and any leading `v` to get a parseable version.
+        let version_str = tag_name
+            .strip_prefix(prefix)
+            .map(|s| s.strip_prefix('v').unwrap_or(s))
+            .unwrap_or(tag_name);
+        let parsed = match semver::Version::parse(version_str) {
+            Ok(v) => v,
+            Err(_) => return true, // Not a valid semver — skip silently.
+        };
+
+        // Resolve reachability — same semantics as find_last_tag.
+        let commit_oid = if let Ok(tag_obj) = repo.find_tag(oid) {
+            tag_obj.target_id()
+        } else {
+            oid
+        };
+        let commit = match repo.find_commit(commit_oid) {
+            Ok(c) => c,
+            Err(_) => return true, // Missing commit (gc'd) — skip.
+        };
+        let reachable =
+            head == commit_oid || repo.graph_descendant_of(head, commit_oid).unwrap_or(false);
+        if !reachable {
+            match strategy {
+                OrphanedTagStrategy::Warn => return true,
+                OrphanedTagStrategy::TreeHash | OrphanedTagStrategy::Message => {
+                    if find_matching_commit(repo, &commit, &strategy).is_none() {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        let mut highest_ref = highest.borrow_mut();
+        match highest_ref.as_ref() {
+            Some((_, existing)) if existing >= &parsed => {}
+            _ => {
+                *highest_ref = Some((tag_name.to_string(), parsed));
+            }
+        }
+        true
+    })?;
+
+    Ok(highest
+        .into_inner()
+        .map(|(name, version)| (name, version.to_string())))
+}
+
 fn find_last_tag_commit(
     repo: &Repository,
     prefix: &str,
@@ -1125,6 +1207,140 @@ mod tests {
             find_last_tag_name(&repo, "site@v", OrphanedTagStrategy::Warn).unwrap(),
             Some("site@v2.0.0".to_string())
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // find_highest_semver_tag
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn find_highest_semver_returns_none_when_no_matching_tags() {
+        let (dir, repo) = init_repo();
+        create_commit_in_repo(&repo, dir.path(), "a.txt", "first");
+        create_lightweight_tag(&repo, "other@v1.0.0");
+
+        let result = find_highest_semver_tag(&repo, "api@v", OrphanedTagStrategy::Warn).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn find_highest_semver_picks_highest_not_latest_in_time() {
+        // Reproduces the real-world drift scenario: an older-in-time but
+        // higher-semver tag (v3.0.0) exists alongside a later-in-time but
+        // lower-semver tag (v2.2.0). `find_last_tag` would return v2.2.0;
+        // `find_highest_semver_tag` must return v3.0.0.
+        let (dir, repo) = init_repo();
+        create_commit_in_repo(&repo, dir.path(), "a.txt", "first");
+        create_lightweight_tag(&repo, "api@v3.0.0");
+        create_commit_in_repo(&repo, dir.path(), "b.txt", "second");
+        create_lightweight_tag(&repo, "api@v2.1.0");
+        create_commit_in_repo(&repo, dir.path(), "c.txt", "third");
+        create_lightweight_tag(&repo, "api@v2.2.0");
+
+        let (tag_name, version) =
+            find_highest_semver_tag(&repo, "api@v", OrphanedTagStrategy::Warn)
+                .unwrap()
+                .expect("a tag should be found");
+        assert_eq!(tag_name, "api@v3.0.0");
+        assert_eq!(version, "3.0.0");
+    }
+
+    #[test]
+    fn find_highest_semver_strips_prefix_and_v() {
+        let (dir, repo) = init_repo();
+        create_commit_in_repo(&repo, dir.path(), "a.txt", "first");
+        create_lightweight_tag(&repo, "api@v1.2.3");
+
+        let (_, version) = find_highest_semver_tag(&repo, "api@v", OrphanedTagStrategy::Warn)
+            .unwrap()
+            .unwrap();
+        assert_eq!(version, "1.2.3");
+    }
+
+    #[test]
+    fn find_highest_semver_ignores_prerelease_tags() {
+        let (dir, repo) = init_repo();
+        create_commit_in_repo(&repo, dir.path(), "a.txt", "first");
+        create_lightweight_tag(&repo, "api@v2.0.0");
+        create_commit_in_repo(&repo, dir.path(), "b.txt", "second");
+        create_lightweight_tag(&repo, "api@v3.0.0-rc.1");
+
+        let (tag_name, version) =
+            find_highest_semver_tag(&repo, "api@v", OrphanedTagStrategy::Warn)
+                .unwrap()
+                .unwrap();
+        assert_eq!(tag_name, "api@v2.0.0");
+        assert_eq!(version, "2.0.0");
+    }
+
+    #[test]
+    fn find_highest_semver_ignores_floating_tags() {
+        let (dir, repo) = init_repo();
+        create_commit_in_repo(&repo, dir.path(), "a.txt", "first");
+        create_lightweight_tag(&repo, "v1.0.0");
+        create_lightweight_tag(&repo, "v1");
+        create_lightweight_tag(&repo, "latest");
+
+        let (tag_name, _) = find_highest_semver_tag(&repo, "v", OrphanedTagStrategy::Warn)
+            .unwrap()
+            .unwrap();
+        assert_eq!(tag_name, "v1.0.0");
+    }
+
+    #[test]
+    fn find_highest_semver_skips_non_semver_tags() {
+        let (dir, repo) = init_repo();
+        create_commit_in_repo(&repo, dir.path(), "a.txt", "first");
+        // "api@vnightly" matches the prefix but isn't a valid semver.
+        create_lightweight_tag(&repo, "api@vnightly");
+        create_lightweight_tag(&repo, "api@v1.0.0");
+
+        let (tag_name, _) = find_highest_semver_tag(&repo, "api@v", OrphanedTagStrategy::Warn)
+            .unwrap()
+            .unwrap();
+        assert_eq!(tag_name, "api@v1.0.0");
+    }
+
+    #[test]
+    fn find_highest_semver_respects_orphan_warn_strategy() {
+        // An orphaned higher tag is ignored under Warn — we don't want to
+        // use a tag that points at a branch no longer reachable from HEAD.
+        let (dir, repo) = init_repo();
+        create_commit_in_repo(&repo, dir.path(), "a.txt", "first");
+        create_lightweight_tag(&repo, "api@v1.0.0");
+        // Create a second branch, tag v9.0.0 on it, then abandon it by moving
+        // HEAD back to the main branch.
+        let main_commit = repo.head().unwrap().peel_to_commit().unwrap();
+        repo.branch("orphan", &main_commit, false).unwrap();
+        repo.set_head("refs/heads/orphan").unwrap();
+        create_commit_in_repo(&repo, dir.path(), "b.txt", "orphan-only");
+        create_lightweight_tag(&repo, "api@v9.0.0");
+        // Back to the original branch (HEAD does not include v9.0.0 anymore).
+        repo.set_head(
+            repo.head()
+                .unwrap()
+                .shorthand()
+                .map(|_| "refs/heads/master")
+                .unwrap_or("refs/heads/master"),
+        )
+        .unwrap();
+        // reset HEAD to the initial commit
+        let initial_oid = main_commit.id();
+        repo.reference(
+            "refs/heads/master",
+            initial_oid,
+            true,
+            "reset after orphan test",
+        )
+        .unwrap();
+        repo.set_head("refs/heads/master").unwrap();
+        repo.checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+            .unwrap();
+
+        let result = find_highest_semver_tag(&repo, "api@v", OrphanedTagStrategy::Warn)
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.0, "api@v1.0.0");
     }
 
     // -----------------------------------------------------------------------

--- a/src/monorepo.rs
+++ b/src/monorepo.rs
@@ -366,7 +366,37 @@ fn run_release_logic(
             continue;
         };
 
-        let current_version = read_version(vf, root)?;
+        // Source of truth for the version we're bumping FROM.
+        //
+        // We intentionally prefer the highest-semver matching git tag over the
+        // version in the versioned file (`Cargo.toml`, `package.json`, …). Two
+        // scenarios make the file untrustworthy:
+        //
+        //   1. Two release workflows racing back-to-back — the second job
+        //      checks out main at the pre-release state and would double-bump
+        //      to the same version as the first.
+        //   2. The file diverges from the tags (merge of an old branch,
+        //      revert, manual edit). The file says `2.0.0` but tags go up to
+        //      `3.0.0`; bumping from `2.0.0` produces tags that collide with
+        //      history and the release gets silently skipped.
+        //
+        // The file stays the canonical write target (so downstream consumers
+        // see a coherent version), but it is not the bump baseline.
+        //
+        // If the file happens to be ahead of the tags (human pre-published a
+        // version manually before tagging), we honour that by taking the max
+        // of the two.
+        let file_version = read_version(vf, root)?;
+        let tag_version = crate::git::find_highest_semver_tag(
+            &repo,
+            &tag_search_prefix,
+            config.workspace.orphaned_tag_strategy,
+        )?
+        .map(|(_tag, version)| version);
+        let current_version = match tag_version {
+            None => file_version,
+            Some(tag) => pick_higher_semver(&file_version, &tag),
+        };
 
         // Determine new version: forced or computed from commits
         let (new_version, is_prerelease, commits, bump) = if let Some(fv) = forced_ver_for_pkg {
@@ -1286,6 +1316,30 @@ fn run_release_logic(
 }
 
 /// Collect the set of dirty (modified/new) file paths in the working tree.
+/// Return whichever of the two inputs parses to the higher semver version.
+/// Falls back to `tag` when `file` is not a valid semver; falls back to `file`
+/// when `tag` is not. When both fail to parse, returns `file` (the behaviour
+/// before this helper existed).
+fn pick_higher_semver(file: &str, tag: &str) -> String {
+    let file_clean = file.trim_start_matches('v');
+    let tag_clean = tag.trim_start_matches('v');
+    match (
+        semver::Version::parse(file_clean),
+        semver::Version::parse(tag_clean),
+    ) {
+        (Ok(f), Ok(t)) => {
+            if t >= f {
+                tag.to_string()
+            } else {
+                file.to_string()
+            }
+        }
+        (Ok(_), Err(_)) => file.to_string(),
+        (Err(_), Ok(_)) => tag.to_string(),
+        (Err(_), Err(_)) => file.to_string(),
+    }
+}
+
 fn collect_dirty_files(repo: &git2::Repository) -> HashSet<String> {
     let mut files = HashSet::new();
     if let Ok(statuses) = repo.statuses(None) {
@@ -1356,6 +1410,39 @@ fn is_package_touched(pkg: &PackageConfig, changed_files: &[String], is_monorepo
 mod tests {
     use super::*;
     use crate::config::PackageConfig;
+
+    #[test]
+    fn pick_higher_semver_prefers_tag_when_tag_is_higher() {
+        assert_eq!(pick_higher_semver("2.0.0", "3.0.0"), "3.0.0");
+    }
+
+    #[test]
+    fn pick_higher_semver_prefers_file_when_file_is_higher() {
+        // Human bumped Cargo.toml ahead of any existing tag — honour intent.
+        assert_eq!(pick_higher_semver("5.0.0", "2.0.0"), "5.0.0");
+    }
+
+    #[test]
+    fn pick_higher_semver_returns_tag_on_equality() {
+        // Doesn't matter which one we pick when equal — returning the tag
+        // means callers print a consistent value in logs.
+        assert_eq!(pick_higher_semver("2.1.0", "2.1.0"), "2.1.0");
+    }
+
+    #[test]
+    fn pick_higher_semver_falls_back_to_tag_when_file_is_invalid() {
+        assert_eq!(pick_higher_semver("garbage", "2.0.0"), "2.0.0");
+    }
+
+    #[test]
+    fn pick_higher_semver_falls_back_to_file_when_tag_is_invalid() {
+        assert_eq!(pick_higher_semver("2.0.0", "garbage"), "2.0.0");
+    }
+
+    #[test]
+    fn pick_higher_semver_strips_leading_v() {
+        assert_eq!(pick_higher_semver("v2.0.0", "v3.0.0"), "v3.0.0");
+    }
 
     fn make_pkg(name: &str, path: &str, shared: &[&str]) -> PackageConfig {
         PackageConfig {


### PR DESCRIPTION
## Summary

Fixes the bug where FerrFlow silently skips releases, or double-bumps to the same version, when the versioned file (`Cargo.toml` / `package.json` / …) is out of sync with the git tags.

Closes #356.

## The bug in one paragraph

Before this change, `release` reads the "current version" from the package's versioned file and computes the bump from there. The file is **not** the authoritative record of what versions have been released — the git tags are. Two scenarios make the file untrustworthy:

1. **Parallel workflow race**: two PRs merge back-to-back, two `release` jobs start in parallel, both check out main at the pre-release state, both read the same version from the file, both compute the same next version. The first pushes, the second races / collides / silently fails.
2. **File/tag drift**: a merge of an old branch, revert, or manual edit leaves the file behind the latest tag. The file says `2.0.0` but a `v3.0.0` tag exists. The next bump tries to create a tag that already exists and FerrFlow prints `tag X already exists, skipping` — no release cut, user confused.

Scenario 2 is real: `FerrFlow-Org/Application#268` and `#269` merged cleanly, tests passed, but no new `api@v*` tag was ever created because `api@v3.0.0` existed from an earlier rollback.

## Change

- **`src/git.rs`** — new `find_highest_semver_tag(repo, prefix, strategy)` that returns `(tag_name, bare_version_string)`. Differs from `find_last_tag` in two ways:
  - compares by **semver** (correct ordering), not by tag-commit **time**
  - **skips pre-release tags** — they're never the authoritative baseline for a stable release
  - still honours `OrphanedTagStrategy` for unreachable tags
- **`src/monorepo.rs`** — the `release` flow now derives `current_version` from the highest matching semver tag, falling back to the file for bootstrap. If the file is manually ahead of the tag (human pre-bump), we take the max via `pick_higher_semver` — user intent is preserved.
- The file remains the write target (`cargo publish` etc. still see a coherent version). Only the bump **baseline** changes.

## Tests

- 7 new unit tests for `find_highest_semver_tag` in `src/git.rs`:
  - returns `None` with no matching tags
  - picks highest semver, not latest by time (reproduces the real-world drift case with `api@v3.0.0` existing alongside `api@v2.1.0` / `api@v2.2.0`)
  - strips prefix and leading `v`
  - ignores pre-release tags
  - ignores floating tags (`v1`, `latest`)
  - skips non-semver tags that happen to match the prefix
  - respects `OrphanedTagStrategy::Warn` for unreachable tags
- 6 new unit tests for `pick_higher_semver` in `src/monorepo.rs` covering tag-higher, file-higher, equality, invalid-file/invalid-tag fallbacks, and leading-`v` handling.
- Full suite: **520/520 tests pass** (507 pre-existing + 13 new). `cargo clippy -- -D warnings` and `cargo fmt --check` clean.

## Edge cases handled

| Situation | Behaviour |
|-----------|-----------|
| No tag yet (bootstrap) | Read from file as before |
| Tag and file agree | Unchanged |
| File > tag (human pre-bump) | Use file (preserves intent) |
| Tag > file (drift / race) | Use tag ← the fix |
| Pre-release tags (`-rc.1`) | Never the baseline for a stable release |
| Orphaned tags (`OrphanedTagStrategy::Warn`) | Excluded |
| Orphaned tags (`TreeHash` / `Message`) | Rematched onto HEAD, then considered |

## Migration

For repos where file and tags agree (the happy path, most repos), **behaviour is unchanged**. For repos where they disagree, FerrFlow now produces a correct bump instead of a silent skip or double-bump. No config flag — the new behaviour is strictly better.

Not a breaking change in the Rust-API sense (no signatures change) or the CLI-contract sense (command outputs are the same or clearer). Calling it `fix(release):` — should be a patch/minor bump, not major.

## Follow-up

Parallel workflows are now safe for version *computation*, but the second workflow's tag push may still race on the remote. A follow-up can add retry logic ("re-read tags, recompute, retry") — tracked separately.