### PR TITLE
feat(action): bot: true flag for hosted ferrflow[bot] identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `ferrflow` will be documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## Unreleased
+
+### Added
+
+- Action input `bot: true` opts into the hosted FerrFlow bot identity. Requires `permissions: { id-token: write }`. Releases are authored by `ferrflow[bot]`. See README for setup.
+
 ## [4.0.2] - 2026-04-21
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -527,6 +527,26 @@ release:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+### Using the hosted bot (ferrflow[bot])
+
+Install the [FerrFlow GitHub App](https://github.com/apps/ferrflow) on your repo or org, then opt in with `bot: true`. Release commits, tags, and GitHub Releases are authored by `ferrflow[bot]` and downstream workflows triggered by those events run normally (unlike the default `GITHUB_TOKEN`, which suppresses them).
+
+```yaml
+permissions:
+  id-token: write
+  contents: read
+
+steps:
+  - uses: actions/checkout@v6
+    with:
+      fetch-depth: 0
+  - uses: FerrLabs/FerrFlow@v4
+    with:
+      bot: true
+```
+
+Three auth modes are supported: `bot: true` uses the hosted FerrFlow App (recommended); `token: <PAT>` uses a personal access token or your own GitHub App token (DIY); omitting both falls back to the workflow's `GITHUB_TOKEN` (simplest, but release events won't trigger downstream workflows).
+
 ## License
 
 [MPL-2.0](LICENSE)

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,18 @@ inputs:
     description: 'Force a specific version, skipping commit analysis. Format: VERSION (single repo) or NAME@VERSION (monorepo)'
     required: false
     default: ''
+  bot:
+    description: 'Opt into the hosted FerrFlow bot identity (ferrflow[bot]). Requires permissions.id-token: write on the caller workflow. If false/unset, the caller''s token or GITHUB_TOKEN is used as before.'
+    required: false
+    default: 'false'
+  bot_endpoint:
+    description: 'Override the hosted bot token endpoint. Defaults to https://api.ferrlabs.com/api/v1/ferrflow/token.'
+    required: false
+    default: 'https://api.ferrlabs.com/api/v1/ferrflow/token'
+  bot_audience:
+    description: 'OIDC audience requested from the GitHub Actions runner. Must match the server-side expected audience.'
+    required: false
+    default: 'ferrflow.ferrlabs.com'
 
 runs:
   using: composite
@@ -74,6 +86,86 @@ runs:
         fi
 
         echo "$INSTALL_DIR" >> "$GITHUB_PATH"
