### PR TITLE
chore(hooks): mirror CI checks in pre-push hook

### DIFF
--- a/.githooks/install.sh
+++ b/.githooks/install.sh
@@ -3,5 +3,5 @@ set -euo pipefail
 git config core.hooksPath .githooks
 chmod +x .githooks/pre-commit .githooks/pre-push 2>/dev/null || true
 echo "Git hooks installed (core.hooksPath=.githooks)."
-echo "pre-commit: cargo fmt --check + cargo clippy -D warnings"
-echo "pre-push:   cargo test --workspace --all-features"
+echo "pre-commit: cargo fmt --check + cargo clippy -D warnings (when .rs files staged)"
+echo "pre-push:   cargo fmt --check + cargo clippy --all-targets -- -D warnings"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "==> cargo test"
-cargo test --workspace --all-features
+echo "==> cargo fmt --check"
+cargo fmt --all -- --check
+
+echo "==> cargo clippy"
+cargo clippy --all-targets -- -D warnings


### PR DESCRIPTION
## Summary

Replaces the test-only pre-push with the fmt+clippy pair that gates the CI 'Test' job and currently slip through to GitHub Actions every push. The full test suite (cargo nextest) is intentionally left out of pre-push — the cargo crate is heavy enough that running tests on every push would push the hook well past the 3-minute developer-budget.

`.githooks/pre-push` runs:
- `cargo fmt --all -- --check` (mirrors `test.Format check`)
- `cargo clippy --all-targets -- -D warnings` (mirrors `test.Clippy`)

Skips:
- `cargo nextest run --no-fail-fast` — too slow for a pre-push budget; CI keeps running it.
- `cargo audit` / `cargo deny` / `cargo machete` — `security` job covers these in CI.
- Coverage / fixtures / benchmarks — CI artefacts, not type-soundness gates.

To activate: run `bash .githooks/install.sh` once (sets `core.hooksPath=.githooks`).

## Test plan
- [ ] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass on a clean checkout
- [ ] `bash .githooks/install.sh` then `git push --dry-run` does not crash