### PR TITLE
ci: cargo-audit + cargo-deny + cargo-machete on every PR (+ daily audit cron)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,25 @@
+name: Audit (RustSec)
+
+on:
+  schedule:
+    - cron: '0 6 * * *'   # daily, 06:00 UTC — picks up newly-published advisories
+  workflow_dispatch:
+  push:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - '.github/workflows/audit.yml'
+
+permissions:
+  contents: read
+  issues: write   # rustsec/audit-check opens issues for new advisories
+
+jobs:
+  audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: rustsec/audit-check@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,24 @@ jobs:
         env:
           FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
 
+  security:
+    name: Cargo Security
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit,cargo-deny,cargo-machete
+      - name: cargo audit (RustSec advisories)
+        run: cargo audit --deny warnings
+      - name: cargo deny (licenses + bans + sources)
+        run: cargo deny --all-features check
+      - name: cargo machete (unused deps)
+        run: cargo machete
+
   build:
     name: Build Release Binary
     needs: test

--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,7 @@ allow = [
     "BSD-3-Clause",
     "BSL-1.0",
     "CC0-1.0",
+    "CDLA-Permissive-2.0",
     "ISC",
     "MIT",
     "MIT-0",


### PR DESCRIPTION
## Summary

Closes the security/quality gap on the Rust pipeline. Existing CI already covers fmt + clippy + tests + tarpaulin coverage; this adds the supply-chain layer:

- **\`cargo audit\`** — RustSec advisory database check on every PR. Fails on any open advisory (warnings denied).
- **\`cargo deny\`** — license allowlist + banned crates + duplicate detection + source pinning (only crates.io). Config in \`deny.toml\` at the repo root.
- **\`cargo machete\`** — flags unused dependencies declared in \`Cargo.toml\`.

Plus a separate daily audit workflow (\`.github/workflows/audit.yml\`) that runs \`rustsec/audit-check\` on cron. When a new advisory is published for a dependency we already use, this opens a GitHub issue automatically — no waiting for the next PR to find out.

## Why a separate audit cron

\`cargo audit\` in the PR pipeline catches advisories at code-change time. The cron catches advisories that are published **between** PRs (e.g. an OpenSSL CVE drops on a Tuesday but no one opens a PR until Friday). The two are complementary, both gratuit.

## What's NOT changed

- Release pipeline (\`needs: [test, fixture-*, benchmark]\`) deliberately doesn't gate on the new \`security\` job. A new RustSec advisory should not block shipping a release that's otherwise green — it should open an issue and force a follow-up. The existing \`test\` gate (which still runs clippy) ensures code quality on every release.
- No changes to clippy, fmt, tarpaulin, or coverage upload.

## Test plan

- [ ] CI's new \`security\` job passes on this PR (signals deny.toml is permissive enough for the current tree)
- [ ] If \`cargo deny\` fails, adjust the licenses allowlist or add specific \`skip\` entries for known duplicates and re-run
- [ ] After merge, the daily cron triggers (visible in Actions tab) and produces no new issues unless there's an actual advisory

## Follow-up (other Rust repos)

Same pattern applies to \`Kit\`, \`FerrLabs-Cloud/api\`, \`FerrTrack-Cloud/api\`, \`FerrAgents/api\`. Worth replicating once this lands and the deny.toml proves stable here.