### PR TITLE
ci: retry cross binary download to survive GitHub 504s

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,9 +42,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install cross
         if: matrix.os == 'ubuntu-latest'
+        # Download via curl with retries — we hit GitHub 504s here from time to
+        # time (see FerrFlow-Org/FerrFlow Publish run 24610662869), and the
+        # whole release pipeline deserves better than a single-shot fetch.
         run: |
-          curl -fsSL https://github.com/cross-rs/cross/releases/latest/download/cross-x86_64-unknown-linux-musl.tar.gz \
-            | tar xz -C "$HOME/.cargo/bin"
+          curl -fsSL --retry 6 --retry-delay 5 --retry-connrefused --retry-all-errors \
+            -o /tmp/cross.tar.gz \
+            https://github.com/cross-rs/cross/releases/latest/download/cross-x86_64-unknown-linux-musl.tar.gz
+          tar xz -C "$HOME/.cargo/bin" -f /tmp/cross.tar.gz
+          rm /tmp/cross.tar.gz
       - name: Build (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: cross build --release --target ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install cross
         if: matrix.os == 'ubuntu-latest'
+        # Download via curl with retries — GitHub occasionally serves 504s on
+        # release-asset URLs and we don't want the whole release matrix to fail
+        # for a transient gateway hiccup.
         run: |
-          curl -fsSL https://github.com/cross-rs/cross/releases/latest/download/cross-x86_64-unknown-linux-musl.tar.gz \
-            | tar xz -C "$HOME/.cargo/bin"
+          curl -fsSL --retry 6 --retry-delay 5 --retry-connrefused --retry-all-errors \
+            -o /tmp/cross.tar.gz \
+            https://github.com/cross-rs/cross/releases/latest/download/cross-x86_64-unknown-linux-musl.tar.gz
+          tar xz -C "$HOME/.cargo/bin" -f /tmp/cross.tar.gz
+          rm /tmp/cross.tar.gz
       - name: Build (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: cross build --release --target ${{ matrix.target }}


### PR DESCRIPTION
## Summary

The Publish run for v3.2.0 failed at \`curl -fsSL https://github.com/cross-rs/cross/releases/latest/download/...\` with HTTP 504 ([failed job](https://github.com/FerrFlow-Org/FerrFlow/actions/runs/24610662869/job/71964354767)). The whole linux-musl cross-compile step dies on a single gateway hiccup.

Fix: curl with \`--retry 6 --retry-delay 5 --retry-connrefused --retry-all-errors\`. The last flag covers 5xx responses in addition to connection errors. Also: download to a file first instead of piping into \`tar\` so a truncated transfer retries instead of producing a corrupted extracted binary.

Applied in both \`publish.yml\` and \`release.yml\` since they share the install step.

## Test plan

- [ ] CI green on this PR.
- [ ] Next release cycle triggers \`Publish\` without needing manual rerun.