### PR TITLE
feat(formats): per-file selector + Maven-aware default for XML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "4.0.2"
+version = "4.4.0"
 dependencies = [
  "anyhow",
  "cargo-husky",

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A single compiled binary with no runtime dependencies. Native monorepo support, 
 | `toml` | `pyproject.toml` | Python | `project.version` or `tool.poetry.version` |
 | `json` | `package.json` | Node.js | `version` |
 | `json` | `composer.json` | PHP | `version` |
-| `xml` | `pom.xml` | Java / Maven | first `<version>` tag |
+| `xml` | `pom.xml` | Java / Maven | first `<version>` that's a direct child of the root element (skips `<parent>` and dependencies) |
 | `csproj` | `*.csproj` | .NET (C#, F#) | `<Version>` in `<PropertyGroup>` |
 | `gradle` | `build.gradle`, `build.gradle.kts` | Java / Kotlin | `version = "…"` |
 | `helm` / `chartyaml` | `Chart.yaml` | Kubernetes / Helm | top-level `version:` |

--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -160,6 +160,10 @@
                   "type": "string",
                   "description": "File format used to locate and update the version field.",
                   "enum": ["csproj", "toml", "json", "xml", "gradle", "gomod", "helm", "txt"]
+                },
+                "selector": {
+                  "type": "string",
+                  "description": "Optional selector to disambiguate which version is bumped. xml: a slash-delimited tag path like '/project/version' (or '//tag' for first-anywhere); txt: a regex with one capture group around the version. Without a selector, xml uses a Maven-aware default (first <version> direct child of root)."
                 }
               },
               "additionalProperties": false

