### PR TITLE
feat(config): auto-detect versioning strategy from existing tags

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -128,7 +128,7 @@ pub struct WorkspaceConfig {
     #[serde(default = "default_telemetry", alias = "telemetry")]
     pub anonymous_telemetry: bool,
     #[serde(default)]
-    pub versioning: VersioningStrategy,
+    pub versioning: Option<VersioningStrategy>,
     #[serde(alias = "tagTemplate")]
     pub tag_template: Option<String>,
     #[serde(default, alias = "recoverMissedReleases")]
@@ -237,8 +237,25 @@ pub enum FloatingTagLevel {
 }
 
 impl PackageConfig {
-    pub fn effective_versioning(&self, workspace: &WorkspaceConfig) -> VersioningStrategy {
-        self.versioning.unwrap_or(workspace.versioning)
+    /// Resolve the effective versioning strategy for this package. Priority:
+    ///   1. package.versioning if explicitly set
+    ///   2. workspace.versioning if explicitly set
+    ///   3. auto-detect from `tags` (filtered to tags relevant to this
+    ///      package — caller's job)
+    ///   4. fallback to [`VersioningStrategy::Semver`]
+    ///
+    /// Note: zerover is intentionally excluded from auto-detection because it
+    /// is ambiguous with semver (both use `X.Y.Z`). Users must opt-in
+    /// explicitly via config.
+    pub fn effective_versioning(
+        &self,
+        workspace: &WorkspaceConfig,
+        tags: &[&str],
+    ) -> VersioningStrategy {
+        self.versioning
+            .or(workspace.versioning)
+            .or_else(|| crate::versioning::detect_strategy_from_tags(tags))
+            .unwrap_or_default()
     }
 
     fn effective_template<'a>(
@@ -1148,12 +1165,24 @@ format = "toml"
             ]
         }"#;
         let config: Config = serde_json::from_str(json).unwrap();
-        assert_eq!(config.workspace.versioning, VersioningStrategy::Calver);
+        assert_eq!(
+            config.workspace.versioning,
+            Some(VersioningStrategy::Calver)
+        );
         assert_eq!(
             config.packages[0].versioning,
             Some(VersioningStrategy::Zerover)
         );
         assert_eq!(config.packages[1].versioning, None);
+    }
+
+    #[test]
+    fn workspace_versioning_defaults_to_none() {
+        // Unset `versioning` in config should deserialize to None so callers
+        // can tell "user said nothing" apart from "user said semver".
+        let json = r#"{ "workspace": {}, "package": [] }"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert_eq!(config.workspace.versioning, None);
     }
 
     #[test]
@@ -1168,7 +1197,11 @@ format = "toml"
         ] {
             let json = format!(r#"{{ "workspace": {{ "versioning": "{s}" }}, "package": [] }}"#);
             let config: Config = serde_json::from_str(&json).unwrap();
-            assert_eq!(config.workspace.versioning, expected, "failed for {s}");
+            assert_eq!(
+                config.workspace.versioning,
+                Some(expected),
+                "failed for {s}"
+            );
         }
     }
 
