### PR TITLE
feat(ci): matrix-shard micro benchmarks across runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,24 +270,99 @@ jobs:
           if-no-files-found: ignore
 
   micro-bench:
-    name: Micro Benchmarks
+    name: Micro Benchmark - ${{ matrix.group }}
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     continue-on-error: true
-    permissions:
-      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        group:
+          - commit_parsing
+          - changelog
+          - version_files
+          - config_loading
+          - git_commits
+          - git_find_tag
+          - git_collect_tags
+          - git_changed_files
+          - git_changed_since_tag
+          - validate
+          - full_check_flow
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v2
       - uses: FerrLabs/Benchmarks@v3
         with:
           type: micro
+          group-filter: ${{ matrix.group }}
           definitions: benchmarks/fixtures/definitions
           ferrflow-token: ${{ secrets.GITHUB_TOKEN }}
           skip-competitors: true
+          comment-on-pr: false
         env:
           FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
+      - uses: actions/upload-artifact@v7
+        with:
+          name: micro-partial-${{ matrix.group }}
+          path: output.txt
+          retention-days: 1
+
+  micro-bench-aggregate:
+    name: Micro Benchmark (aggregate)
+    needs: micro-bench
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: micro-partial-*
+          merge-multiple: true
+          path: shards/
+      - name: Merge partials
+        run: |
+          cat shards/* > output.txt
+          echo "Merged bench rows: $(wc -l < output.txt)"
+      - name: Find baseline artifact from main
+        id: find-baseline
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RUN_ID=$(gh api "repos/${{ github.repository }}/actions/artifacts?name=criterion-baseline&per_page=1" \
+            --jq '.artifacts[0].workflow_run.id // empty')
+          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+      - name: Download baseline
+        if: steps.find-baseline.outputs.run_id
+        uses: actions/download-artifact@v8
+        with:
+          name: criterion-baseline
+          path: baseline/
+          run-id: ${{ steps.find-baseline.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+      - name: Ensure baseline file
+        run: |
+          if [[ ! -f baseline/benchmark-data.json ]]; then
+            mkdir -p baseline
+            echo '[]' > baseline/benchmark-data.json
+          fi
+      - uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: cargo
+          output-file-path: output.txt
+          external-data-json-path: baseline/benchmark-data.json
+          comment-on-alert: true
+          alert-threshold: '120%'
+          fail-on-alert: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-always: true
 
   benchmark:
     name: Benchmark

--- a/benches/ferrflow_benchmarks.rs
+++ b/benches/ferrflow_benchmarks.rs
@@ -347,12 +347,7 @@ fn bench_full_check_flow(c: &mut Criterion) {
         let config_content = generate_config_json(1);
         std::fs::write(_dir.path().join(".ferrflow"), &config_content).unwrap();
 
-        // Create version file
-        std::fs::write(
-            _dir.path().join("packages/pkg-001/package.json"),
-            r#"{"name":"pkg-001","version":"1.0.0"}"#,
-        )
-        .unwrap();
+        // Create version file (directory MUST exist before write)
         std::fs::create_dir_all(_dir.path().join("packages/pkg-001")).unwrap();
         std::fs::write(
             _dir.path().join("packages/pkg-001/package.json"),


### PR DESCRIPTION
Splits the PR-only `micro-bench` job across a matrix of criterion groups so shards run in parallel, then aggregates partials in a follow-up job that posts the merged comparison to the PR.

- Each shard runs its own isolated VM with unchanged criterion defaults, preserving measurement precision.
- The full hyperfine benchmark job on main pushes is untouched (still a single runner for stable baselines).
- Requires the new `group-filter` input on `FerrLabs/Benchmarks@v3` (landed in FerrLabs/Benchmarks#94).

Matrix groups match the exact prefixes used by `criterion_group!` entries in `benches/ferrflow_benchmarks.rs`:
`commit_parsing`, `changelog`, `version_files`, `config_loading`, `git_commits`, `git_find_tag`, `git_collect_tags`, `git_changed_files`, `git_changed_since_tag`, `validate`, `full_check_flow`.

Leaving this PR open for reviewer validation — the shard + aggregate flow needs a live PR run to confirm it produces a single merged comment.

## Test plan
- [ ] PR run spawns 11 shard jobs plus 1 aggregate job
- [ ] Aggregate posts a single benchmark comparison comment
- [ ] No duplicate or partial comments from individual shards