### PR TITLE
feat(action): support Windows runners in install script

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,10 +35,13 @@ runs:
         OS=$(uname -s | tr '[:upper:]' '[:lower:]')
         ARCH=$(uname -m)
 
+        # Git Bash / MSYS / Cygwin on Windows runners all report a compound
+        # kernel name like "mingw64_nt-10.0". Normalise to "windows".
         case "$OS" in
-          linux)  PLATFORM="linux" ;;
-          darwin) PLATFORM="darwin" ;;
-          *)      echo "Unsupported OS: $OS" && exit 1 ;;
+          linux)                  PLATFORM="linux"   ; EXT="tar.gz" ;;
+          darwin)                 PLATFORM="darwin"  ; EXT="tar.gz" ;;
+          mingw*|msys*|cygwin*)   PLATFORM="windows" ; EXT="zip"    ;;
+          *)                      echo "Unsupported OS: $OS" && exit 1 ;;
         esac
 
         case "$ARCH" in
@@ -47,7 +50,7 @@ runs:
           *)             echo "Unsupported architecture: $ARCH" && exit 1 ;;
         esac
 
-        ARCHIVE="ferrflow-${PLATFORM}-${ARCH_NAME}.tar.gz"
+        ARCHIVE="ferrflow-${PLATFORM}-${ARCH_NAME}.${EXT}"
 
         if [ "${{ inputs.version }}" = "latest" ]; then
           URL="https://github.com/FerrFlow-Org/ferrflow/releases/latest/download/${ARCHIVE}"
@@ -57,8 +60,19 @@ runs:
 
         INSTALL_DIR="${RUNNER_TEMP:-$HOME/.local/bin}/ferrflow-bin"
         mkdir -p "$INSTALL_DIR"
-        curl --fail --location --silent --show-error "$URL" | tar -xz -C "$INSTALL_DIR"
-        chmod +x "$INSTALL_DIR/ferrflow"
+
+        if [ "$PLATFORM" = "windows" ]; then
+          # Can't pipe into unzip (needs a seekable file), so download first.
+          TMP_ZIP="${RUNNER_TEMP:-/tmp}/ferrflow.zip"
+          curl --fail --location --silent --show-error --output "$TMP_ZIP" "$URL"
+          unzip -q -o "$TMP_ZIP" -d "$INSTALL_DIR"
+          rm -f "$TMP_ZIP"
+          # No chmod needed on Windows; the .exe is already executable.
+        else
+          curl --fail --location --silent --show-error "$URL" | tar -xz -C "$INSTALL_DIR"
+          chmod +x "$INSTALL_DIR/ferrflow"
+        fi
+
         echo "$INSTALL_DIR" >> "$GITHUB_PATH"
 
     - name: Preview release


### PR DESCRIPTION
The install script in \`action.yml\` only handled Linux and macOS; Windows runners failed because \`uname -s\` returns \`MINGW64_NT-*\` / \`MSYS_NT-*\` and the \`windows-x64\` archive is a zip, not a tarball.

## Changes

- Detect Windows in the OS case (\`mingw*|msys*|cygwin*\`) and normalize the platform to \`windows\`.
- Pick archive extension per-platform: \`tar.gz\` for Linux/macOS, \`zip\` for Windows.
- On Windows, download to a temp file and extract with \`unzip\` (can't pipe into unzip — it needs a seekable file). Skip \`chmod +x\` since the \`.exe\` is already executable.
- Linux/macOS path unchanged (stream curl | tar -xz).

The install directory is still appended to \`GITHUB_PATH\`, so downstream steps can call \`ferrflow\` regardless of OS.

Closes #227