### PR TITLE
fix(ci): release job pushes as github-actions[bot] instead of ferrflow[bot]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,6 +411,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          # Don't bake GITHUB_TOKEN into the git remote — ferrflow's OIDC
+          # exchange yields an App installation token that authenticates as
+          # ferrflow[bot]. Without this, every git push silently reverts
+          # to GITHUB_TOKEN (i.e. github-actions[bot]) which isn't in the
+          # branch-rule bypass list and can't push to main.
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v2
       - name: Build ferrflow

--- a/action.yml
+++ b/action.yml
@@ -87,6 +87,23 @@ runs:
 
         echo "$INSTALL_DIR" >> "$GITHUB_PATH"
 
+    - name: Strip cached GITHUB_TOKEN credentials
+      # actions/checkout writes `AUTHORIZATION: basic <GITHUB_TOKEN>` into
+      # the repo's git extraheader. When ferrflow later swaps in the App
+      # installation token via OIDC, that extraheader still wins on every
+      # `git push` / `git fetch` — so the push authenticates as
+      # github-actions[bot] (not ferrflow[bot]) and is rejected by any
+      # branch ruleset that lists ferrflow[bot] in its bypass actors.
+      #
+      # Dropping the cache here means ferrflow's URL-rewrite path
+      # (`build_authenticated_url` in src/git.rs) takes over and the bot
+      # identity is what reaches the server. Idempotent: a no-op when the
+      # caller already set `persist-credentials: false` on the checkout.
+      if: inputs.bot == 'true'
+      shell: bash
+      run: |
+        git config --unset-all http.https://github.com/.extraheader || true
+
     - name: Configure git identity for ferrflow[bot]
       # When bot: true, release commits must be authored by ferrflow[bot] (not
       # the checkout actor or the runner's previous git identity). libgit2


### PR DESCRIPTION
## Summary

\`actions/checkout@v6\` writes \`AUTHORIZATION: basic <GITHUB_TOKEN>\` into the repo's git config extraheader. Even though \`ferrflow release\` then exchanges the OIDC token for a ferrflow[bot] App installation token, every subsequent \`git push\` keeps sending the extraheader → server sees github-actions[bot]. That identity isn't in the main-branch ruleset bypass list, so the push gets rejected as a rule violation.

\`persist-credentials: false\` keeps the extraheader from being written. ferrflow then rewrites the remote URL with \`FERRFLOW_TOKEN\` (\`src/git.rs build_authenticated_url\`) and pushes/fetches under the bot identity, which IS in the bypass list.

## Test plan

- [ ] After merge, the next push to main triggers the Release job
- [ ] Job log shows \`Authenticated as ferrflow[bot]\` and the push succeeds (no 'rule violations' rejection)
- [ ] Resulting release commit on main is authored by \`ferrflow[bot]\`

Closes #390