### PR TITLE
perf(ci): build micro-bench binary once, share across matrix shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,8 +269,52 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  # Compile the bench binary ONCE per PR and hand it to the matrix shards
+  # below. Before this split, every shard ran `cargo bench` with its own
+  # cold rust-cache (all 11 shards start in parallel and share a key, so
+  # nobody hits a sibling's cache), paying the ~5–7 min build cost 11
+  # times. With a pre-built binary the matrix only does the actual
+  # measurement step. See FerrLabs/FerrFlow#397.
+  micro-bench-build:
+    name: Build micro bench binary
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+      - name: Compile bench binary (no run)
+        run: cargo bench --bench ferrflow_benchmarks --no-run
+      - name: Locate compiled binary
+        id: locate
+        run: |
+          set -euo pipefail
+          # criterion + cargo emit a hashed binary name like
+          # ferrflow_benchmarks-1234abcd. Pick the most recent matching
+          # executable and skip dSYMs, .d files, and pdbs.
+          bin=$(find target/release/deps -maxdepth 1 -type f \
+                  -name 'ferrflow_benchmarks-*' \
+                  ! -name '*.d' ! -name '*.pdb' ! -name '*.dSYM' \
+                  -printf '%T@ %p\n' \
+                | sort -nr | head -n1 | cut -d' ' -f2-)
+          if [ -z "$bin" ] || [ ! -x "$bin" ]; then
+            echo "::error::could not find compiled bench binary under target/release/deps"
+            ls -la target/release/deps/ferrflow_benchmarks-* 2>/dev/null || true
+            exit 1
+          fi
+          echo "bin=$bin" >> "$GITHUB_OUTPUT"
+          # Strip the hash so the matrix doesn't have to re-derive it.
+          cp "$bin" target/release/deps/ferrflow_benchmarks
+      - uses: actions/upload-artifact@v7
+        with:
+          name: micro-bench-binary
+          path: target/release/deps/ferrflow_benchmarks
+          retention-days: 1
+          if-no-files-found: error
+
   micro-bench:
     name: Micro Benchmark - ${{ matrix.group }}
+    needs: micro-bench-build
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -290,21 +334,38 @@ jobs:
           - validate
           - full_check_flow
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
         with:
-          fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v2
-      - uses: FerrLabs/Benchmarks@v3
-        with:
-          type: micro
-          group-filter: ${{ matrix.group }}
-          definitions: benchmarks/fixtures/definitions
-          ferrflow-token: ${{ secrets.GITHUB_TOKEN }}
-          skip-competitors: true
-          comment-on-pr: false
-        env:
-          FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
+          name: micro-bench-binary
+          path: bench-bin/
+      - name: Run group ${{ matrix.group }}
+        # Mirrors what FerrLabs/Benchmarks@v3 used to do for the micro
+        # path: invoke the bench binary directly with the criterion
+        # positional filter, capture bencher-format stdout, and keep
+        # only the well-formed `test … bench: …` rows so the aggregate
+        # job's benchmark-action consumer doesn't choke on noise.
+        # The bench binary's fixtures are all in-process (tempdir +
+        # libgit2), so no checkout is needed in this job.
+        run: |
+          set +e
+          chmod +x bench-bin/ferrflow_benchmarks
+          ./bench-bin/ferrflow_benchmarks --bench --output-format bencher \
+              "${{ matrix.group }}" \
+              2> bench-stderr.log | tee raw-output.txt
+          bench_exit=${PIPESTATUS[0]}
+          set -e
+          if [ "$bench_exit" != "0" ]; then
+            echo "::warning::bench binary exited ${bench_exit} — tolerating as long as rows were captured. Stderr tail:"
+            tail -40 bench-stderr.log || true
+          fi
+          grep -E '^test .+ \.\.\. bench:[[:space:]]+[0-9,]+ ns/iter' raw-output.txt > output.txt || true
+          echo "---"
+          echo "Filtered bencher output ($(wc -l < output.txt) lines kept):"
+          cat output.txt
+          if [ ! -s output.txt ]; then
+            echo "::error::no well-formed benchmark rows captured; bench exit was ${bench_exit}"
+            exit 1
+          fi
       - uses: actions/upload-artifact@v7
         with:
           name: micro-partial-${{ matrix.group }}


### PR DESCRIPTION
## Summary

The matrix-sharded micro benchmarks introduced by #379 each ran \`cargo bench\` from scratch. All 11 shards share the same Swatinem/rust-cache key but launch in parallel, so none could hit a sibling's cache — each paid the full ~5–7 min cold rebuild before ~30s of actual measurement. Net: ~12 min × 11 shards per PR, dominated by redundant builds.

Split into:

1. **\`micro-bench-build\`** — single upstream job, compiles \`ferrflow_benchmarks\` once with \`cargo bench --no-run\`, uploads as artifact.
2. **\`micro-bench\` (matrix)** — downloads the binary, runs only its group with criterion's positional filter, captures bencher-format rows.
3. **\`micro-bench-aggregate\`** — unchanged, still merges shard partials and feeds \`benchmark-action/github-action-benchmark\`.

The matrix jobs no longer need \`actions/checkout\` or \`Swatinem/rust-cache\` since the bench binary's fixtures are all in-process (libgit2 + tempdir).

Drops the \`FerrLabs/Benchmarks@v3\` wrapper for this path — the action invokes \`cargo bench\` itself, so it can't consume a pre-built binary. The micro path only used the action for criterion filter passthrough, bencher-format output, and a row-validity grep, all faithfully inlined here. The wrapper stays in use for the macro \`Benchmark\` job on main pushes.

## Expected impact

- Wall time: ~6 min cold / ~1 min on cache hit, vs ~12 min × 11 today
- Compute saved per PR: ~10 builds worth of runner minutes (~50–70 min)
- Identical bench output: same criterion filter, same bencher format, same row grep

## Test plan

- [ ] CI on this PR shows \`micro-bench-build\` runs once, \`micro-bench\` matrix shards finish in <2 min each (the build is the expensive part — once it's done, runs are just measurement)
- [ ] \`Micro Benchmark (aggregate)\` job consumes the partials successfully and posts the same regression comment shape as before
- [ ] No other CI job breaks (this only restructures the bench path)

## Out of scope

- Adding a \`prebuilt-binary\` input to \`FerrLabs/Benchmarks@v3\` so other repos benefit too — separate concern, requires action release.
- Lowering criterion sample-size to shrink the measurement phase further. Would help but the build was the actual bottleneck.

Closes #397