### PR TITLE
fix(action): re-trigger release to include dropped git identity fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,3 +550,4 @@ Three auth modes are supported: `bot: true` uses the hosted FerrFlow App (recomm
 ## License
 
 [MPL-2.0](LICENSE)
+


### PR DESCRIPTION
v4.3.0 tag was created on a commit that did NOT include PR #380 (race between PR #379 and #380 releases). Re-trigger to cut v4.3.1 on top of current main which does contain the fix.