--- a/src/config.rs
+++ b/src/config.rs
@@ -305,6 +305,19 @@ impl PackageConfig {
 pub struct VersionedFile {
     pub path: String,
     pub format: FileFormat,
+    /// Optional selector to disambiguate which occurrence in the file is the
+    /// version to bump. Syntax depends on the format:
+    ///
+    /// - `xml`: a slash-delimited path of tag names rooted at the document
+    ///   element, e.g. `/project/version`. Without a selector the handler
+    ///   targets the first `<version>` that is a direct child of the root
+    ///   element — which fixes the common Maven `<parent>` pitfall.
+    /// - `txt`: a regex with a single capture group that brackets the
+    ///   version string, e.g. `^VERSION=(.+)$`.
+    ///
+    /// Other formats currently ignore this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selector: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
@@ -758,6 +771,7 @@ impl Config {
             versioned_files.push(VersionedFile {
                 path: "Cargo.toml".to_string(),
                 format: FileFormat::Toml,
+                selector: None,
             });
         }
         if root.join("build.gradle").exists() || root.join("build.gradle.kts").exists() {
@@ -769,30 +783,35 @@ impl Config {
             versioned_files.push(VersionedFile {
                 path: path.to_string(),
                 format: FileFormat::Gradle,
+                selector: None,
             });
         }
         if root.join("Chart.yaml").exists() {
             versioned_files.push(VersionedFile {
                 path: "Chart.yaml".to_string(),
                 format: FileFormat::Helm,
+                selector: None,
             });
         }
         if root.join("go.mod").exists() {
             versioned_files.push(VersionedFile {
                 path: "go.mod".to_string(),
                 format: FileFormat::GoMod,
+                selector: None,
             });
         }
         if root.join("package.json").exists() {
             versioned_files.push(VersionedFile {
                 path: "package.json".to_string(),
                 format: FileFormat::Json,
+                selector: None,
             });
         }
         if root.join("pom.xml").exists() {
             versioned_files.push(VersionedFile {
                 path: "pom.xml".to_string(),
                 format: FileFormat::Xml,
+                selector: None,
             });
         }
         for name in &["VERSION", "VERSION.txt"] {
@@ -800,6 +819,7 @@ impl Config {
                 versioned_files.push(VersionedFile {
                     path: name.to_string(),
                     format: FileFormat::Txt,
+                    selector: None,
                 });
                 break;
             }
@@ -808,6 +828,7 @@ impl Config {
             versioned_files.push(VersionedFile {
                 path: "pyproject.toml".to_string(),
                 format: FileFormat::Toml,
+                selector: None,
             });
         }
 
@@ -1010,6 +1031,7 @@ fn collect_package(path_default: &str, monorepo: bool) -> PackageConfig {
         versioned_files: vec![VersionedFile {
             path: version_file_path,
             format: parse_file_format(&format_str),
+            selector: None,
         }],
         changelog: Some(changelog),
         shared_paths: Vec::new(),
@@ -1537,6 +1559,7 @@ format = "toml"
                 versioned_files: vec![VersionedFile {
                     path: "Cargo.toml".into(),
                     format: FileFormat::Toml,
+                    selector: None,
                 }],
                 changelog: None,
                 shared_paths: vec!["shared/".into()],
@@ -1582,6 +1605,7 @@ format = "toml"
                 versioned_files: vec![VersionedFile {
                     path: "Cargo.toml".into(),
                     format: FileFormat::Toml,
+                    selector: None,
                 }],
                 changelog: None,
                 shared_paths: vec!["shared/".into()],

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -27,6 +27,27 @@ pub trait VersionFile {
     }
     /// Parse version from raw file content without filesystem access.
     fn read_version_from_bytes(&self, content: &[u8], filename: &str) -> Result<String>;
+
+    /// Read with an optional per-file selector. Default delegates to the
+    /// selector-less path; formats that support selectors override this.
+    /// See [`crate::config::VersionedFile::selector`] for syntax.
+    fn read_version_with_selector(
+        &self,
+        file_path: &Path,
+        _selector: Option<&str>,
+    ) -> Result<String> {
+        self.read_version(file_path)
+    }
+
+    /// Write counterpart of [`Self::read_version_with_selector`].
+    fn write_version_with_selector(
+        &self,
+        file_path: &Path,
+        version: &str,
+        _selector: Option<&str>,
+    ) -> Result<()> {
+        self.write_version(file_path, version)
+    }
 }
 
 pub fn get_handler(format: &FileFormat) -> Box<dyn VersionFile> {
@@ -50,13 +71,13 @@ pub fn get_handler(format: &FileFormat) -> Box<dyn VersionFile> {
 pub fn read_version(vf: &VersionedFile, repo_root: &Path) -> Result<String> {
     let path = repo_root.join(&vf.path);
     let handler = get_handler(&vf.format);
-    handler.read_version(&path)
+    handler.read_version_with_selector(&path, vf.selector.as_deref())
 }
 
 pub fn write_version(vf: &VersionedFile, repo_root: &Path, version: &str) -> Result<()> {
     let path = repo_root.join(&vf.path);
     let handler = get_handler(&vf.format);
-    handler.write_version(&path, version)
+    handler.write_version_with_selector(&path, version, vf.selector.as_deref())
 }
 
 #[cfg(test)]
@@ -128,6 +149,7 @@ mod tests {
         let vf = VersionedFile {
             path: "package.json".to_string(),
             format: FileFormat::Json,
+            selector: None,
         };
         assert_eq!(read_version(&vf, dir.path()).unwrap(), "3.2.1");
     }
@@ -143,6 +165,7 @@ mod tests {
         let vf = VersionedFile {
             path: "package.json".to_string(),
             format: FileFormat::Json,
+            selector: None,
         };
         write_version(&vf, dir.path(), "2.0.0").unwrap();
         assert_eq!(read_version(&vf, dir.path()).unwrap(), "2.0.0");
@@ -159,6 +182,7 @@ mod tests {
         let vf = VersionedFile {
             path: "Cargo.toml".to_string(),
             format: FileFormat::Toml,
+            selector: None,
         };
         assert_eq!(read_version(&vf, dir.path()).unwrap(), "0.5.0");
     }
@@ -170,6 +194,7 @@ mod tests {
         let vf = VersionedFile {
             path: "VERSION".to_string(),
             format: FileFormat::Txt,
+            selector: None,
         };
         assert_eq!(read_version(&vf, dir.path()).unwrap(), "4.1.0");
     }
@@ -181,6 +206,7 @@ mod tests {
         let vf = VersionedFile {
             path: "VERSION".to_string(),
             format: FileFormat::Txt,
+            selector: None,
         };
         write_version(&vf, dir.path(), "1.1.0").unwrap();
         assert_eq!(read_version(&vf, dir.path()).unwrap(), "1.1.0");
@@ -197,6 +223,7 @@ mod tests {
         let vf = VersionedFile {
             path: "pom.xml".to_string(),
             format: FileFormat::Xml,
+            selector: None,
         };
         assert_eq!(read_version(&vf, dir.path()).unwrap(), "2.3.4");
     }
@@ -207,6 +234,7 @@ mod tests {
         let vf = VersionedFile {
             path: "nope.json".to_string(),
             format: FileFormat::Json,
+            selector: None,
         };
         assert!(read_version(&vf, dir.path()).is_err());
     }
@@ -218,6 +246,7 @@ mod tests {
         let vf = VersionedFile {
             path: "build.gradle".to_string(),
             format: FileFormat::Gradle,
+            selector: None,
         };
         assert_eq!(read_version(&vf, dir.path()).unwrap(), "1.2.3");
     }
@@ -231,6 +260,7 @@ mod tests {
         let vf = VersionedFile {
             path: "sub/VERSION".to_string(),
             format: FileFormat::Txt,
+            selector: None,
         };
         assert_eq!(read_version(&vf, dir.path()).unwrap(), "5.0.0");
     }

--- a/src/formats/txt.rs
+++ b/src/formats/txt.rs
@@ -1,8 +1,26 @@
 use crate::error_code::{self, ErrorCodeExt};
 use anyhow::{Context, Result};
+use regex::Regex;
 use std::path::Path;
 
 pub struct TxtVersionFile;
+
+/// Compile a user-supplied selector into a regex. The selector must contain
+/// exactly one capture group whose match is the version string. We surface
+/// a clear error rather than panicking on regex compile failures or wrong
+/// arity, since the selector ships from user-authored config.
+fn compile_selector(selector: &str) -> Result<Regex> {
+    let re = Regex::new(selector)
+        .with_context(|| format!("invalid regex selector: {selector:?}"))
+        .error_code(error_code::TXT_VERSION_NOT_FOUND)?;
+    if re.captures_len() != 2 {
+        Err(anyhow::anyhow!(
+            "regex selector must contain exactly one capture group: {selector:?}"
+        ))
+        .error_code(error_code::TXT_VERSION_NOT_FOUND)?;
+    }
+    Ok(re)
+}
 
 #[cfg(test)]
 mod tests {
@@ -42,6 +60,48 @@ mod tests {
         let content = std::fs::read_to_string(f.path()).unwrap();
         assert_eq!(content, "2.0.0\n");
     }
+
+    #[test]
+    fn read_with_regex_selector_picks_capture_group() {
+        let mut f = NamedTempFile::new().unwrap();
+        write!(f, "name=foo\nVERSION=4.5.6\nother=ignored\n").unwrap();
+        let v = TxtVersionFile
+            .read_version_with_selector(f.path(), Some(r"(?m)^VERSION=(.+)$"))
+            .unwrap();
+        assert_eq!(v, "4.5.6");
+    }
+
+    #[test]
+    fn write_with_regex_selector_replaces_capture_only() {
+        let mut f = NamedTempFile::new().unwrap();
+        write!(f, "name=foo\nVERSION=1.0.0\nother=ignored\n").unwrap();
+        TxtVersionFile
+            .write_version_with_selector(f.path(), "2.0.0", Some(r"(?m)^VERSION=(.+)$"))
+            .unwrap();
+        let content = std::fs::read_to_string(f.path()).unwrap();
+        // Only the version part of the matched line changes.
+        assert_eq!(content, "name=foo\nVERSION=2.0.0\nother=ignored\n");
+    }
+
+    #[test]
+    fn selector_with_no_match_errors() {
+        let mut f = NamedTempFile::new().unwrap();
+        write!(f, "no version here").unwrap();
+        let result = TxtVersionFile.read_version_with_selector(f.path(), Some(r"^VERSION=(.+)$"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn selector_with_wrong_capture_count_errors() {
+        let mut f = NamedTempFile::new().unwrap();
+        write!(f, "VERSION=1.0.0").unwrap();
+        // Zero capture groups.
+        let result = TxtVersionFile.read_version_with_selector(f.path(), Some(r"VERSION=.+"));
+        assert!(result.is_err());
+        // Two capture groups.
+        let result = TxtVersionFile.read_version_with_selector(f.path(), Some(r"(VERSION)=(.+)"));
+        assert!(result.is_err());
+    }
 }
 
 impl super::VersionFile for TxtVersionFile {
@@ -77,5 +137,71 @@ impl super::VersionFile for TxtVersionFile {
                 .error_code(error_code::TXT_VERSION_NOT_FOUND)?;
         }
         Ok(version.to_string())
+    }
+
+    fn read_version_with_selector(
+        &self,
+        file_path: &Path,
+        selector: Option<&str>,
+    ) -> Result<String> {
+        let Some(sel) = selector else {
+            return self.read_version(file_path);
+        };
+        let re = compile_selector(sel)?;
+        let content = std::fs::read_to_string(file_path)
+            .with_context(|| format!("failed to read {}", file_path.display()))
+            .error_code(error_code::TXT_READ)?;
+        let cap = re
+            .captures(&content)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "selector {sel:?} did not match anything in {}",
+                    file_path.display()
+                )
+            })
+            .error_code(error_code::TXT_VERSION_NOT_FOUND)?;
+        let m = cap.get(1).ok_or_else(|| {
+            anyhow::anyhow!("selector {sel:?} matched but capture group 1 is empty")
+        })?;
+        Ok(m.as_str().to_string())
+    }
+
+    fn write_version_with_selector(
+        &self,
+        file_path: &Path,
+        version: &str,
+        selector: Option<&str>,
+    ) -> Result<()> {
+        let Some(sel) = selector else {
+            return self.write_version(file_path, version);
+        };
+        let re = compile_selector(sel)?;
+        let content = std::fs::read_to_string(file_path)
+            .with_context(|| format!("failed to read {}", file_path.display()))
+            .error_code(error_code::TXT_READ)?;
+        // Replace only the capture group, leaving the rest of the matched
+        // line (prefix, suffix, surrounding whitespace) untouched. We need
+        // the absolute byte range of capture group 1 — `replacen` would
+        // operate on the whole match.
+        let cap = re
+            .captures(&content)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "selector {sel:?} did not match anything in {}",
+                    file_path.display()
+                )
+            })
+            .error_code(error_code::TXT_VERSION_NOT_FOUND)?;
+        let m = cap.get(1).ok_or_else(|| {
+            anyhow::anyhow!("selector {sel:?} matched but capture group 1 is empty")
+        })?;
+        let mut new_content = String::with_capacity(content.len() + version.len());
+        new_content.push_str(&content[..m.start()]);
+        new_content.push_str(version);
+        new_content.push_str(&content[m.end()..]);
+        std::fs::write(file_path, new_content)
+            .with_context(|| format!("failed to write {}", file_path.display()))
+            .error_code(error_code::TXT_WRITE)?;
+        Ok(())
     }
 }

--- a/src/formats/xml.rs
+++ b/src/formats/xml.rs
@@ -1,11 +1,436 @@
+//! XML version-file handler.
+//!
+//! The original implementation used a single `<version>([^<]+)</version>` regex
+//! that matched the **first** occurrence in the file. That broke on every
+//! Maven `pom.xml` whose `<parent>` block precedes the project's own
+//! `<groupId>`/`<artifactId>`/`<version>` — Spring Boot apps and any
+//! multi-module Maven project. FerrFlow would read the parent dependency's
+//! version (e.g. `spring-boot-starter-parent` 3.5.14) instead of the
+//! project version, then rewrite the wrong tag on bump.
+//!
+//! The handler now walks the document with a tiny state machine that
+//! tracks element depth, so it can target a `<version>` that is a direct
+//! child of the document root (`<project>` for Maven). For weirder layouts
+//! (profile blocks, Maven BOM imports, `.csproj` flavours, …) the user can
+//! point at any tag via a slash-delimited selector like `/project/version`.
+//!
+//! No XML parser pulled in — the format is forgiving enough that a small
+//! tokeniser handles everything FerrFlow needs (open / close / self-close
+//! tags, comments, CDATA, processing instructions, `xmlns`/attributes).
+
 use super::VersionFile;
 use crate::error_code::{self, ErrorCodeExt};
 use anyhow::{Context, Result};
-use regex::Regex;
 use std::path::Path;
-use std::sync::OnceLock;
 
 pub struct XmlVersionFile;
+
+/// One match inside the document — byte offsets covering the inner text
+/// between `<tag>` and `</tag>`.
+#[derive(Debug, Clone, Copy)]
+struct InnerRange {
+    start: usize,
+    end: usize,
+}
+
+/// Tokeniser state.
+struct Scanner<'a> {
+    src: &'a [u8],
+    i: usize,
+}
+
+impl<'a> Scanner<'a> {
+    fn new(src: &'a str) -> Self {
+        Self {
+            src: src.as_bytes(),
+            i: 0,
+        }
+    }
+
+    fn done(&self) -> bool {
+        self.i >= self.src.len()
+    }
+
+    /// Skip a `<!-- ... -->` comment, `<![CDATA[...]]>` block, or
+    /// `<? ... ?>` processing instruction starting at `self.i` (which
+    /// points at the leading `<`). Returns true if one was consumed.
+    fn skip_special(&mut self) -> bool {
+        let rest = &self.src[self.i..];
+        if rest.starts_with(b"<!--") {
+            self.i += 4;
+            if let Some(end) = self.find_at(b"-->") {
+                self.i = end + 3;
+            } else {
+                self.i = self.src.len();
+            }
+            return true;
+        }
+        if rest.starts_with(b"<![CDATA[") {
+            self.i += 9;
+            if let Some(end) = self.find_at(b"]]>") {
+                self.i = end + 3;
+            } else {
+                self.i = self.src.len();
+            }
+            return true;
+        }
+        if rest.starts_with(b"<?") {
+            self.i += 2;
+            if let Some(end) = self.find_at(b"?>") {
+                self.i = end + 2;
+            } else {
+                self.i = self.src.len();
+            }
+            return true;
+        }
+        // <!DOCTYPE ...> — naive: eat until the matching '>'
+        if rest.starts_with(b"<!") {
+            self.i += 2;
+            while self.i < self.src.len() && self.src[self.i] != b'>' {
+                self.i += 1;
+            }
+            if self.i < self.src.len() {
+                self.i += 1;
+            }
+            return true;
+        }
+        false
+    }
+
+    fn find_at(&self, needle: &[u8]) -> Option<usize> {
+        find_subslice(&self.src[self.i..], needle).map(|p| self.i + p)
+    }
+
+    /// Parse a tag starting at `self.i` (which must point at `<`). Returns
+    /// `(name, kind, end_index_after_close_bracket)`.
+    fn read_tag(&mut self) -> Option<(String, TagKind, usize)> {
+        debug_assert_eq!(self.src.get(self.i).copied(), Some(b'<'));
+        let mut p = self.i + 1;
+        let kind_close = if self.src.get(p).copied() == Some(b'/') {
+            p += 1;
+            true
+        } else {
+            false
+        };
+
+        // Read the name.
+        let name_start = p;
+        while p < self.src.len() {
+            let c = self.src[p];
+            if c == b' ' || c == b'\t' || c == b'\n' || c == b'\r' || c == b'/' || c == b'>' {
+                break;
+            }
+            p += 1;
+        }
+        if p == name_start {
+            return None;
+        }
+        let name = std::str::from_utf8(&self.src[name_start..p])
+            .ok()?
+            .to_string();
+
+        // Skip past attributes to the closing '>'.
+        let mut self_close = false;
+        let mut in_quote: Option<u8> = None;
+        while p < self.src.len() {
+            let c = self.src[p];
+            match in_quote {
+                Some(q) if c == q => in_quote = None,
+                Some(_) => {}
+                None => match c {
+                    b'"' | b'\'' => in_quote = Some(c),
+                    b'/' => {
+                        // Could be the self-close marker. Peek next non-space.
+                        let mut q = p + 1;
+                        while q < self.src.len() && (self.src[q] == b' ' || self.src[q] == b'\t') {
+                            q += 1;
+                        }
+                        if q < self.src.len() && self.src[q] == b'>' {
+                            self_close = true;
+                            p = q;
+                            break;
+                        }
+                    }
+                    b'>' => break,
+                    _ => {}
+                },
+            }
+            p += 1;
+        }
+        if p >= self.src.len() {
+            return None;
+        }
+        let end = p + 1; // after '>'
+        let kind = if kind_close {
+            TagKind::Close
+        } else if self_close {
+            TagKind::SelfClose
+        } else {
+            TagKind::Open
+        };
+        Some((name, kind, end))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum TagKind {
+    Open,
+    Close,
+    SelfClose,
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || needle.len() > haystack.len() {
+        return if needle.is_empty() { Some(0) } else { None };
+    }
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Walk the document and find the inner-text range of the first tag that
+/// matches `selector`. The selector is interpreted as:
+///
+/// - `Some("/a/b/c")` — absolute path of element names from the root. The
+///   first segment must equal the document root element. Empty leading
+///   segment from the leading slash is ignored.
+/// - `Some("//tag")` — first occurrence of `<tag>` at any depth (anywhere).
+/// - `None` — Maven-aware default: first `<version>` that is a direct
+///   child of the document root. Falls back to the first `<version>`
+///   anywhere (preserving legacy behaviour) when none is found at depth 1.
+fn find_target(content: &str, selector: Option<&str>) -> Option<InnerRange> {
+    let path: Vec<&str> = match selector {
+        Some(sel) if sel.starts_with("//") => {
+            let name = sel.trim_start_matches('/');
+            return find_first_named(content, name, None);
+        }
+        Some(sel) => sel.trim_start_matches('/').split('/').collect(),
+        None => {
+            // Default: try Maven-aware first, then the legacy first-match.
+            if let Some(r) = find_root_child_named(content, "version") {
+                return Some(r);
+            }
+            return find_first_named(content, "version", None);
+        }
+    };
+
+    if path.is_empty() {
+        return None;
+    }
+    walk_path(content, &path)
+}
+
+/// Find the first `<name>` whose ancestry from the root matches `path`
+/// exactly. `path[0]` is the root element name; subsequent entries are
+/// the nested children.
+fn walk_path(content: &str, path: &[&str]) -> Option<InnerRange> {
+    let mut s = Scanner::new(content);
+    let mut stack: Vec<String> = Vec::new();
+
+    while !s.done() {
+        // Skip text until we hit '<'.
+        while s.i < s.src.len() && s.src[s.i] != b'<' {
+            s.i += 1;
+        }
+        if s.done() {
+            break;
+        }
+        if s.skip_special() {
+            continue;
+        }
+        let Some((name, kind, end)) = s.read_tag() else {
+            s.i += 1;
+            continue;
+        };
+        match kind {
+            TagKind::Open => {
+                stack.push(name.clone());
+                if stack.len() == path.len()
+                    && stack.iter().zip(path.iter()).all(|(a, b)| a.as_str() == *b)
+                {
+                    // Inner text starts at `end`. Find matching close tag
+                    // for `name`, accounting for nested same-name tags.
+                    let inner_start = end;
+                    let close_idx = find_matching_close(&s.src[end..], &name)?;
+                    return Some(InnerRange {
+                        start: inner_start,
+                        end: end + close_idx,
+                    });
+                }
+                s.i = end;
+            }
+            TagKind::Close => {
+                stack.pop();
+                s.i = end;
+            }
+            TagKind::SelfClose => {
+                s.i = end;
+            }
+        }
+    }
+    None
+}
+
+/// Find first `<name>` element (anywhere, or at depth 1 if `min_depth` is
+/// `Some(1)` — depth here is 0-indexed, so depth 1 means a direct child of
+/// the root element).
+fn find_first_named(content: &str, name: &str, min_depth: Option<usize>) -> Option<InnerRange> {
+    let mut s = Scanner::new(content);
+    let mut depth: usize = 0;
+    while !s.done() {
+        while s.i < s.src.len() && s.src[s.i] != b'<' {
+            s.i += 1;
+        }
+        if s.done() {
+            break;
+        }
+        if s.skip_special() {
+            continue;
+        }
+        let Some((tag, kind, end)) = s.read_tag() else {
+            s.i += 1;
+            continue;
+        };
+        match kind {
+            TagKind::Open => {
+                if tag == name && min_depth.is_none_or(|m| depth == m) {
+                    let inner_start = end;
+                    let close_idx = find_matching_close(&s.src[end..], &tag)?;
+                    return Some(InnerRange {
+                        start: inner_start,
+                        end: end + close_idx,
+                    });
+                }
+                depth += 1;
+                s.i = end;
+            }
+            TagKind::Close => {
+                depth = depth.saturating_sub(1);
+                s.i = end;
+            }
+            TagKind::SelfClose => {
+                s.i = end;
+            }
+        }
+    }
+    None
+}
+
+fn find_root_child_named(content: &str, name: &str) -> Option<InnerRange> {
+    find_first_named(content, name, Some(1))
+}
+
+/// Given bytes starting just after an opening `<tag>`, find the byte
+/// offset of the matching `</tag>` opening `<`. Handles nested same-name
+/// tags by counting depth.
+fn find_matching_close(after_open: &[u8], name: &str) -> Option<usize> {
+    let mut s = Scanner {
+        src: after_open,
+        i: 0,
+    };
+    let mut depth: usize = 0;
+    while !s.done() {
+        while s.i < s.src.len() && s.src[s.i] != b'<' {
+            s.i += 1;
+        }
+        if s.done() {
+            return None;
+        }
+        let lt = s.i;
+        if s.skip_special() {
+            continue;
+        }
+        let Some((tag, kind, end)) = s.read_tag() else {
+            s.i += 1;
+            continue;
+        };
+        match kind {
+            TagKind::Open => {
+                if tag == name {
+                    depth += 1;
+                }
+                s.i = end;
+            }
+            TagKind::Close => {
+                if tag == name {
+                    if depth == 0 {
+                        return Some(lt);
+                    }
+                    depth -= 1;
+                }
+                s.i = end;
+            }
+            TagKind::SelfClose => s.i = end,
+        }
+    }
+    None
+}
+
+impl VersionFile for XmlVersionFile {
+    fn read_version(&self, file_path: &Path) -> Result<String> {
+        self.read_version_with_selector(file_path, None)
+    }
+
+    fn write_version(&self, file_path: &Path, version: &str) -> Result<()> {
+        self.write_version_with_selector(file_path, version, None)
+    }
+
+    fn read_version_with_selector(
+        &self,
+        file_path: &Path,
+        selector: Option<&str>,
+    ) -> Result<String> {
+        let content = std::fs::read_to_string(file_path)
+            .with_context(|| format!("Cannot read {}", file_path.display()))
+            .error_code(error_code::XML_READ)?;
+        let range = find_target(&content, selector)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "No matching version tag found in {} (selector: {:?})",
+                    file_path.display(),
+                    selector
+                )
+            })
+            .error_code(error_code::XML_VERSION_NOT_FOUND)?;
+        Ok(content[range.start..range.end].trim().to_string())
+    }
+
+    fn write_version_with_selector(
+        &self,
+        file_path: &Path,
+        version: &str,
+        selector: Option<&str>,
+    ) -> Result<()> {
+        let content = std::fs::read_to_string(file_path)
+            .with_context(|| format!("Cannot read {}", file_path.display()))
+            .error_code(error_code::XML_READ)?;
+        let range = find_target(&content, selector)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "No matching version tag found to update in {} (selector: {:?})",
+                    file_path.display(),
+                    selector
+                )
+            })
+            .error_code(error_code::XML_VERSION_NOT_FOUND)?;
+        let mut new_content = String::with_capacity(content.len() + version.len());
+        new_content.push_str(&content[..range.start]);
+        new_content.push_str(version);
+        new_content.push_str(&content[range.end..]);
+        std::fs::write(file_path, new_content)
+            .with_context(|| format!("Cannot write {}", file_path.display()))
+            .error_code(error_code::XML_WRITE)?;
+        Ok(())
+    }
+
+    fn read_version_from_bytes(&self, content: &[u8], filename: &str) -> Result<String> {
+        let text = std::str::from_utf8(content)
+            .with_context(|| format!("Invalid UTF-8 in {filename}"))
+            .error_code(error_code::XML_INVALID_UTF8)?;
+        let range = find_target(text, None)
+            .ok_or_else(|| anyhow::anyhow!("No <version> tag found in {filename}"))
+            .error_code(error_code::XML_VERSION_NOT_FOUND)?;
+        Ok(text[range.start..range.end].trim().to_string())
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -25,6 +450,20 @@ mod tests {
   <groupId>com.example</groupId>
   <artifactId>myapp</artifactId>
   <version>1.0.0</version>
+</project>"#;
+
+    const SPRING_BOOT_POM: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.14</version>
+    </parent>
+    <groupId>com.homepedia</groupId>
+    <artifactId>homepedia-backend</artifactId>
+    <version>3.6.0</version>
+    <packaging>pom</packaging>
 </project>"#;
 
     #[test]
@@ -52,63 +491,82 @@ mod tests {
         let f = write_temp(xml);
         XmlVersionFile.write_version(f.path(), "2.0.0").unwrap();
         let content = std::fs::read_to_string(f.path()).unwrap();
-        // Only the first <version> should be replaced
         assert!(content.contains("<version>2.0.0</version>"));
-    }
-}
-
-static VERSION_RE: OnceLock<Regex> = OnceLock::new();
-
-fn version_re() -> &'static Regex {
-    VERSION_RE.get_or_init(|| Regex::new(r"<version>([^<]+)</version>").unwrap())
-}
-
-impl VersionFile for XmlVersionFile {
-    fn read_version(&self, file_path: &Path) -> Result<String> {
-        let content = std::fs::read_to_string(file_path)
-            .with_context(|| format!("Cannot read {}", file_path.display()))
-            .error_code(error_code::XML_READ)?;
-
-        version_re()
-            .captures(&content)
-            .map(|c| c[1].trim().to_string())
-            .ok_or_else(|| anyhow::anyhow!("No <version> tag found in {}", file_path.display()))
-            .error_code(error_code::XML_VERSION_NOT_FOUND)
+        // The nested dependency version is untouched.
+        assert!(content.contains("<version>3.0</version>"));
     }
 
-    fn write_version(&self, file_path: &Path, version: &str) -> Result<()> {
-        let content = std::fs::read_to_string(file_path)
-            .with_context(|| format!("Cannot read {}", file_path.display()))
-            .error_code(error_code::XML_READ)?;
-
-        let mut count = 0;
-        let new_content = version_re().replace(&content, |_: &regex::Captures| {
-            count += 1;
-            format!("<version>{version}</version>")
-        });
-
-        if count == 0 {
-            Err(anyhow::anyhow!(
-                "No <version> tag found to update in {}",
-                file_path.display()
-            ))
-            .error_code(error_code::XML_VERSION_NOT_FOUND)?;
-        }
-
-        std::fs::write(file_path, new_content.as_ref())
-            .with_context(|| format!("Cannot write {}", file_path.display()))
-            .error_code(error_code::XML_WRITE)?;
-        Ok(())
+    #[test]
+    fn read_skips_parent_block_in_spring_boot_pom() {
+        // Regression: with the legacy first-match regex, this returned
+        // `3.5.14` (Spring Boot parent's version). We now want the
+        // project's own `<version>3.6.0</version>`.
+        let f = write_temp(SPRING_BOOT_POM);
+        assert_eq!(XmlVersionFile.read_version(f.path()).unwrap(), "3.6.0");
     }
 
-    fn read_version_from_bytes(&self, content: &[u8], filename: &str) -> Result<String> {
-        let text = std::str::from_utf8(content)
-            .with_context(|| format!("Invalid UTF-8 in {filename}"))
-            .error_code(error_code::XML_INVALID_UTF8)?;
-        version_re()
-            .captures(text)
-            .map(|c| c[1].trim().to_string())
-            .ok_or_else(|| anyhow::anyhow!("No <version> tag found in {filename}"))
-            .error_code(error_code::XML_VERSION_NOT_FOUND)
+    #[test]
+    fn write_skips_parent_block_in_spring_boot_pom() {
+        let f = write_temp(SPRING_BOOT_POM);
+        XmlVersionFile.write_version(f.path(), "3.7.0").unwrap();
+        let content = std::fs::read_to_string(f.path()).unwrap();
+        // Project version got bumped.
+        assert!(content.contains("<version>3.7.0</version>"));
+        // Parent block was left alone — Spring Boot's version intact.
+        assert!(content.contains("<version>3.5.14</version>"));
+        // No duplicate version tags either side of the parent block.
+        assert_eq!(content.matches("<version>").count(), 2);
+    }
+
+    #[test]
+    fn explicit_selector_targets_specific_path() {
+        // Force-select the parent's version even when a Maven default
+        // would otherwise prefer the project version.
+        let f = write_temp(SPRING_BOOT_POM);
+        let v = XmlVersionFile
+            .read_version_with_selector(f.path(), Some("/project/parent/version"))
+            .unwrap();
+        assert_eq!(v, "3.5.14");
+    }
+
+    #[test]
+    fn explicit_selector_writes_through() {
+        let f = write_temp(SPRING_BOOT_POM);
+        XmlVersionFile
+            .write_version_with_selector(f.path(), "9.9.9", Some("/project/parent/version"))
+            .unwrap();
+        let content = std::fs::read_to_string(f.path()).unwrap();
+        assert!(content.contains("<version>9.9.9</version>"));
+        assert!(content.contains("<version>3.6.0</version>")); // project version untouched
+    }
+
+    #[test]
+    fn double_slash_selector_finds_first_anywhere() {
+        let f = write_temp(SPRING_BOOT_POM);
+        let v = XmlVersionFile
+            .read_version_with_selector(f.path(), Some("//version"))
+            .unwrap();
+        // First <version> in document order — that's the parent's.
+        assert_eq!(v, "3.5.14");
+    }
+
+    #[test]
+    fn comments_and_pi_are_ignored() {
+        let xml = r#"<?xml version="1.0"?>
+<!-- a leading comment with <version>fake</version> inside -->
+<project>
+    <!-- another <version>also-fake</version> -->
+    <version>4.2.0</version>
+</project>"#;
+        let f = write_temp(xml);
+        assert_eq!(XmlVersionFile.read_version(f.path()).unwrap(), "4.2.0");
+    }
+
+    #[test]
+    fn read_from_bytes_uses_default_heuristic() {
+        let v = XmlVersionFile
+            .read_version_from_bytes(SPRING_BOOT_POM.as_bytes(), "pom.xml")
+            .unwrap();
+        assert_eq!(v, "3.6.0");
     }
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -962,6 +962,7 @@ mod tests {
         pkg.versioned_files = vec![VersionedFile {
             path: "packages/api/package.json".to_string(),
             format: FileFormat::Json,
+            selector: None,
         }];
         let config = make_config(vec![pkg]);
         let (entries, versions) = check_versioned_files(&config, &source);


### PR DESCRIPTION
## Summary

- XML handler now skips Maven `<parent>` blocks by default — targets the first `<version>` that is a direct child of the document root instead of the literal first match. Fixes pom.xml + Spring Boot bumping the wrong tag.
- New optional `selector` field on each `VersionedFile` entry. For `xml`: slash-delimited tag path (`/project/parent/version`), with `//tag` to fall back to legacy first-anywhere. For `txt`: regex with one capture group around the version. Other formats ignore it for now.
- Schema, README, and the `formats.mdx` docs (EN + FR) updated to reflect both behaviours. The cloud copy of the JSON schema is back in sync with the source-of-truth in `schema/`.

## Test plan

- [x] `cargo test --lib` — 493 pass, including new regression tests
  - `read_skips_parent_block_in_spring_boot_pom`
  - `write_skips_parent_block_in_spring_boot_pom`
  - `explicit_selector_targets_specific_path`
  - `explicit_selector_writes_through`
  - `double_slash_selector_finds_first_anywhere`
  - `comments_and_pi_are_ignored`
  - `read_with_regex_selector_picks_capture_group`, `write_with_regex_selector_replaces_capture_only`, …
- [x] `cargo test --tests` — 581 pass
- [x] `cargo clippy --lib --bins -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Backwards compat: existing `read_pom_version`, `write_replaces_first_version_tag_only`, `read_version_xml` etc. still pass

Closes #387