### PR TITLE
ci: switch cargo test → cargo nextest run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,17 @@ jobs:
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - name: Format check
         run: cargo fmt --check
       - name: Clippy
         run: cargo clippy -- -D warnings
         env:
           FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
-      - name: Tests
-        run: cargo test
+      - name: Tests (nextest)
+        run: cargo nextest run --no-fail-fast
         env:
           FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
 


### PR DESCRIPTION
Per FerrLabs-Cloud#232 nextest migration. ~30% faster on parallel test execution. Adds taiki-e/install-action for cargo-nextest before the test step.

`--no-fail-fast` keeps running all tests after a failure so the CI log shows the full picture in one run instead of needing a re-run after fixing the first failure.