### PR TITLE
chore(renovate): extend shared FerrLabs preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,32 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
-  "rebaseWhen": "behind-base-branch",
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["patch", "minor"],
-      "matchManagers": ["cargo"],
-      "automerge": true,
-      "automergeType": "pr",
-      "automergeStrategy": "squash"
-    },
-    {
-      "matchUpdateTypes": ["major"],
-      "automerge": false
-    },
-    {
-      "matchManagers": ["github-actions"],
-      "automerge": true,
-      "automergeType": "pr",
-      "automergeStrategy": "squash",
-      "groupName": "GitHub Actions"
-    },
-    {
-      "matchManagers": ["dockerfile"],
-      "automerge": true,
-      "automergeType": "pr",
-      "automergeStrategy": "squash",
-      "groupName": "Docker images"
-    }
-  ]
+  "extends": ["local>FerrLabs/.github"]
 }


### PR DESCRIPTION
Switches to the shared preset at `FerrLabs/.github/default.json`. See FerrLabs/.github#1.