@@ -1179,7 +1212,7 @@ format = "toml"
     #[test]
     fn effective_versioning_inherits_workspace() {
         let ws = WorkspaceConfig {
-            versioning: VersioningStrategy::Calver,
+            versioning: Some(VersioningStrategy::Calver),
             ..WorkspaceConfig::default()
         };
         let pkg = PackageConfig {
@@ -1194,13 +1227,16 @@ format = "toml"
             hooks: None,
             floating_tags: None,
         };
-        assert_eq!(pkg.effective_versioning(&ws), VersioningStrategy::Calver);
+        assert_eq!(
+            pkg.effective_versioning(&ws, &[]),
+            VersioningStrategy::Calver
+        );
     }
 
     #[test]
     fn effective_versioning_package_overrides() {
         let ws = WorkspaceConfig {
-            versioning: VersioningStrategy::Calver,
+            versioning: Some(VersioningStrategy::Calver),
             ..WorkspaceConfig::default()
         };
         let pkg = PackageConfig {
@@ -1215,7 +1251,53 @@ format = "toml"
             hooks: None,
             floating_tags: None,
         };
-        assert_eq!(pkg.effective_versioning(&ws), VersioningStrategy::Zerover);
+        assert_eq!(
+            pkg.effective_versioning(&ws, &[]),
+            VersioningStrategy::Zerover
+        );
+    }
+
+    #[test]
+    fn effective_versioning_autodetects_from_tags_when_unset() {
+        let ws = WorkspaceConfig::default();
+        let pkg = PackageConfig {
+            name: "a".into(),
+            path: ".".into(),
+            versioned_files: vec![],
+            changelog: None,
+            shared_paths: vec![],
+            depends_on: vec![],
+            versioning: None,
+            tag_template: None,
+            hooks: None,
+            floating_tags: None,
+        };
+        let tags = vec!["v2024.04.18", "v2024.05.01"];
+        assert_eq!(
+            pkg.effective_versioning(&ws, &tags),
+            VersioningStrategy::Calver
+        );
+    }
+
+    #[test]
+    fn effective_versioning_falls_back_to_semver_without_tags() {
+        let ws = WorkspaceConfig::default();
+        let pkg = PackageConfig {
+            name: "a".into(),
+            path: ".".into(),
+            versioned_files: vec![],
+            changelog: None,
+            shared_paths: vec![],
+            depends_on: vec![],
+            versioning: None,
+            tag_template: None,
+            hooks: None,
+            floating_tags: None,
+        };
+        assert_eq!(
+            pkg.effective_versioning(&ws, &[]),
+            VersioningStrategy::Semver
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -2014,7 +2096,7 @@ format = "toml"
     fn default_workspace_config_values() {
         // Default trait gives empty strings; serde defaults give "origin"/"main"
         let ws = WorkspaceConfig::default();
-        assert_eq!(ws.versioning, VersioningStrategy::Semver);
+        assert_eq!(ws.versioning, None);
         assert!(ws.tag_template.is_none());
         assert!(!ws.recover_missed_releases);
         assert_eq!(ws.release_commit_mode, ReleaseCommitMode::Commit);

--- a/src/monorepo.rs
+++ b/src/monorepo.rs
@@ -23,6 +23,17 @@ use git2::Repository;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
+/// Collect the subset of `all_tags` whose names start with the package's
+/// configured tag prefix. Used to feed per-package versioning auto-detection
+/// so that unrelated packages' tags don't pollute the result.
+fn tags_for_package<'a>(all_tags: &'a [String], prefix: &str) -> Vec<&'a str> {
+    all_tags
+        .iter()
+        .filter(|t| t.starts_with(prefix))
+        .map(|t| t.as_str())
+        .collect()
+}
+
 fn build_forge_instance(repo: &Repository, config: &Config) -> Option<Box<dyn forge::Forge>> {
     let remote_url = get_remote_url(repo, &config.workspace.remote)?;
     let slug = forge::extract_repo_slug(&remote_url)?;
@@ -389,7 +400,10 @@ fn run_release_logic(
         // Pre-compute the package strategy so we can bootstrap a baseline
         // when neither a git tag nor an on-disk version is available (fresh
         // go.mod-only package being released for the first time).
-        let pkg_strategy = pkg.effective_versioning(&config.workspace);
+        let pkg_strategy = pkg.effective_versioning(
+            &config.workspace,
+            &tags_for_package(&all_tags, &tag_search_prefix),
+        );
 
         // `read_version` fails for `go.mod` when no matching tag exists yet
         // — and potentially for other formats in edge cases. Fall back to
@@ -450,7 +464,10 @@ fn run_release_logic(
                 continue;
             }
 
-            let strategy = pkg.effective_versioning(&config.workspace);
+            let strategy = pkg.effective_versioning(
+                &config.workspace,
+                &tags_for_package(&all_tags, &tag_search_prefix),
+            );
 
             let bump = commits
                 .iter()
@@ -508,7 +525,10 @@ fn run_release_logic(
         let strategy_label = if forced_ver_for_pkg.is_some() {
             "forced".to_string()
         } else {
-            let strategy = pkg.effective_versioning(&config.workspace);
+            let strategy = pkg.effective_versioning(
+                &config.workspace,
+                &tags_for_package(&all_tags, &tag_search_prefix),
+            );
             let is_date_or_seq = matches!(
                 strategy,
                 VersioningStrategy::Calver
@@ -757,7 +777,11 @@ fn run_release_logic(
                 let Ok(current_version) = read_version(vf, root) else {
                     continue;
                 };
-                let strategy = pkg.effective_versioning(&config.workspace);
+                let pkg_tag_prefix = pkg.tag_prefix(&config.workspace, config.is_monorepo());
+                let strategy = pkg.effective_versioning(
+                    &config.workspace,
+                    &tags_for_package(&all_tags, &pkg_tag_prefix),
+                );
                 let Ok(new_version) =
                     compute_next_version(&current_version, BumpType::Patch, strategy)
                 else {

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -148,6 +148,150 @@ pub fn bump_version(current: &str, bump: BumpType) -> Result<String> {
     bump_semver(current, bump)
 }
 
+/// Strip any monorepo prefix like `my-pkg@` and a leading `v`, yielding the
+/// raw version-like tail. Also handles `release/` style prefixes by dropping
+/// any leading non-digit characters up to (but not including) the first
+/// segment that looks like a version.
+fn strip_tag_prefix(tag: &str) -> &str {
+    // First, if there's a `@` in the tag, take the portion after the last `@`.
+    // This covers `pkg@v1.2.3`, `@scope/pkg@v1.2.3`, etc.
+    let after_at = tag.rsplit_once('@').map(|(_, rest)| rest).unwrap_or(tag);
+    // Then drop a `release/`, `rel/`, `refs/tags/` or any other prefix segment
+    // separated by `/` — take the last path component.
+    let after_slash = after_at
+        .rsplit_once('/')
+        .map(|(_, r)| r)
+        .unwrap_or(after_at);
+    // Finally strip a leading `v` or `V`.
+    after_slash
+        .strip_prefix('v')
+        .or_else(|| after_slash.strip_prefix('V'))
+        .unwrap_or(after_slash)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum TagClass {
+    CalverSeq,
+    Calver,
+    CalverShort,
+    Semver,
+    Sequential,
+}
+
+/// Classify a single tag into its most-specific category, if any.
+///
+/// Returns `None` for tags that don't look like any known version shape.
+///
+/// For 4-digit-year `YYYY.M.D` shapes with a third segment ≤ 31 we return
+/// `Calver`; larger third segments indicate an auto-increment counter and
+/// return `CalverSeq`. See module docs for the ambiguity rules.
+fn classify_tag(tag: &str) -> Option<TagClass> {
+    use regex::Regex;
+    use std::sync::OnceLock;
+
+    // Three-segment calver/calver-seq (4-digit year)
+    static CALVER_RE: OnceLock<Regex> = OnceLock::new();
+    // Three-segment calver-short (2-digit year 20..=99)
+    static CALVER_SHORT_RE: OnceLock<Regex> = OnceLock::new();
+    // Three-segment semver-ish
+    static SEMVER_RE: OnceLock<Regex> = OnceLock::new();
+    // Single number sequential
+    static SEQUENTIAL_RE: OnceLock<Regex> = OnceLock::new();
+
+    let calver_re = CALVER_RE.get_or_init(|| Regex::new(r"^(\d{4})\.(\d{1,2})\.(\d+)$").unwrap());
+    let calver_short_re =
+        CALVER_SHORT_RE.get_or_init(|| Regex::new(r"^(\d{2})\.(\d{1,2})\.(\d{1,2})$").unwrap());
+    let semver_re = SEMVER_RE.get_or_init(|| Regex::new(r"^\d+\.\d+\.\d+$").unwrap());
+    let sequential_re = SEQUENTIAL_RE.get_or_init(|| Regex::new(r"^\d+$").unwrap());
+
+    let stripped = strip_tag_prefix(tag);
+
+    if let Some(caps) = calver_re.captures(stripped) {
+        let year: u32 = caps[1].parse().ok()?;
+        let month: u32 = caps[2].parse().ok()?;
+        let third: u32 = caps[3].parse().ok()?;
+        // Require a plausible year and month to avoid misclassifying oddball
+        // semver tags like `1970.13.0` that happen to match the digit shape.
+        if (1970..=9999).contains(&year) && (1..=12).contains(&month) {
+            if third > 31 {
+                return Some(TagClass::CalverSeq);
+            }
+            return Some(TagClass::Calver);
+        }
+    }
+
+    if let Some(caps) = calver_short_re.captures(stripped) {
+        let year: u32 = caps[1].parse().ok()?;
+        let month: u32 = caps[2].parse().ok()?;
+        let day: u32 = caps[3].parse().ok()?;
+        // Plausible short-year range + valid month/day window. Lower bound 20
+        // avoids matching semver tags like `1.2.3` / `10.11.12`.
+        if (20..=99).contains(&year) && (1..=12).contains(&month) && (1..=31).contains(&day) {
+            return Some(TagClass::CalverShort);
+        }
+    }
+
+    if semver_re.is_match(stripped) {
+        return Some(TagClass::Semver);
+    }
+
+    if sequential_re.is_match(stripped) {
+        return Some(TagClass::Sequential);
+    }
+
+    None
+}
+
+/// Infer the versioning strategy from a list of existing git tag names.
+///
+/// Returns `None` when no tags match any known strategy. Callers should fall
+/// back to the explicit default ([`VersioningStrategy::Semver`]) in that case.
+///
+/// When tags match multiple patterns, the most specific one wins:
+/// `calver-seq` > `calver` > `calver-short` > `semver` > `sequential`. That
+/// ordering matters because a `v2024.04.18` tag matches both calver and a
+/// relaxed semver shape — we pick the date-aware one.
+///
+/// Zerover is intentionally excluded: it is ambiguous with semver (both use
+/// `X.Y.Z`), so we fall through to semver and require an explicit opt-in for
+/// zerover.
+pub fn detect_strategy_from_tags(tags: &[&str]) -> Option<VersioningStrategy> {
+    let mut has_calver_seq = false;
+    let mut has_calver = false;
+    let mut has_calver_short = false;
+    let mut has_semver = false;
+    let mut has_sequential = false;
+
+    for tag in tags {
+        match classify_tag(tag) {
+            Some(TagClass::CalverSeq) => has_calver_seq = true,
+            Some(TagClass::Calver) => has_calver = true,
+            Some(TagClass::CalverShort) => has_calver_short = true,
+            Some(TagClass::Semver) => has_semver = true,
+            Some(TagClass::Sequential) => has_sequential = true,
+            None => {}
+        }
+    }
+
+    // Specificity tiers — most specific wins even if less specific has more hits.
+    if has_calver_seq {
+        return Some(VersioningStrategy::CalverSeq);
+    }
+    if has_calver {
+        return Some(VersioningStrategy::Calver);
+    }
+    if has_calver_short {
+        return Some(VersioningStrategy::CalverShort);
+    }
+    if has_semver {
+        return Some(VersioningStrategy::Semver);
+    }
+    if has_sequential {
+        return Some(VersioningStrategy::Sequential);
+    }
+    None
+}
+
 pub fn truncate_version(version: &str, level: FloatingTagLevel) -> Option<String> {
     let v = version.trim_start_matches('v');
     let parts: Vec<&str> = v.split('.').collect();
@@ -580,6 +724,118 @@ mod tests {
     fn bump_semver_none_strips_prerelease() {
         let result = bump_semver("1.1.0-dev.1", BumpType::None).unwrap();
         assert_eq!(result, "1.1.0");
+    }
+
+    #[test]
+    fn detect_returns_none_when_no_tags() {
+        assert_eq!(detect_strategy_from_tags(&[]), None);
+    }
+
+    #[test]
+    fn detect_semver_from_plain_v_tags() {
+        let tags = vec!["v1.2.3", "v1.3.0", "v2.0.0"];
+        assert_eq!(
+            detect_strategy_from_tags(&tags),
+            Some(VersioningStrategy::Semver)
+        );
+    }
+
+    #[test]
+    fn detect_calver() {
+        let tags = vec!["v2024.04.18", "v2024.05.01"];
+        assert_eq!(
+            detect_strategy_from_tags(&tags),
+            Some(VersioningStrategy::Calver)
+        );
+    }
+
+    #[test]
+    fn detect_calver_short() {
+        let tags = vec!["v24.4.18", "v25.1.1"];
+        assert_eq!(
+            detect_strategy_from_tags(&tags),
+            Some(VersioningStrategy::CalverShort)
+        );
+    }
+
+    #[test]
+    fn detect_calver_seq() {
+        let tags = vec!["v2024.04.1", "v2024.04.42", "v2024.04.100"];
+        assert_eq!(
+            detect_strategy_from_tags(&tags),
+            Some(VersioningStrategy::CalverSeq)
+        );
+    }
+
+    #[test]
+    fn detect_sequential() {
+        let tags = vec!["v1", "v2", "v3"];
+        assert_eq!(
+            detect_strategy_from_tags(&tags),
+            Some(VersioningStrategy::Sequential)
+        );
+    }
+
+    #[test]
+    fn detect_ignores_monorepo_prefix() {
+        let tags = vec!["pkg@v1.2.3", "pkg@v1.3.0"];
+        assert_eq!(
+            detect_strategy_from_tags(&tags),
+            Some(VersioningStrategy::Semver)
+        );
+    }
+
+    #[test]
+    fn detect_none_for_gibberish() {
+        let tags = vec!["release-foo", "rc-2024"];
+        assert_eq!(detect_strategy_from_tags(&tags), None);
+    }
+
+    #[test]
+    fn detect_prefers_calver_over_semver() {
+        let tags = vec!["v2024.01.01", "v1.2.3"];
+        assert_eq!(
+            detect_strategy_from_tags(&tags),
+            Some(VersioningStrategy::Calver)
+        );
+    }
+
+    #[test]
+    fn detect_strips_tag_prefixes_like_release_slash() {
+        let tags = vec!["release/v1.2.3"];
+        assert_eq!(
+            detect_strategy_from_tags(&tags),
+            Some(VersioningStrategy::Semver)
+        );
+    }
+
+    #[test]
+    fn detect_sequential_without_v_prefix() {
+        let tags = vec!["1", "2", "3"];
+        assert_eq!(
+            detect_strategy_from_tags(&tags),
+            Some(VersioningStrategy::Sequential)
+        );
+    }
+
+    #[test]
+    fn detect_ignores_non_matching_tags_but_picks_matching() {
+        let tags = vec!["latest", "stable", "v1.2.3", "nightly"];
+        assert_eq!(
+            detect_strategy_from_tags(&tags),
+            Some(VersioningStrategy::Semver)
+        );
+    }
+
+    #[test]
+    fn detect_calver_seq_mixed_with_calver_shape_prefers_seq() {
+        // v2024.04.100 triggers calver-seq (100 > 31), even though
+        // v2024.04.10 would otherwise classify as calver.
+        let tags = vec!["v2024.04.10", "v2024.04.100"];
+        assert_eq!(
+            detect_strategy_from_tags(&tags),
+            Some(VersioningStrategy::CalverSeq)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When \`versioning\` isn't set in the config, FerrFlow now scans existing git tags and infers the strategy instead of silently defaulting to semver.

Resolution order: \`package.versioning\` > \`workspace.versioning\` > detected from tags > \`semver\` fallback.

Detection specificity (most-specific wins): \`calver-seq\` > \`calver\` > \`calver-short\` > \`semver\` > \`sequential\`.

\`zerover\` is intentionally not auto-detected — its tag shape is identical to \`semver\`, so users must opt in explicitly.

## Behaviour changes

- Empty repo or tags that match nothing recognisable → \`Semver\` fallback (same as today).
- Repo with calver-shaped tags and no \`versioning\` in config → \`Calver\` now; was silently \`Semver\` before (the bug this fixes).
- Monorepo tags are stripped of their \`name@\` prefix before classification, so per-package detection works when tag templates use the monorepo default.
- Ambiguous single calver vs calver-seq (3rd segment ≤ 31) resolves to \`Calver\` unless a second tag reveals a segment > 31.

## Breaking change for library consumers

- \`WorkspaceConfig.versioning\` is now \`Option<VersioningStrategy>\` (was \`VersioningStrategy\` defaulting to \`Semver\`).
- \`PackageConfig::effective_versioning\` now takes \`tags: &[&str]\` in addition to the workspace config.

CLI end users are unaffected — config files that explicitly set \`versioning\` keep working exactly as before.

## Test plan

- [x] \`cargo build\` clean.
- [x] \`cargo test\` green — 449 bin tests + 542 lib tests (14 new: 11 detection cases + 3 config cases).
- [x] \`cargo clippy -- -D warnings\` clean on touched files.
- [x] \`cargo fmt --check\` clean on touched files.
- [ ] CI green.

Closes #334