### PR TITLE
fix(action): set git identity to ferrflow[bot] when bot: true

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,6 +87,19 @@ runs:
 
         echo "$INSTALL_DIR" >> "$GITHUB_PATH"
 
+    - name: Configure git identity for ferrflow[bot]
+      # When bot: true, release commits must be authored by ferrflow[bot] (not
+      # the checkout actor or the runner's previous git identity). libgit2
+      # reads the repo config, so we set it here before `ferrflow release`
+      # does any committing. The bot user ID (278126555) is stable for the
+      # hosted ferrflow GitHub App; self-hosters running their own App should
+      # replace these values with their bot's identity.
+      if: inputs.bot == 'true'
+      shell: bash
+      run: |
+        git config user.name "ferrflow[bot]"
+        git config user.email "278126555+ferrflow[bot]@users.noreply.github.com"
+
     - name: Preview release
       if: inputs.mode == 'preview'
       shell: bash


### PR DESCRIPTION
Release and API show ferrflow[bot] as the author, but the underlying git commit kept whatever identity was configured locally (e.g. 'ferrflow-old' after the user rename). Explicitly set `git config user.name/user.email` to the hosted bot's identity before `ferrflow release` runs so libgit2 picks it up.

Bot user id 278126555 is stable for the hosted ferrflow App; self-hosters running their own App replace these values.