### PR TITLE
feat(cli): handle bot OIDC exchange in rust, drop node dependency from action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 - Action input `bot: true` opts into the hosted FerrFlow bot identity. Requires `permissions: { id-token: write }`. Releases are authored by `ferrflow[bot]`. See README for setup.
 
+### Changed
+
+- `bot: true` flow now performs the OIDC exchange directly in the Rust CLI. Users no longer need `actions/setup-node` (or any Node runtime) on minimal self-hosted runners. The `action.yml` step that shelled out to `node -e` is removed.
+
 ## [4.0.2] - 2026-04-21
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "anyhow",
  "cargo-husky",

--- a/README.md
+++ b/README.md
@@ -545,6 +545,8 @@ steps:
       bot: true
 ```
 
+That's it — no `setup-node`, no extra dependencies. FerrFlow's Rust binary handles the OIDC exchange directly, so minimal self-hosted runners work out of the box.
+
 Three auth modes are supported: `bot: true` uses the hosted FerrFlow App (recommended); `token: <PAT>` uses a personal access token or your own GitHub App token (DIY); omitting both falls back to the workflow's `GITHUB_TOKEN` (simplest, but release events won't trigger downstream workflows).
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -87,92 +87,20 @@ runs:
 
         echo "$INSTALL_DIR" >> "$GITHUB_PATH"
 
-    - name: Exchange OIDC for FerrFlow bot token
-      if: inputs.bot == 'true'
-      shell: bash
-      env:
-        BOT_ENDPOINT: ${{ inputs.bot_endpoint }}
-        BOT_AUDIENCE: ${{ inputs.bot_audience }}
-      run: |
-        set -euo pipefail
-
-        if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] || [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]; then
-          echo "::error::FerrFlow bot mode requires OIDC access. Add 'permissions: { id-token: write }' to your workflow (or the job) so the runner exposes an OIDC token endpoint."
-          exit 1
-        fi
-
-        # Request an OIDC JWT from the runner, scoped to the FerrFlow bot audience.
-        OIDC_RESPONSE=$(curl --fail -sSL \
-          -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-          "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${BOT_AUDIENCE}") || {
-          echo "::error::Failed to fetch OIDC token from the GitHub Actions runner."
-          exit 1
-        }
-
-        OIDC_JWT=$(printf '%s' "$OIDC_RESPONSE" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const o=JSON.parse(s);if(!o.value){process.exit(2);}process.stdout.write(o.value);})')
-        if [ -z "$OIDC_JWT" ]; then
-          echo "::error::OIDC response from the runner did not contain a token value."
-          exit 1
-        fi
-
-        # Exchange the OIDC JWT for a short-lived GitHub App installation token.
-        HTTP_BODY_FILE="$(mktemp)"
-        HTTP_CODE=$(curl -sSL -o "$HTTP_BODY_FILE" -w "%{http_code}" \
-          -X POST "$BOT_ENDPOINT" \
-          -H "Authorization: Bearer $OIDC_JWT" \
-          -H "Content-Type: application/json" \
-          --data "$(node -e 'process.stdout.write(JSON.stringify({token: process.argv[1]}))' "$OIDC_JWT")") || HTTP_CODE="000"
-
-        case "$HTTP_CODE" in
-          200|201)
-            ;;
-          401)
-            echo "::error::FerrFlow OIDC verification failed. The runner's OIDC token was rejected by the hosted bot service."
-            rm -f "$HTTP_BODY_FILE"
-            exit 1
-            ;;
-          404)
-            echo "::error::FerrFlow App not installed on this repository's owner. Install at https://github.com/apps/ferrflow."
-            rm -f "$HTTP_BODY_FILE"
-            exit 1
-            ;;
-          429)
-            echo "::error::FerrFlow hosted bot rate limit hit. Retry in a few minutes or use 'token:' fallback."
-            rm -f "$HTTP_BODY_FILE"
-            exit 1
-            ;;
-          5*|000)
-            echo "::error::FerrFlow hosted bot unavailable. See status.ferrlabs.com or fall back to 'token:' input."
-            rm -f "$HTTP_BODY_FILE"
-            exit 1
-            ;;
-          *)
-            echo "::error::FerrFlow hosted bot returned unexpected HTTP $HTTP_CODE."
-            rm -f "$HTTP_BODY_FILE"
-            exit 1
-            ;;
-        esac
-
-        BOT_TOKEN=$(node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const o=JSON.parse(s);if(!o.token){process.exit(2);}process.stdout.write(o.token);})' < "$HTTP_BODY_FILE")
-        BOT_EXPIRES=$(node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const o=JSON.parse(s);process.stdout.write(o.expires_at||"");})' < "$HTTP_BODY_FILE")
-        rm -f "$HTTP_BODY_FILE"
-
-        if [ -z "$BOT_TOKEN" ]; then
-          echo "::error::FerrFlow hosted bot response did not contain a token."
-          exit 1
-        fi
-
-        echo "::add-mask::$BOT_TOKEN"
-        echo "GITHUB_TOKEN=$BOT_TOKEN" >> "$GITHUB_ENV"
-        echo "FERRFLOW_TOKEN=$BOT_TOKEN" >> "$GITHUB_ENV"
-        echo "Authenticated as ferrflow[bot] (token expires at ${BOT_EXPIRES:-unknown})."
-
     - name: Preview release
       if: inputs.mode == 'preview'
       shell: bash
+      env:
+        FERRFLOW_BOT: ${{ inputs.bot }}
+        FERRFLOW_BOT_ENDPOINT: ${{ inputs.bot_endpoint }}
+        FERRFLOW_BOT_AUDIENCE: ${{ inputs.bot_audience }}
       run: ferrflow check --comment
 
     - name: Run FerrFlow release
       if: inputs.mode == 'release'
       shell: bash
+      env:
+        FERRFLOW_BOT: ${{ inputs.bot }}
+        FERRFLOW_BOT_ENDPOINT: ${{ inputs.bot_endpoint }}
+        FERRFLOW_BOT_AUDIENCE: ${{ inputs.bot_audience }}
       run: ferrflow ${{ inputs.dry_run == 'true' && '--dry-run' || '' }} release ${{ inputs.force_version != '' && format('--force-version {0}', inputs.force_version) || '' }}

--- a/src/bot_token.rs
+++ b/src/bot_token.rs
@@ -1,0 +1,364 @@
+//! Hosted FerrFlow bot OIDC exchange.
+//!
+//! When the user opts into `bot: true` on the GitHub Action, the composite
+//! action simply forwards the relevant environment variables to this binary.
+//! This module performs the full OIDC exchange in-process, so self-hosted
+//! runners do not need Node.js (or any other runtime) installed.
+//!
+//! Flow:
+//! 1. Read `ACTIONS_ID_TOKEN_REQUEST_URL` and `ACTIONS_ID_TOKEN_REQUEST_TOKEN`
+//!    provided by the GitHub Actions runner (requires `permissions.id-token: write`).
+//! 2. GET `{url}&audience={audience}` with the bearer request token to obtain
+//!    a short-lived OIDC JWT from the runner.
+//! 3. POST that JWT to the hosted bot service, which verifies it and returns
+//!    a short-lived GitHub App installation token.
+//! 4. Export that token into the process environment as both `GITHUB_TOKEN`
+//!    and `FERRFLOW_TOKEN` so the rest of FerrFlow picks it up transparently.
+
+use anyhow::{Context, Result, bail};
+
+const DEFAULT_ENDPOINT: &str = "https://api.ferrlabs.com/api/v1/ferrflow/token";
+const DEFAULT_AUDIENCE: &str = "ferrflow.ferrlabs.com";
+
+/// Returns true when the `FERRFLOW_BOT` env var is set to a truthy value.
+pub fn bot_mode_enabled() -> bool {
+    match std::env::var("FERRFLOW_BOT") {
+        Ok(value) => {
+            let v = value.trim().to_ascii_lowercase();
+            matches!(v.as_str(), "true" | "1")
+        }
+        Err(_) => false,
+    }
+}
+
+pub struct BotTokenExchange {
+    pub endpoint: String,
+    pub audience: String,
+}
+
+impl Default for BotTokenExchange {
+    fn default() -> Self {
+        Self {
+            endpoint: std::env::var("FERRFLOW_BOT_ENDPOINT")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string()),
+            audience: std::env::var("FERRFLOW_BOT_AUDIENCE")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| DEFAULT_AUDIENCE.to_string()),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct IssuedToken {
+    pub token: String,
+    pub expires_at: String,
+    pub repository: String,
+}
+
+#[derive(serde::Deserialize)]
+struct IssuedTokenResponse {
+    token: String,
+    #[serde(default)]
+    expires_at: String,
+    #[serde(default)]
+    repository: String,
+}
+
+#[derive(serde::Deserialize)]
+struct OidcResponse {
+    value: String,
+}
+
+impl BotTokenExchange {
+    /// Runs the full OIDC exchange and returns a short-lived installation token.
+    pub fn issue(&self) -> Result<IssuedToken> {
+        let req_url = std::env::var("ACTIONS_ID_TOKEN_REQUEST_URL").map_err(|_| {
+            anyhow::anyhow!(
+                "bot mode requires `permissions: id-token: write` in your workflow — ACTIONS_ID_TOKEN_REQUEST_URL not set"
+            )
+        })?;
+        let req_token = std::env::var("ACTIONS_ID_TOKEN_REQUEST_TOKEN").map_err(|_| {
+            anyhow::anyhow!(
+                "bot mode requires `permissions: id-token: write` in your workflow — ACTIONS_ID_TOKEN_REQUEST_TOKEN not set"
+            )
+        })?;
+
+        // 1. Fetch the runner OIDC JWT, scoped to the FerrFlow audience.
+        let separator = if req_url.contains('?') { '&' } else { '?' };
+        let oidc_url = format!(
+            "{req_url}{separator}audience={}",
+            encode_query_component(&self.audience)
+        );
+
+        let oidc_body: OidcResponse = ureq::get(&oidc_url)
+            .header("Authorization", &format!("Bearer {req_token}"))
+            .header("Accept", "application/json")
+            .header(
+                "User-Agent",
+                concat!("ferrflow/", env!("CARGO_PKG_VERSION")),
+            )
+            .call()
+            .context("failed to request OIDC token from GitHub Actions runner")?
+            .body_mut()
+            .read_json()
+            .context("OIDC response from runner was not valid JSON")?;
+
+        if oidc_body.value.is_empty() {
+            bail!("OIDC response from GitHub Actions runner was missing the `value` field");
+        }
+
+        // 2. Exchange the JWT with the FerrFlow hosted bot service.
+        let payload = serde_json::json!({ "token": oidc_body.value });
+        let mut response = match ureq::post(&self.endpoint)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .header(
+                "User-Agent",
+                concat!("ferrflow/", env!("CARGO_PKG_VERSION")),
+            )
+            .send_json(payload)
+        {
+            Ok(r) => r,
+            Err(ureq::Error::StatusCode(code)) => {
+                return Err(map_status_error(code));
+            }
+            Err(err) => {
+                bail!(
+                    "FerrFlow hosted bot unavailable: {err}. Check https://status.ferrlabs.com or fall back to a PAT via `token:`."
+                );
+            }
+        };
+
+        let body: IssuedTokenResponse = response
+            .body_mut()
+            .read_json()
+            .context("FerrFlow bot service response was not valid JSON")?;
+
+        if body.token.is_empty() {
+            bail!("FerrFlow bot service response did not contain a token");
+        }
+
+        Ok(IssuedToken {
+            token: body.token,
+            expires_at: body.expires_at,
+            repository: body.repository,
+        })
+    }
+}
+
+fn map_status_error(code: u16) -> anyhow::Error {
+    match code {
+        401 => anyhow::anyhow!(
+            "FerrFlow OIDC verification failed (401). The runner's OIDC token was rejected by the hosted bot service."
+        ),
+        404 => anyhow::anyhow!(
+            "FerrFlow App not installed on this repository's owner. Install at https://github.com/apps/ferrflow"
+        ),
+        429 => anyhow::anyhow!(
+            "FerrFlow hosted bot rate limit hit (429). Retry shortly or use `token:` with a PAT."
+        ),
+        500..=599 => anyhow::anyhow!(
+            "FerrFlow hosted bot service unavailable ({code}). Check https://status.ferrlabs.com"
+        ),
+        _ => anyhow::anyhow!("FerrFlow hosted bot returned unexpected HTTP status {code}"),
+    }
+}
+
+/// Minimal RFC 3986 query component encoder — enough for the audience string,
+/// which is almost always a plain hostname. Avoids pulling in a URL crate.
+fn encode_query_component(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for b in input.bytes() {
+        let safe = b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'~');
+        if safe {
+            out.push(b as char);
+        } else {
+            out.push_str(&format!("%{:02X}", b));
+        }
+    }
+    out
+}
+
+/// If `FERRFLOW_BOT` is enabled, perform the OIDC exchange and export the
+/// resulting installation token into the process environment so the rest
+/// of FerrFlow (forge, git push) picks it up via the normal lookup.
+///
+/// Safe to call more than once; the exchange only runs on the first call.
+pub fn ensure_bot_token() -> Result<()> {
+    if !bot_mode_enabled() {
+        return Ok(());
+    }
+
+    // If a previous invocation already exchanged, don't do it again.
+    static EXCHANGED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    if EXCHANGED.get().is_some() {
+        return Ok(());
+    }
+
+    let exchange = BotTokenExchange::default();
+    let issued = exchange
+        .issue()
+        .context("failed to obtain FerrFlow bot token")?;
+
+    // SAFETY: set_var is marked unsafe in edition 2024. This is single-threaded
+    // initialization at the top of a command, before any spawned threads read
+    // these variables. Same pattern as the rest of FerrFlow's env handling
+    // (see git.rs tests).
+    unsafe {
+        std::env::set_var("GITHUB_TOKEN", &issued.token);
+        std::env::set_var("FERRFLOW_TOKEN", &issued.token);
+    }
+
+    // Mask the token for any downstream log sinks that honor GitHub's
+    // `::add-mask::` workflow command.
+    println!("::add-mask::{}", issued.token);
+
+    let repo_note = if issued.repository.is_empty() {
+        String::new()
+    } else {
+        format!(" on {}", issued.repository)
+    };
+    let expires_note = if issued.expires_at.is_empty() {
+        String::new()
+    } else {
+        format!(" (expires at {})", issued.expires_at)
+    };
+    println!("Authenticated as ferrflow[bot]{repo_note}{expires_note}.");
+
+    let _ = EXCHANGED.set(());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_env<F: FnOnce()>(vars: &[(&str, Option<&str>)], f: F) {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let previous: Vec<(String, Option<String>)> = vars
+            .iter()
+            .map(|(k, _)| ((*k).to_string(), std::env::var(*k).ok()))
+            .collect();
+        for (k, v) in vars {
+            unsafe {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+        f();
+        for (k, v) in previous {
+            unsafe {
+                match v {
+                    Some(val) => std::env::set_var(&k, val),
+                    None => std::env::remove_var(&k),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn bot_mode_detection() {
+        with_env(&[("FERRFLOW_BOT", Some("true"))], || {
+            assert!(bot_mode_enabled());
+        });
+        with_env(&[("FERRFLOW_BOT", Some("1"))], || {
+            assert!(bot_mode_enabled());
+        });
+        with_env(&[("FERRFLOW_BOT", Some("TRUE"))], || {
+            assert!(bot_mode_enabled());
+        });
+        with_env(&[("FERRFLOW_BOT", Some("false"))], || {
+            assert!(!bot_mode_enabled());
+        });
+        with_env(&[("FERRFLOW_BOT", Some(""))], || {
+            assert!(!bot_mode_enabled());
+        });
+        with_env(&[("FERRFLOW_BOT", None)], || {
+            assert!(!bot_mode_enabled());
+        });
+    }
+
+    #[test]
+    fn defaults_use_hosted_endpoint_and_audience() {
+        with_env(
+            &[
+                ("FERRFLOW_BOT_ENDPOINT", None),
+                ("FERRFLOW_BOT_AUDIENCE", None),
+            ],
+            || {
+                let ex = BotTokenExchange::default();
+                assert_eq!(ex.endpoint, DEFAULT_ENDPOINT);
+                assert_eq!(ex.audience, DEFAULT_AUDIENCE);
+            },
+        );
+    }
+
+    #[test]
+    fn overrides_applied() {
+        with_env(
+            &[
+                ("FERRFLOW_BOT_ENDPOINT", Some("https://example.test/t")),
+                ("FERRFLOW_BOT_AUDIENCE", Some("aud.example.test")),
+            ],
+            || {
+                let ex = BotTokenExchange::default();
+                assert_eq!(ex.endpoint, "https://example.test/t");
+                assert_eq!(ex.audience, "aud.example.test");
+            },
+        );
+    }
+
+    #[test]
+    fn empty_overrides_fall_back_to_defaults() {
+        with_env(
+            &[
+                ("FERRFLOW_BOT_ENDPOINT", Some("")),
+                ("FERRFLOW_BOT_AUDIENCE", Some("")),
+            ],
+            || {
+                let ex = BotTokenExchange::default();
+                assert_eq!(ex.endpoint, DEFAULT_ENDPOINT);
+                assert_eq!(ex.audience, DEFAULT_AUDIENCE);
+            },
+        );
+    }
+
+    #[test]
+    fn issue_errors_when_runner_env_missing() {
+        with_env(
+            &[
+                ("ACTIONS_ID_TOKEN_REQUEST_URL", None),
+                ("ACTIONS_ID_TOKEN_REQUEST_TOKEN", None),
+            ],
+            || {
+                let err = BotTokenExchange::default().issue().unwrap_err();
+                let msg = err.to_string();
+                assert!(
+                    msg.contains("id-token: write"),
+                    "expected id-token hint in error, got: {msg}"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn encode_query_component_leaves_safe_chars() {
+        assert_eq!(
+            encode_query_component("ferrflow.ferrlabs.com"),
+            "ferrflow.ferrlabs.com"
+        );
+    }
+
+    #[test]
+    fn encode_query_component_escapes_unsafe() {
+        assert_eq!(encode_query_component("a b&c=d"), "a%20b%26c%3Dd");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod bot_token;
 mod changelog;
 mod cli;
 mod config;

--- a/src/monorepo.rs
+++ b/src/monorepo.rs
@@ -79,6 +79,7 @@ pub fn check(
     channel: Option<&str>,
     comment: bool,
 ) -> Result<()> {
+    crate::bot_token::ensure_bot_token()?;
     let repo = open_repo(&std::env::current_dir()?)?;
     let root = get_repo_root(&repo)?;
     let config = Config::load(&root, config_path)?;
@@ -180,6 +181,7 @@ pub fn release(
     channel: Option<&str>,
     draft: bool,
 ) -> Result<()> {
+    crate::bot_token::ensure_bot_token()?;
     let repo = open_repo(&std::env::current_dir()?)?;
     let root = get_repo_root(&repo)?;
     let config = Config::load(&root, config_path)?;


### PR DESCRIPTION
Closes #374.

## Summary

- Move the `bot: true` OIDC exchange from a `node -e`-based composite-action step into the Rust CLI. Minimal self-hosted runners no longer need Node.js to use the hosted FerrFlow bot.
- New module `src/bot_token.rs` performs the exchange using the existing `ureq` HTTP client. It's invoked at the top of `release` and `check` via `ensure_bot_token()`, which also masks the issued token (`::add-mask::`) and exports it as `GITHUB_TOKEN`/`FERRFLOW_TOKEN` so the rest of FerrFlow picks it up unchanged.
- `action.yml` drops the whole OIDC exchange step and just forwards `FERRFLOW_BOT` / `FERRFLOW_BOT_ENDPOINT` / `FERRFLOW_BOT_AUDIENCE` to the `ferrflow` invocation. The runner-provided `ACTIONS_ID_TOKEN_REQUEST_*` vars are auto-inherited.
- Error mapping mirrors the previous shell logic: 401 -> OIDC verification failed, 404 -> App not installed, 429 -> rate limit, 5xx/network -> hosted bot unavailable.
- README's "Using the hosted bot" section now explicitly states no extra runtime is required. CHANGELOG gets a `Changed` entry.

## Test plan

- [x] `cargo build` and `cargo clippy --lib --bins` clean.
- [x] New unit tests cover: truthy detection for `FERRFLOW_BOT`, default endpoint/audience, empty-string override fallback, missing-runner-env error message, and query-component encoding.
- [x] Full `cargo test --bins --lib` passes (570 tests).
- [x] `scripts/test-action-bot.sh` still parses `action.yml`.
- [ ] End-to-end bot flow verified in a downstream workflow after release (follow-up PRs in FerrLabs-Cloud and Status will drop their `actions/setup-node` steps).