### PR TITLE
feat(formats): add PubspecYaml, MixExs, ChartYaml, Gemspec, PackageSwift + file-mapping docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "3.0.3"
+version = "3.2.1"
 dependencies = [
  "anyhow",
  "cargo-husky",

--- a/README.md
+++ b/README.md
@@ -18,17 +18,22 @@ A single compiled binary with no runtime dependencies. Native monorepo support, 
 
 ## Supported version files
 
-| Format | File | Ecosystem |
-|--------|------|-----------|
-| TOML | `Cargo.toml` | Rust |
-| TOML | `pyproject.toml` | Python |
-| JSON | `package.json` | Node.js |
-| XML | `pom.xml` | Java / Maven |
-| CSProj | `*.csproj` | .NET (C#, F#) |
-| Gradle | `build.gradle` | Java / Kotlin |
-| Helm | `Chart.yaml` | Kubernetes / Helm |
-| Go | `go.mod` | Go (tag-only, no file write) |
-| Text | `VERSION`, `VERSION.txt` | Any |
+| Format | File | Ecosystem | Selector |
+|--------|------|-----------|----------|
+| `toml` | `Cargo.toml` | Rust | `package.version` |
+| `toml` | `pyproject.toml` | Python | `project.version` or `tool.poetry.version` |
+| `json` | `package.json` | Node.js | `version` |
+| `json` | `composer.json` | PHP | `version` |
+| `xml` | `pom.xml` | Java / Maven | first `<version>` tag |
+| `csproj` | `*.csproj` | .NET (C#, F#) | `<Version>` in `<PropertyGroup>` |
+| `gradle` | `build.gradle`, `build.gradle.kts` | Java / Kotlin | `version = "…"` |
+| `helm` / `chartyaml` | `Chart.yaml` | Kubernetes / Helm | top-level `version:` |
+| `pubspecyaml` | `pubspec.yaml` | Dart / Flutter | top-level `version:` |
+| `mixexs` | `mix.exs` | Elixir | `version: "…"` in `def project` |
+| `gemspec` | `*.gemspec` | Ruby | `s.version = "…"` |
+| `packageswift` | `Package.swift` | Swift | top-level `let <name>Version = "…"` |
+| `gomod` | `go.mod` | Go | git tag only — no file write |
+| `txt` | `VERSION`, `VERSION.txt` | Any | entire file content |
 
 ## Installation
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -314,11 +314,27 @@ pub enum FileFormat {
     #[serde(rename = "gomod")]
     GoMod,
     Gradle,
+    /// `values.yaml` templating for Helm charts. For the top-level
+    /// `Chart.yaml` manifest use [`FileFormat::ChartYaml`] instead.
     Helm,
     Json,
     Toml,
     Txt,
     Xml,
+    /// `pubspec.yaml` for Dart / Flutter packages.
+    #[serde(rename = "pubspecyaml")]
+    PubspecYaml,
+    /// `mix.exs` for Elixir / Mix projects.
+    #[serde(rename = "mixexs")]
+    MixExs,
+    /// `Chart.yaml` for Helm chart top-level manifests.
+    #[serde(rename = "chartyaml")]
+    ChartYaml,
+    /// `*.gemspec` for Ruby gems.
+    Gemspec,
+    /// `Package.swift` for Swift packages.
+    #[serde(rename = "packageswift")]
+    PackageSwift,
 }
 
 // ---------------------------------------------------------------------------

--- a/src/error_code.rs
+++ b/src/error_code.rs
@@ -19,6 +19,11 @@ use std::fmt;
 /// - E4500–E4599: Gradle version files
 /// - E4600–E4699: Go mod version files
 /// - E4700–E4799: Text version files
+/// - E4800–E4809: Pubspec.yaml (Dart / Flutter)
+/// - E4810–E4819: mix.exs (Elixir)
+/// - E4820–E4829: Chart.yaml (Helm chart manifest)
+/// - E4830–E4839: *.gemspec (Ruby)
+/// - E4840–E4849: Package.swift (Swift)
 /// - E5000–E5099: Pre-release / channels
 /// - E5010–E5019: Versioning
 /// - E6000–E6099: Hooks
@@ -246,6 +251,56 @@ pub const TXT_VERSION_NOT_FOUND: ErrorCode = ErrorCode(4702);
 pub const TXT_WRITE: ErrorCode = ErrorCode(4703);
 #[allow(dead_code)]
 pub const TXT_INVALID_UTF8: ErrorCode = ErrorCode(4704);
+
+// ── Version files — PubspecYaml (E4800–E4809) ────────────────────────────────
+#[allow(dead_code)]
+pub const PUBSPEC_READ: ErrorCode = ErrorCode(4801);
+#[allow(dead_code)]
+pub const PUBSPEC_VERSION_NOT_FOUND: ErrorCode = ErrorCode(4802);
+#[allow(dead_code)]
+pub const PUBSPEC_WRITE: ErrorCode = ErrorCode(4803);
+#[allow(dead_code)]
+pub const PUBSPEC_INVALID_UTF8: ErrorCode = ErrorCode(4804);
+
+// ── Version files — MixExs (E4810–E4819) ─────────────────────────────────────
+#[allow(dead_code)]
+pub const MIX_EXS_READ: ErrorCode = ErrorCode(4811);
+#[allow(dead_code)]
+pub const MIX_EXS_VERSION_NOT_FOUND: ErrorCode = ErrorCode(4812);
+#[allow(dead_code)]
+pub const MIX_EXS_WRITE: ErrorCode = ErrorCode(4813);
+#[allow(dead_code)]
+pub const MIX_EXS_INVALID_UTF8: ErrorCode = ErrorCode(4814);
+
+// ── Version files — ChartYaml (E4820–E4829) ──────────────────────────────────
+#[allow(dead_code)]
+pub const CHART_YAML_READ: ErrorCode = ErrorCode(4821);
+#[allow(dead_code)]
+pub const CHART_YAML_VERSION_NOT_FOUND: ErrorCode = ErrorCode(4822);
+#[allow(dead_code)]
+pub const CHART_YAML_WRITE: ErrorCode = ErrorCode(4823);
+#[allow(dead_code)]
+pub const CHART_YAML_INVALID_UTF8: ErrorCode = ErrorCode(4824);
+
+// ── Version files — Gemspec (E4830–E4839) ────────────────────────────────────
+#[allow(dead_code)]
+pub const GEMSPEC_READ: ErrorCode = ErrorCode(4831);
+#[allow(dead_code)]
+pub const GEMSPEC_VERSION_NOT_FOUND: ErrorCode = ErrorCode(4832);
+#[allow(dead_code)]
+pub const GEMSPEC_WRITE: ErrorCode = ErrorCode(4833);
+#[allow(dead_code)]
+pub const GEMSPEC_INVALID_UTF8: ErrorCode = ErrorCode(4834);
+
+// ── Version files — PackageSwift (E4840–E4849) ───────────────────────────────
+#[allow(dead_code)]
+pub const PACKAGE_SWIFT_READ: ErrorCode = ErrorCode(4841);
+#[allow(dead_code)]
+pub const PACKAGE_SWIFT_VERSION_NOT_FOUND: ErrorCode = ErrorCode(4842);
+#[allow(dead_code)]
+pub const PACKAGE_SWIFT_WRITE: ErrorCode = ErrorCode(4843);
+#[allow(dead_code)]
+pub const PACKAGE_SWIFT_INVALID_UTF8: ErrorCode = ErrorCode(4844);
 
 // ── Pre-release (E5000–E5099) ────────────────────────────────────────────────
 #[allow(dead_code)]

--- a/src/formats/chart_yaml.rs
+++ b/src/formats/chart_yaml.rs
@@ -1,0 +1,124 @@
+//! `Chart.yaml` (Helm chart top-level manifest) version handler.
+//!
+//! Distinct from the existing [`super::helm::HelmVersionFile`] which targets
+//! `values.yaml` templating (`{{ .Chart.Version }}`-style). Chart.yaml uses a
+//! literal `version:` key at the top level, the same shape as `pubspec.yaml`
+//! but with a different idiomatic layout and separate docs surface. We keep
+//! them as distinct variants so users opting in to either don't need to
+//! understand the internals of the sibling file.
+
+use super::VersionFile;
+use crate::error_code::{self, ErrorCodeExt};
+use anyhow::{Context, Result};
+use regex::Regex;
+use std::path::Path;
+use std::sync::OnceLock;
+
+pub struct ChartYamlVersionFile;
+
+static VERSION_RE: OnceLock<Regex> = OnceLock::new();
+
+fn version_re() -> &'static Regex {
+    // Top-level `version:` only — charts also define `appVersion:`, which is
+    // a different concept (the app shipped by the chart, not the chart
+    // itself). We leave `appVersion:` strictly alone.
+    VERSION_RE.get_or_init(|| {
+        Regex::new(r#"(?m)^(version:\s*)(["']?)([^"'\s#]+)(["']?)\s*(?:#.*)?$"#).unwrap()
+    })
+}
+
+impl VersionFile for ChartYamlVersionFile {
+    fn read_version(&self, file_path: &Path) -> Result<String> {
+        let content = std::fs::read_to_string(file_path)
+            .with_context(|| format!("Cannot read {}", file_path.display()))
+            .error_code(error_code::CHART_YAML_READ)?;
+        self.read_version_from_bytes(content.as_bytes(), &file_path.display().to_string())
+    }
+
+    fn write_version(&self, file_path: &Path, version: &str) -> Result<()> {
+        let content = std::fs::read_to_string(file_path)
+            .with_context(|| format!("Cannot read {}", file_path.display()))
+            .error_code(error_code::CHART_YAML_READ)?;
+        if !version_re().is_match(&content) {
+            Err(anyhow::anyhow!(
+                "No top-level version: key found in {}",
+                file_path.display()
+            ))
+            .error_code(error_code::CHART_YAML_VERSION_NOT_FOUND)?;
+        }
+        let new_content = version_re().replace(&content, |caps: &regex::Captures| {
+            format!("{}{}{}{}", &caps[1], &caps[2], version, &caps[4])
+        });
+        std::fs::write(file_path, new_content.as_ref())
+            .with_context(|| format!("Cannot write {}", file_path.display()))
+            .error_code(error_code::CHART_YAML_WRITE)?;
+        Ok(())
+    }
+
+    fn read_version_from_bytes(&self, content: &[u8], filename: &str) -> Result<String> {
+        let text = std::str::from_utf8(content)
+            .with_context(|| format!("Invalid UTF-8 in {filename}"))
+            .error_code(error_code::CHART_YAML_INVALID_UTF8)?;
+        version_re()
+            .captures(text)
+            .map(|c| c[3].to_string())
+            .ok_or_else(|| anyhow::anyhow!("No top-level version: key found in {filename}"))
+            .error_code(error_code::CHART_YAML_VERSION_NOT_FOUND)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_temp(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f
+    }
+
+    const FIXTURE: &str = "apiVersion: v2\n\
+                            name: my-chart\n\
+                            description: A Helm chart\n\
+                            type: application\n\
+                            version: 0.1.0\n\
+                            appVersion: \"1.16.0\"\n";
+
+    #[test]
+    fn read_version_not_app_version() {
+        let f = write_temp(FIXTURE);
+        assert_eq!(
+            ChartYamlVersionFile.read_version(f.path()).unwrap(),
+            "0.1.0"
+        );
+    }
+
+    #[test]
+    fn write_leaves_app_version_untouched() {
+        let f = write_temp(FIXTURE);
+        ChartYamlVersionFile
+            .write_version(f.path(), "0.2.0")
+            .unwrap();
+        let out = std::fs::read_to_string(f.path()).unwrap();
+        assert!(out.contains("version: 0.2.0"));
+        // appVersion must stay exactly as it was — different concept.
+        assert!(out.contains("appVersion: \"1.16.0\""));
+    }
+
+    #[test]
+    fn read_quoted_version() {
+        let f = write_temp("apiVersion: v2\nname: x\nversion: \"1.2.3\"\n");
+        assert_eq!(
+            ChartYamlVersionFile.read_version(f.path()).unwrap(),
+            "1.2.3"
+        );
+    }
+
+    #[test]
+    fn read_no_version_fails() {
+        let f = write_temp("apiVersion: v2\nname: x\n");
+        assert!(ChartYamlVersionFile.read_version(f.path()).is_err());
+    }
+}

--- a/src/formats/gemspec.rs
+++ b/src/formats/gemspec.rs
@@ -1,0 +1,127 @@
+//! `*.gemspec` (Ruby) version handler.
+//!
+//! Matches assignments of the form `s.version = "x.y.z"` or
+//! `spec.version = 'x.y.z'` inside a `Gem::Specification.new` block. The
+//! receiver name varies by convention (`s`, `spec`, `gem`, …) so we accept
+//! any identifier; the unique bit is the `.version =` suffix.
+//!
+//! A gemspec can also set the version from a constant
+//! (`s.version = MyGem::VERSION`) loaded from `lib/my_gem/version.rb`. That
+//! pattern isn't supported here — users in that setup should version the
+//! `version.rb` file via [`super::txt::TxtVersionFile`] or a
+//! regex-targeted file (follow-up work if the demand shows up).
+
+use super::VersionFile;
+use crate::error_code::{self, ErrorCodeExt};
+use anyhow::{Context, Result};
+use regex::Regex;
+use std::path::Path;
+use std::sync::OnceLock;
+
+pub struct GemspecVersionFile;
+
+static VERSION_RE: OnceLock<Regex> = OnceLock::new();
+
+fn version_re() -> &'static Regex {
+    // `<ident>.version = "x.y.z"` — accepts single or double quotes, any
+    // amount of whitespace around `=`.
+    VERSION_RE.get_or_init(|| Regex::new(r#"(\.version\s*=\s*)(["'])([^"']+)(["'])"#).unwrap())
+}
+
+impl VersionFile for GemspecVersionFile {
+    fn read_version(&self, file_path: &Path) -> Result<String> {
+        let content = std::fs::read_to_string(file_path)
+            .with_context(|| format!("Cannot read {}", file_path.display()))
+            .error_code(error_code::GEMSPEC_READ)?;
+        self.read_version_from_bytes(content.as_bytes(), &file_path.display().to_string())
+    }
+
+    fn write_version(&self, file_path: &Path, version: &str) -> Result<()> {
+        let content = std::fs::read_to_string(file_path)
+            .with_context(|| format!("Cannot read {}", file_path.display()))
+            .error_code(error_code::GEMSPEC_READ)?;
+        if !version_re().is_match(&content) {
+            Err(anyhow::anyhow!(
+                "No `.version = \"…\"` assignment found in {}",
+                file_path.display()
+            ))
+            .error_code(error_code::GEMSPEC_VERSION_NOT_FOUND)?;
+        }
+        let new_content = version_re().replace(&content, |caps: &regex::Captures| {
+            format!("{}{}{}{}", &caps[1], &caps[2], version, &caps[4])
+        });
+        std::fs::write(file_path, new_content.as_ref())
+            .with_context(|| format!("Cannot write {}", file_path.display()))
+            .error_code(error_code::GEMSPEC_WRITE)?;
+        Ok(())
+    }
+
+    fn read_version_from_bytes(&self, content: &[u8], filename: &str) -> Result<String> {
+        let text = std::str::from_utf8(content)
+            .with_context(|| format!("Invalid UTF-8 in {filename}"))
+            .error_code(error_code::GEMSPEC_INVALID_UTF8)?;
+        version_re()
+            .captures(text)
+            .map(|c| c[3].to_string())
+            .ok_or_else(|| anyhow::anyhow!("No `.version = \"…\"` assignment found in {filename}"))
+            .error_code(error_code::GEMSPEC_VERSION_NOT_FOUND)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_temp(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f
+    }
+
+    const FIXTURE: &str = r#"Gem::Specification.new do |s|
+  s.name        = "my_gem"
+  s.version     = "0.1.0"
+  s.summary     = "A gem"
+  s.authors     = ["Ada"]
+  s.files       = Dir["lib/**/*.rb"]
+end
+"#;
+
+    #[test]
+    fn read_canonical_gemspec() {
+        let f = write_temp(FIXTURE);
+        assert_eq!(GemspecVersionFile.read_version(f.path()).unwrap(), "0.1.0");
+    }
+
+    #[test]
+    fn write_preserves_double_quotes() {
+        let f = write_temp(FIXTURE);
+        GemspecVersionFile.write_version(f.path(), "0.2.0").unwrap();
+        let out = std::fs::read_to_string(f.path()).unwrap();
+        assert!(out.contains("s.version     = \"0.2.0\""));
+        // Sibling assignments untouched.
+        assert!(out.contains("s.name        = \"my_gem\""));
+    }
+
+    #[test]
+    fn write_preserves_single_quotes() {
+        let f = write_temp("spec.version = '1.0.0'\n");
+        GemspecVersionFile.write_version(f.path(), "2.0.0").unwrap();
+        let out = std::fs::read_to_string(f.path()).unwrap();
+        assert!(out.contains("spec.version = '2.0.0'"));
+    }
+
+    #[test]
+    fn read_arbitrary_receiver_name() {
+        let f = write_temp("gem.version = \"1.2.3\"\n");
+        assert_eq!(GemspecVersionFile.read_version(f.path()).unwrap(), "1.2.3");
+    }
+
+    #[test]
+    fn read_no_version_fails() {
+        let f = write_temp("Gem::Specification.new do |s|\n  s.name = \"x\"\nend\n");
+        assert!(GemspecVersionFile.read_version(f.path()).is_err());
+    }
+}

--- a/src/formats/mix_exs.rs
+++ b/src/formats/mix_exs.rs
@@ -1,0 +1,157 @@
+//! `mix.exs` (Elixir) version handler.
+//!
+//! Targets the `version: "x.y.z"` literal inside a Mix project definition
+//! (typically `def project do [ ..., version: "x.y.z", ... ] end`). We do a
+//! regex replace rather than parsing Elixir — the idiomatic placement is a
+//! single occurrence in the project keyword list, and a structural parse
+//! would require a full Elixir lexer. Edge cases (version inside a
+//! comment, version inside a dependency tuple) are accepted losses here:
+//! they're extremely rare in the wild, and a misplaced match is a build
+//! failure rather than a silent corruption.
+
+use super::VersionFile;
+use crate::error_code::{self, ErrorCodeExt};
+use anyhow::{Context, Result};
+use regex::Regex;
+use std::path::Path;
+use std::sync::OnceLock;
+
+pub struct MixExsVersionFile;
+
+static VERSION_RE: OnceLock<Regex> = OnceLock::new();
+
+fn version_re() -> &'static Regex {
+    // Captures `version: "..."` — tolerant of whitespace and either quote
+    // style. We deliberately do **not** match `:version` (which would be an
+    // atom reference inside deps tuples) — the `(?!:)` isn't needed because
+    // Elixir keyword keys end with `:` on the right, not `:` on the left.
+    VERSION_RE.get_or_init(|| Regex::new(r#"(?m)(version:\s*)(["'])([^"']+)(["'])"#).unwrap())
+}
+
+impl VersionFile for MixExsVersionFile {
+    fn read_version(&self, file_path: &Path) -> Result<String> {
+        let content = std::fs::read_to_string(file_path)
+            .with_context(|| format!("Cannot read {}", file_path.display()))
+            .error_code(error_code::MIX_EXS_READ)?;
+        self.read_version_from_bytes(content.as_bytes(), &file_path.display().to_string())
+    }
+
+    fn write_version(&self, file_path: &Path, version: &str) -> Result<()> {
+        let content = std::fs::read_to_string(file_path)
+            .with_context(|| format!("Cannot read {}", file_path.display()))
+            .error_code(error_code::MIX_EXS_READ)?;
+        if !version_re().is_match(&content) {
+            Err(anyhow::anyhow!(
+                "No `version: \"…\"` literal found in {}",
+                file_path.display()
+            ))
+            .error_code(error_code::MIX_EXS_VERSION_NOT_FOUND)?;
+        }
+        // Replace only the first match — a well-formed mix.exs has exactly
+        // one version in the project definition. Matches further down (e.g.
+        // accidental dep tuples) are intentionally left alone.
+        let mut replaced = false;
+        let new_content = version_re().replace_all(&content, |caps: &regex::Captures| {
+            if replaced {
+                caps.get(0).unwrap().as_str().to_string()
+            } else {
+                replaced = true;
+                format!("{}{}{}{}", &caps[1], &caps[2], version, &caps[4])
+            }
+        });
+        std::fs::write(file_path, new_content.as_ref())
+            .with_context(|| format!("Cannot write {}", file_path.display()))
+            .error_code(error_code::MIX_EXS_WRITE)?;
+        Ok(())
+    }
+
+    fn read_version_from_bytes(&self, content: &[u8], filename: &str) -> Result<String> {
+        let text = std::str::from_utf8(content)
+            .with_context(|| format!("Invalid UTF-8 in {filename}"))
+            .error_code(error_code::MIX_EXS_INVALID_UTF8)?;
+        version_re()
+            .captures(text)
+            .map(|c| c[3].to_string())
+            .ok_or_else(|| anyhow::anyhow!("No `version: \"…\"` literal found in {filename}"))
+            .error_code(error_code::MIX_EXS_VERSION_NOT_FOUND)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_temp(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f
+    }
+
+    const FIXTURE: &str = r#"defmodule MyApp.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :my_app,
+      version: "0.1.0",
+      elixir: "~> 1.15",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  defp deps do
+    [{:phoenix, "~> 1.7"}]
+  end
+end
+"#;
+
+    #[test]
+    fn read_canonical_project() {
+        let f = write_temp(FIXTURE);
+        assert_eq!(MixExsVersionFile.read_version(f.path()).unwrap(), "0.1.0");
+    }
+
+    #[test]
+    fn write_canonical_project() {
+        let f = write_temp(FIXTURE);
+        MixExsVersionFile.write_version(f.path(), "0.2.0").unwrap();
+        let out = std::fs::read_to_string(f.path()).unwrap();
+        assert!(out.contains("version: \"0.2.0\""));
+        // Sibling keyword entries stay intact.
+        assert!(out.contains("app: :my_app"));
+        assert!(out.contains("deps: deps()"));
+    }
+
+    #[test]
+    fn write_only_replaces_first_match() {
+        // Contrived: second `version:` lives in a nested config that happens
+        // to share the keyword name. We only touch the first one.
+        let src = "version: \"1.0.0\"\n# later:\nconfig: [version: \"2.0.0\"]\n";
+        let f = write_temp(src);
+        MixExsVersionFile.write_version(f.path(), "1.1.0").unwrap();
+        let out = std::fs::read_to_string(f.path()).unwrap();
+        assert!(out.contains("version: \"1.1.0\""));
+        assert!(out.contains("version: \"2.0.0\""));
+    }
+
+    #[test]
+    fn read_single_quoted() {
+        let f = write_temp("version: '3.4.5'\n");
+        assert_eq!(MixExsVersionFile.read_version(f.path()).unwrap(), "3.4.5");
+    }
+
+    #[test]
+    fn read_no_version_fails() {
+        let f = write_temp("defmodule Foo do\nend\n");
+        assert!(MixExsVersionFile.read_version(f.path()).is_err());
+    }
+
+    #[test]
+    fn write_no_version_fails() {
+        let f = write_temp("defmodule Foo do\nend\n");
+        assert!(MixExsVersionFile.write_version(f.path(), "1.0.0").is_err());
+    }
+}

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -1,8 +1,13 @@
+pub mod chart_yaml;
 pub mod csproj;
+pub mod gemspec;
 pub mod gomod;
 pub mod gradle;
 pub mod helm;
 pub mod json;
+pub mod mix_exs;
+pub mod package_swift;
+pub mod pubspec_yaml;
 pub mod toml_format;
 pub mod txt;
 pub mod xml;
@@ -34,6 +39,11 @@ pub fn get_handler(format: &FileFormat) -> Box<dyn VersionFile> {
         FileFormat::Toml => Box::new(toml_format::TomlVersionFile),
         FileFormat::Txt => Box::new(txt::TxtVersionFile),
         FileFormat::Xml => Box::new(xml::XmlVersionFile),
+        FileFormat::PubspecYaml => Box::new(pubspec_yaml::PubspecYamlVersionFile),
+        FileFormat::MixExs => Box::new(mix_exs::MixExsVersionFile),
+        FileFormat::ChartYaml => Box::new(chart_yaml::ChartYamlVersionFile),
+        FileFormat::Gemspec => Box::new(gemspec::GemspecVersionFile),
+        FileFormat::PackageSwift => Box::new(package_swift::PackageSwiftVersionFile),
     }
 }
 
@@ -66,6 +76,11 @@ mod tests {
             FileFormat::Toml,
             FileFormat::Txt,
             FileFormat::Xml,
+            FileFormat::PubspecYaml,
+            FileFormat::MixExs,
+            FileFormat::ChartYaml,
+            FileFormat::Gemspec,
+            FileFormat::PackageSwift,
         ] {
             let _ = get_handler(format);
         }
@@ -87,6 +102,11 @@ mod tests {
             FileFormat::Toml,
             FileFormat::Txt,
             FileFormat::Xml,
+            FileFormat::PubspecYaml,
+            FileFormat::MixExs,
+            FileFormat::ChartYaml,
+            FileFormat::Gemspec,
+            FileFormat::PackageSwift,
         ] {
             let handler = get_handler(format);
             assert!(

--- a/src/formats/package_swift.rs
+++ b/src/formats/package_swift.rs
@@ -1,0 +1,172 @@
+//! `Package.swift` (Swift Package Manager) version handler.
+//!
+//! Swift packages declare their own version in a few places; the canonical
+//! spot we target is a top-level constant:
+//!
+//! ```swift
+//! let packageVersion = "1.2.3"
+//! ```
+//!
+//! or a comment sentinel:
+//!
+//! ```swift
+//! // ferrflow:version
+//! let version = "1.2.3"
+//! ```
+//!
+//! Swift PM itself derives a package's version from git tags, so there is
+//! no canonical location inside `Package.swift` for it. We therefore accept
+//! any top-level `let <name>Version? = "x.y.z"` declaration where the
+//! constant name ends with `Version` or is literally `version`. That matches
+//! the conventions we see in real-world Swift packages (`AppVersion`,
+//! `MyPackageVersion`, `version`) without touching dependency `.package(...)`
+//! calls which use their own `from:` / `exact:` string arguments and are
+//! *not* the package's own version.
+
+use super::VersionFile;
+use crate::error_code::{self, ErrorCodeExt};
+use anyhow::{Context, Result};
+use regex::Regex;
+use std::path::Path;
+use std::sync::OnceLock;
+
+pub struct PackageSwiftVersionFile;
+
+static VERSION_RE: OnceLock<Regex> = OnceLock::new();
+
+fn version_re() -> &'static Regex {
+    // `let <ident>Version = "x.y.z"` or `let version = "x.y.z"` — anchored to
+    // line start to avoid accidentally grabbing similar patterns inside the
+    // `dependencies: [.package(url:..., from: "x.y.z")]` array. Swift
+    // requires let bindings at statement start, so `^\s*let\b` is safe.
+    VERSION_RE.get_or_init(|| {
+        Regex::new(r#"(?m)^(\s*let\s+(?:[A-Za-z_][A-Za-z0-9_]*[Vv]ersion|version)\s*=\s*)(["'])([^"']+)(["'])"#).unwrap()
+    })
+}
+
+impl VersionFile for PackageSwiftVersionFile {
+    fn read_version(&self, file_path: &Path) -> Result<String> {
+        let content = std::fs::read_to_string(file_path)
+            .with_context(|| format!("Cannot read {}", file_path.display()))
+            .error_code(error_code::PACKAGE_SWIFT_READ)?;
+        self.read_version_from_bytes(content.as_bytes(), &file_path.display().to_string())
+    }
+
+    fn write_version(&self, file_path: &Path, version: &str) -> Result<()> {
+        let content = std::fs::read_to_string(file_path)
+            .with_context(|| format!("Cannot read {}", file_path.display()))
+            .error_code(error_code::PACKAGE_SWIFT_READ)?;
+        if !version_re().is_match(&content) {
+            Err(anyhow::anyhow!(
+                "No `let <name>Version = \"…\"` declaration found in {}",
+                file_path.display()
+            ))
+            .error_code(error_code::PACKAGE_SWIFT_VERSION_NOT_FOUND)?;
+        }
+        let new_content = version_re().replace(&content, |caps: &regex::Captures| {
+            format!("{}{}{}{}", &caps[1], &caps[2], version, &caps[4])
+        });
+        std::fs::write(file_path, new_content.as_ref())
+            .with_context(|| format!("Cannot write {}", file_path.display()))
+            .error_code(error_code::PACKAGE_SWIFT_WRITE)?;
+        Ok(())
+    }
+
+    fn read_version_from_bytes(&self, content: &[u8], filename: &str) -> Result<String> {
+        let text = std::str::from_utf8(content)
+            .with_context(|| format!("Invalid UTF-8 in {filename}"))
+            .error_code(error_code::PACKAGE_SWIFT_INVALID_UTF8)?;
+        version_re()
+            .captures(text)
+            .map(|c| c[3].to_string())
+            .ok_or_else(|| {
+                anyhow::anyhow!("No `let <name>Version = \"…\"` declaration found in {filename}")
+            })
+            .error_code(error_code::PACKAGE_SWIFT_VERSION_NOT_FOUND)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_temp(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f
+    }
+
+    const FIXTURE: &str = r#"// swift-tools-version:5.9
+import PackageDescription
+
+let packageVersion = "0.1.0"
+
+let package = Package(
+    name: "MyPackage",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-log", from: "1.5.0"),
+    ],
+    targets: [
+        .target(name: "MyPackage"),
+    ]
+)
+"#;
+
+    #[test]
+    fn read_canonical_package() {
+        let f = write_temp(FIXTURE);
+        assert_eq!(
+            PackageSwiftVersionFile.read_version(f.path()).unwrap(),
+            "0.1.0"
+        );
+    }
+
+    #[test]
+    fn write_leaves_dependency_versions_untouched() {
+        let f = write_temp(FIXTURE);
+        PackageSwiftVersionFile
+            .write_version(f.path(), "0.2.0")
+            .unwrap();
+        let out = std::fs::read_to_string(f.path()).unwrap();
+        assert!(out.contains("let packageVersion = \"0.2.0\""));
+        // Dep version stays at 1.5.0.
+        assert!(out.contains("from: \"1.5.0\""));
+    }
+
+    #[test]
+    fn read_accepts_lowercase_version_name() {
+        let f = write_temp("let version = \"1.2.3\"\n");
+        assert_eq!(
+            PackageSwiftVersionFile.read_version(f.path()).unwrap(),
+            "1.2.3"
+        );
+    }
+
+    #[test]
+    fn read_accepts_prefixed_version_name() {
+        let f = write_temp("let AppVersion = \"1.2.3\"\n");
+        assert_eq!(
+            PackageSwiftVersionFile.read_version(f.path()).unwrap(),
+            "1.2.3"
+        );
+    }
+
+    #[test]
+    fn read_rejects_file_without_version_let() {
+        let f = write_temp(
+            "import PackageDescription\n\
+             let package = Package(name: \"X\")\n",
+        );
+        assert!(PackageSwiftVersionFile.read_version(f.path()).is_err());
+    }
+
+    #[test]
+    fn read_ignores_dep_from_arg() {
+        let f = write_temp(".package(url: \"https://example.com\", from: \"9.9.9\")\n");
+        // No `let … = "…"` → not found, even though a version-shaped string
+        // exists on the line.
+        assert!(PackageSwiftVersionFile.read_version(f.path()).is_err());
+    }
+}

--- a/src/formats/pubspec_yaml.rs
+++ b/src/formats/pubspec_yaml.rs
@@ -1,0 +1,196 @@
+//! `pubspec.yaml` (Dart / Flutter) version handler.
+//!
+//! Matches the top-level `version:` key, regardless of quoting. The regex is
+//! anchored to line start with a multiline flag so inline `version:` values
+//! inside dependency maps or `flutter:` blocks are ignored. Anchors and
+//! comments elsewhere in the file are preserved verbatim — we rewrite only
+//! the captured version substring.
+//!
+//! Pub uses SemVer with an optional `+<build>` suffix (e.g. `1.2.3+42`).
+//! That fits any string the version bumper would produce; no special casing
+//! needed here.
+
+use super::VersionFile;
+use crate::error_code::{self, ErrorCodeExt};
+use anyhow::{Context, Result};
+use regex::Regex;
+use std::path::Path;
+use std::sync::OnceLock;
+
+pub struct PubspecYamlVersionFile;
+
+static VERSION_RE: OnceLock<Regex> = OnceLock::new();
+
+fn version_re() -> &'static Regex {
+    // `^version:` — top-level YAML key, no indentation. Captures:
+    //   1. prefix including `:` + whitespace
+    //   2. optional opening quote (`'`, `"`, or empty)
+    //   3. version value
+    //   4. optional closing quote (same rule)
+    VERSION_RE.get_or_init(|| {
+        Regex::new(r#"(?m)^(version:\s*)(["']?)([^"'\s#]+)(["']?)\s*(?:#.*)?$"#).unwrap()
+    })
+}
+
+impl VersionFile for PubspecYamlVersionFile {
+    fn read_version(&self, file_path: &Path) -> Result<String> {
+        let content = std::fs::read_to_string(file_path)
+            .with_context(|| format!("Cannot read {}", file_path.display()))
+            .error_code(error_code::PUBSPEC_READ)?;
+        self.read_version_from_bytes(content.as_bytes(), &file_path.display().to_string())
+    }
+
+    fn write_version(&self, file_path: &Path, version: &str) -> Result<()> {
+        let content = std::fs::read_to_string(file_path)
+            .with_context(|| format!("Cannot read {}", file_path.display()))
+            .error_code(error_code::PUBSPEC_READ)?;
+        if !version_re().is_match(&content) {
+            Err(anyhow::anyhow!(
+                "No top-level version: key found in {}",
+                file_path.display()
+            ))
+            .error_code(error_code::PUBSPEC_VERSION_NOT_FOUND)?;
+        }
+        let new_content = version_re().replace(&content, |caps: &regex::Captures| {
+            format!("{}{}{}{}", &caps[1], &caps[2], version, &caps[4])
+        });
+        std::fs::write(file_path, new_content.as_ref())
+            .with_context(|| format!("Cannot write {}", file_path.display()))
+            .error_code(error_code::PUBSPEC_WRITE)?;
+        Ok(())
+    }
+
+    fn read_version_from_bytes(&self, content: &[u8], filename: &str) -> Result<String> {
+        let text = std::str::from_utf8(content)
+            .with_context(|| format!("Invalid UTF-8 in {filename}"))
+            .error_code(error_code::PUBSPEC_INVALID_UTF8)?;
+        version_re()
+            .captures(text)
+            .map(|c| c[3].to_string())
+            .ok_or_else(|| anyhow::anyhow!("No top-level version: key found in {filename}"))
+            .error_code(error_code::PUBSPEC_VERSION_NOT_FOUND)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_temp(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f
+    }
+
+    #[test]
+    fn read_unquoted() {
+        let f = write_temp("name: my_app\nversion: 1.2.3\n");
+        assert_eq!(
+            PubspecYamlVersionFile.read_version(f.path()).unwrap(),
+            "1.2.3"
+        );
+    }
+
+    #[test]
+    fn read_with_build_suffix() {
+        let f = write_temp("name: my_app\nversion: 1.2.3+42\n");
+        assert_eq!(
+            PubspecYamlVersionFile.read_version(f.path()).unwrap(),
+            "1.2.3+42"
+        );
+    }
+
+    #[test]
+    fn read_double_quoted() {
+        let f = write_temp("version: \"1.0.0\"\n");
+        assert_eq!(
+            PubspecYamlVersionFile.read_version(f.path()).unwrap(),
+            "1.0.0"
+        );
+    }
+
+    #[test]
+    fn read_single_quoted() {
+        let f = write_temp("version: '0.5.0'\n");
+        assert_eq!(
+            PubspecYamlVersionFile.read_version(f.path()).unwrap(),
+            "0.5.0"
+        );
+    }
+
+    #[test]
+    fn read_ignores_nested_version_under_dependencies() {
+        let f = write_temp(
+            "name: my_app\n\
+             version: 1.0.0\n\
+             dependencies:\n  some_pkg:\n    version: 2.0.0\n",
+        );
+        assert_eq!(
+            PubspecYamlVersionFile.read_version(f.path()).unwrap(),
+            "1.0.0"
+        );
+    }
+
+    #[test]
+    fn read_handles_trailing_comment() {
+        let f = write_temp("version: 9.9.9 # pinned for release\n");
+        assert_eq!(
+            PubspecYamlVersionFile.read_version(f.path()).unwrap(),
+            "9.9.9"
+        );
+    }
+
+    #[test]
+    fn read_no_version_fails() {
+        let f = write_temp("name: my_app\n");
+        assert!(PubspecYamlVersionFile.read_version(f.path()).is_err());
+    }
+
+    #[test]
+    fn write_preserves_quotes() {
+        let f = write_temp("version: '1.0.0'\n");
+        PubspecYamlVersionFile
+            .write_version(f.path(), "2.0.0")
+            .unwrap();
+        let content = std::fs::read_to_string(f.path()).unwrap();
+        assert!(content.contains("version: '2.0.0'"));
+    }
+
+    #[test]
+    fn write_preserves_unquoted() {
+        let f = write_temp("version: 1.0.0\n");
+        PubspecYamlVersionFile
+            .write_version(f.path(), "1.2.3")
+            .unwrap();
+        let content = std::fs::read_to_string(f.path()).unwrap();
+        assert!(content.contains("version: 1.2.3"));
+        assert!(!content.contains("'1.2.3'"));
+    }
+
+    #[test]
+    fn write_leaves_dependency_versions_untouched() {
+        let f = write_temp(
+            "name: my_app\n\
+             version: 1.0.0\n\
+             dependencies:\n  some_pkg:\n    version: 2.0.0\n",
+        );
+        PubspecYamlVersionFile
+            .write_version(f.path(), "1.1.0")
+            .unwrap();
+        let content = std::fs::read_to_string(f.path()).unwrap();
+        assert!(content.contains("version: 1.1.0"));
+        assert!(content.contains("version: 2.0.0"));
+    }
+
+    #[test]
+    fn write_no_version_fails() {
+        let f = write_temp("name: my_app\n");
+        assert!(
+            PubspecYamlVersionFile
+                .write_version(f.path(), "2.0.0")
+                .is_err()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Five new \`FileFormat\` variants so Dart / Flutter, Elixir, Ruby, Swift, and Helm chart manifests work out of the box:

| Variant | Target file | Matcher |
|---|---|---|
| \`pubspecyaml\` | \`pubspec.yaml\` | top-level \`version:\` (comments, dep versions, anchors preserved) |
| \`mixexs\` | \`mix.exs\` | first \`version: \"…\"\` literal in \`def project\` |
| \`chartyaml\` | \`Chart.yaml\` | top-level \`version:\` (alias for \`helm\`, explicit about \`appVersion\` separation) |
| \`gemspec\` | \`*.gemspec\` | \`<ident>.version = \"…\"\` |
| \`packageswift\` | \`Package.swift\` | top-level \`let <name>Version = \"…\"\` |

Each handler ships with the full matrix of unit tests that the existing formats have (canonical fixture, quoting variants, sibling-dep preservation, failure cases) — 26 new tests, all of them green, no regressions in the 482-test suite.

## Docs pass

- \`README.md\` now has a proper format → file → selector table covering all 13 variants.
- \`packages/site/src/content/docs/docs/configuration/formats.mdx\` gains 5 new \`<TabItem>\` blocks + a comprehensive quick-reference table at the bottom, mirroring the README.
- Existing Helm tab calls out the new \`chartyaml\` alias.

## Out of scope

- Ruby \`Gemfile.lock\`, \`go.sum\`, \`uv.lock\`, \`poetry.lock\` — transitive lockfiles, not version sources (called out in the issue).
- PHP \`composer.json\` — already supported via \`json\` format; documented in the new table.
- Auto-generated docs table script — the README / formats.mdx tables are hand-maintained; a small \`generate-docs\` command is a reasonable follow-up if the table drifts.
- Benchmarks — criterion benches are deferred to a follow-up PR so this one stays focused on the parsers + docs.

## Breaking change

Technically \`FileFormat\` is \`Deserialize\`-only from config, so adding variants isn't breaking for existing configs. Marked \`feat!\` anyway because it bumps the public enum surface — any downstream consumer matching on \`FileFormat\` exhaustively will need to add arms.

Closes #364.

## Test plan

- [x] \`cargo test --lib\` — 482/482 (+26 new).
- [x] \`cargo fmt --check\` clean.
- [ ] Manual: run \`ferrflow release\` in a toy Dart repo with a \`pubspec.yaml\` bump → file updates, tag pushed.
- [ ] Manual: same flow on a toy Mix / Swift / Ruby / Chart.yaml project.