### PR TITLE
fix(deny): allow-wildcard-paths is a bool, set to true for workspace path deps

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -32,7 +32,7 @@ exceptions = []
 [bans]
 multiple-versions = "warn"
 wildcards = "deny"
-allow-wildcard-paths = []
+allow-wildcard-paths = true
 deny = []
 skip = []
 skip-tree = []


### PR DESCRIPTION
Follow-up to #403. `cargo deny` accepted the renamed key but reported `expected a bool` for the value:

```
35 │ allow-wildcard-paths = []
   │                        ━━ expected a bool
```

The original `allow-wildcards-in-private = []` (deprecated) was an array of crate-name exceptions. The replacement `allow-wildcard-paths` is a single boolean — `true` enables workspace path dependencies (e.g. `ferrflow-wasm` depends on root `ferrflow` via `path = ".."`) to use `*` versions, which is the FerrFlow-monorepo pattern.