+
+    - name: Exchange OIDC for FerrFlow bot token
+      if: inputs.bot == 'true'
+      shell: bash
+      env:
+        BOT_ENDPOINT: ${{ inputs.bot_endpoint }}
+        BOT_AUDIENCE: ${{ inputs.bot_audience }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] || [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]; then
+          echo "::error::FerrFlow bot mode requires OIDC access. Add 'permissions: { id-token: write }' to your workflow (or the job) so the runner exposes an OIDC token endpoint."
+          exit 1
+        fi
+
+        # Request an OIDC JWT from the runner, scoped to the FerrFlow bot audience.
+        OIDC_RESPONSE=$(curl --fail -sSL \
+          -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+          "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${BOT_AUDIENCE}") || {
+          echo "::error::Failed to fetch OIDC token from the GitHub Actions runner."
+          exit 1
+        }
+
+        OIDC_JWT=$(printf '%s' "$OIDC_RESPONSE" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const o=JSON.parse(s);if(!o.value){process.exit(2);}process.stdout.write(o.value);})')
+        if [ -z "$OIDC_JWT" ]; then
+          echo "::error::OIDC response from the runner did not contain a token value."
+          exit 1
+        fi
+
+        # Exchange the OIDC JWT for a short-lived GitHub App installation token.
+        HTTP_BODY_FILE="$(mktemp)"
+        HTTP_CODE=$(curl -sSL -o "$HTTP_BODY_FILE" -w "%{http_code}" \
+          -X POST "$BOT_ENDPOINT" \
+          -H "Authorization: Bearer $OIDC_JWT" \
+          -H "Content-Type: application/json" \
+          --data "$(node -e 'process.stdout.write(JSON.stringify({token: process.argv[1]}))' "$OIDC_JWT")") || HTTP_CODE="000"
+
+        case "$HTTP_CODE" in
+          200|201)
+            ;;
+          401)
+            echo "::error::FerrFlow OIDC verification failed. The runner's OIDC token was rejected by the hosted bot service."
+            rm -f "$HTTP_BODY_FILE"
+            exit 1
+            ;;
+          404)
+            echo "::error::FerrFlow App not installed on this repository's owner. Install at https://github.com/apps/ferrflow."
+            rm -f "$HTTP_BODY_FILE"
+            exit 1
+            ;;
+          429)
+            echo "::error::FerrFlow hosted bot rate limit hit. Retry in a few minutes or use 'token:' fallback."
+            rm -f "$HTTP_BODY_FILE"
+            exit 1
+            ;;
+          5*|000)
+            echo "::error::FerrFlow hosted bot unavailable. See status.ferrlabs.com or fall back to 'token:' input."
+            rm -f "$HTTP_BODY_FILE"
+            exit 1
+            ;;
+          *)
+            echo "::error::FerrFlow hosted bot returned unexpected HTTP $HTTP_CODE."
+            rm -f "$HTTP_BODY_FILE"
+            exit 1
+            ;;
+        esac
+
+        BOT_TOKEN=$(node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const o=JSON.parse(s);if(!o.token){process.exit(2);}process.stdout.write(o.token);})' < "$HTTP_BODY_FILE")
+        BOT_EXPIRES=$(node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const o=JSON.parse(s);process.stdout.write(o.expires_at||"");})' < "$HTTP_BODY_FILE")
+        rm -f "$HTTP_BODY_FILE"
+
+        if [ -z "$BOT_TOKEN" ]; then
+          echo "::error::FerrFlow hosted bot response did not contain a token."
+          exit 1
+        fi
+
+        echo "::add-mask::$BOT_TOKEN"
+        echo "GITHUB_TOKEN=$BOT_TOKEN" >> "$GITHUB_ENV"
+        echo "FERRFLOW_TOKEN=$BOT_TOKEN" >> "$GITHUB_ENV"
+        echo "Authenticated as ferrflow[bot] (token expires at ${BOT_EXPIRES:-unknown})."
 
     - name: Preview release
       if: inputs.mode == 'preview'

--- a/scripts/test-action-bot.sh
+++ b/scripts/test-action-bot.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Best-effort lint for action.yml.
+# Verifies the YAML parses and runs actionlint if installed.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ACTION_FILE="$ROOT/action.yml"
+
+if [ ! -f "$ACTION_FILE" ]; then
+  echo "action.yml not found at $ACTION_FILE" >&2
+  exit 1
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+  python3 -c "import sys, yaml; yaml.safe_load(open('$ACTION_FILE'))" \
+    && echo "action.yml parses as valid YAML"
+elif command -v python >/dev/null 2>&1; then
+  python -c "import sys, yaml; yaml.safe_load(open('$ACTION_FILE'))" \
+    && echo "action.yml parses as valid YAML"
+else
+  echo "python not found; skipping YAML parse check"
+fi
+
+if command -v actionlint >/dev/null 2>&1; then
+  actionlint "$ACTION_FILE"
+  echo "actionlint passed"
+else
+  echo "actionlint not installed; skipping"
+fi


### PR DESCRIPTION
Closes #372.

Adds a `bot: true` input to the FerrFlow composite action that exchanges the runner's OIDC token for a short-lived FerrFlow App installation token, and uses it as `GITHUB_TOKEN`/`FERRFLOW_TOKEN` for the release step.

Depends on the server endpoint in FerrLabs/FerrLabs-Cloud#16 (already merged), which signs installation tokens at `POST https://api.ferrlabs.com/api/v1/ferrflow/token`.

## Caller requirement

The caller workflow must grant OIDC access — otherwise the runner's token endpoint is unreachable:

```yaml
permissions:
  id-token: write
  contents: read
```

## Behaviour

- `bot: true` -> OIDC exchange, commits/tags/releases authored by `ferrflow[bot]`.
- `token: <PAT>` -> unchanged DIY flow.
- Neither -> falls back to `GITHUB_TOKEN` as before. Strictly additive.

Error cases (401/404/429/5xx/network) produce explicit `::error::` messages pointing at the fix (install the App, rate limit, fall back to `token:`, etc.).

## Test plan

- [x] `action.yml` parses as valid YAML (`js-yaml` via npx).
- [ ] End-to-end: a downstream caller workflow with `bot: true` + `permissions: id-token: write` successfully releases.
- [ ] 401/404/429 error paths surface the expected messages.