### PR TITLE
chore: add cargo fmt/clippy/test git hooks (.githooks/)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.githooks/* text eol=lf
+*.sh text eol=lf

--- a/.githooks/install.sh
+++ b/.githooks/install.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+git config core.hooksPath .githooks
+chmod +x .githooks/pre-commit .githooks/pre-push 2>/dev/null || true
+echo "Git hooks installed (core.hooksPath=.githooks)."
+echo "pre-commit: cargo fmt --check + cargo clippy -D warnings"
+echo "pre-push:   cargo test --workspace --all-features"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! git diff --cached --name-only --diff-filter=ACM | grep -qE '\.rs$'; then
+  exit 0
+fi
+
+echo "==> cargo fmt --check"
+cargo fmt --all -- --check
+
+echo "==> cargo clippy"
+cargo clippy --workspace --all-targets -- -D warnings

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> cargo test"
+cargo test --workspace --all-features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,19 @@ cargo clippy
 cargo fmt --check
 ```
 
+## Git hooks
+
+Run once after cloning:
+
+```bash
+./.githooks/install.sh
+```
+
+That sets `git config core.hooksPath .githooks` so:
+
+- **pre-commit** runs `cargo fmt --check` + `cargo clippy -D warnings` on every commit that touches Rust files.
+- **pre-push** runs `cargo test --workspace --all-features` so broken code never reaches the remote.
+
 ## Guidelines
 
 ### Branches


### PR DESCRIPTION
## Summary
- `.githooks/pre-commit` runs `cargo fmt --check` + `cargo clippy -D warnings` on commits that touch Rust files.
- `.githooks/pre-push` runs `cargo test --workspace --all-features`.
- `.githooks/install.sh` sets `core.hooksPath = .githooks` for one-shot setup.
- CONTRIBUTING updated with a one-liner setup instruction.
- `.gitattributes` enforces LF line endings on the hook scripts so they execute on Windows checkouts too.

Why `.githooks/` instead of husky: husky needs a Node toolchain in the repo. FerrFlow is pure Rust + a slim npm wrapper, so the canonical Rust pattern (`core.hooksPath`) keeps the repo Node-free.

## Test plan
- [x] `./.githooks/install.sh` set `core.hooksPath` correctly.
- [x] Pre-commit fired on this commit (no Rust files staged, hook short-circuited as designed).
- [x] Pre-push fired and ran `cargo test --workspace --all-features` clean (586 passed, 0 failed).