### PR TITLE
fix: audit batch (#426, #427, #429, #430, #432)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
@@ -65,7 +65,7 @@ jobs:
     runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build ferrflow
         run: cargo build --release
@@ -84,7 +84,7 @@ jobs:
     runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin
@@ -302,7 +302,7 @@ jobs:
     runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Compile bench binary (no run)
         run: cargo bench --bench ferrflow_benchmarks --no-run
@@ -453,7 +453,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: actions/setup-node@v6
         with:
@@ -499,7 +499,7 @@ jobs:
           # to GITHUB_TOKEN (i.e. github-actions[bot]) which isn't in the
           # branch-rule bypass list and can't push to main.
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build ferrflow
         run: cargo build --release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
             archive: ferrflow-windows-x64.zip
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
@@ -90,7 +90,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.FERRFLOW_TOKEN }}
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build ferrflow
         run: cargo build --release
@@ -134,7 +134,7 @@ jobs:
     runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
       - run: cargo publish --allow-dirty --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   publish-npm:
@@ -164,7 +164,7 @@ jobs:
     runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
       - uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag }}
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "4.6.3"
+version = "4.7.0"
 dependencies = [
  "anyhow",
  "cargo-husky",
@@ -1306,6 +1306,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ cli = ["dep:git2", "dep:ureq", "dep:clap", "dep:clap_complete", "dep:colored", "
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["preserve_order"] }
 json5 = "1.0"
 toml_edit = { version = "0.25", features = ["serde"] }
 semver = "1"

--- a/action.yml
+++ b/action.yml
@@ -65,9 +65,9 @@ runs:
         ARCHIVE="ferrflow-${PLATFORM}-${ARCH_NAME}.${EXT}"
 
         if [ "${{ inputs.version }}" = "latest" ]; then
-          URL="https://github.com/FerrLabs/ferrflow/releases/latest/download/${ARCHIVE}"
+          URL="https://github.com/FerrLabs/FerrFlow/releases/latest/download/${ARCHIVE}"
         else
-          URL="https://github.com/FerrLabs/ferrflow/releases/download/v${{ inputs.version }}/${ARCHIVE}"
+          URL="https://github.com/FerrLabs/FerrFlow/releases/download/v${{ inputs.version }}/${ARCHIVE}"
         fi
 
         INSTALL_DIR="${RUNNER_TEMP:-$HOME/.local/bin}/ferrflow-bin"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"
 components = ["rustfmt", "clippy"]

--- a/src/conventional_commits.rs
+++ b/src/conventional_commits.rs
@@ -24,28 +24,36 @@ static BREAKING_RE: OnceLock<Regex> = OnceLock::new();
 static FEAT_RE: OnceLock<Regex> = OnceLock::new();
 static PATCH_RE: OnceLock<Regex> = OnceLock::new();
 
-fn breaking_re() -> &'static Regex {
+fn breaking_header_re() -> &'static Regex {
     BREAKING_RE.get_or_init(|| {
-        Regex::new(r"(?m)^(feat|fix|refactor|perf|build|chore|docs|style|test|ci)(\(.+\))?!:|^BREAKING CHANGE").unwrap()
+        Regex::new(r"^(feat|fix|refactor|perf|build|chore|docs|style|test|ci)(\(.+\))?!:").unwrap()
     })
 }
 
-fn feat_re() -> &'static Regex {
-    FEAT_RE.get_or_init(|| Regex::new(r"(?m)^feat(\(.+\))?:").unwrap())
+fn feat_header_re() -> &'static Regex {
+    FEAT_RE.get_or_init(|| Regex::new(r"^feat(\(.+\))?:").unwrap())
 }
 
-fn patch_re() -> &'static Regex {
-    PATCH_RE.get_or_init(|| Regex::new(r"(?m)^(fix|perf|refactor)(\(.+\))?:").unwrap())
+fn patch_header_re() -> &'static Regex {
+    PATCH_RE.get_or_init(|| Regex::new(r"^(fix|perf|refactor)(\(.+\))?:").unwrap())
+}
+
+static BREAKING_FOOTER_RE: OnceLock<Regex> = OnceLock::new();
+
+fn breaking_footer_re() -> &'static Regex {
+    BREAKING_FOOTER_RE.get_or_init(|| Regex::new(r"(?m)^BREAKING CHANGE").unwrap())
 }
 
 pub fn determine_bump(message: &str) -> BumpType {
-    if breaking_re().is_match(message) {
+    let header = parse_subject(message);
+
+    if breaking_header_re().is_match(header) || breaking_footer_re().is_match(message) {
         return BumpType::Major;
     }
-    if feat_re().is_match(message) {
+    if feat_header_re().is_match(header) {
         return BumpType::Minor;
     }
-    if patch_re().is_match(message) {
+    if patch_header_re().is_match(header) {
         return BumpType::Patch;
     }
     BumpType::None
@@ -266,9 +274,20 @@ mod tests {
     }
 
     #[test]
-    fn test_multiline_body_feat_in_body_matches() {
+    fn test_multiline_body_feat_in_body_does_not_match() {
         let msg = "chore: update deps\n\nfeat: this is in the body";
-        // The regex uses (?m) multiline, so feat: in the body DOES match
-        assert_eq!(determine_bump(msg), BumpType::Minor);
+        assert_eq!(determine_bump(msg), BumpType::None);
+    }
+
+    #[test]
+    fn test_multiline_body_fix_in_body_does_not_match() {
+        let msg = "chore: update deps\n\nfix: this is in the body";
+        assert_eq!(determine_bump(msg), BumpType::None);
+    }
+
+    #[test]
+    fn test_multiline_body_breaking_marker_in_body_does_not_match() {
+        let msg = "chore: update deps\n\nfeat!: this is in the body";
+        assert_eq!(determine_bump(msg), BumpType::None);
     }
 }

--- a/src/formats/gomod.rs
+++ b/src/formats/gomod.rs
@@ -6,17 +6,23 @@ use std::path::Path;
 pub struct GoModVersionFile;
 
 impl VersionFile for GoModVersionFile {
-    fn read_version(&self, _file_path: &Path) -> Result<String> {
-        let output = std::process::Command::new("git")
-            .args([
-                "describe",
-                "--tags",
-                "--match",
-                "*@v*",
-                "--match",
-                "v*",
-                "--abbrev=0",
-            ])
+    fn read_version(&self, file_path: &Path) -> Result<String> {
+        let mut cmd = std::process::Command::new("git");
+        cmd.args([
+            "describe",
+            "--tags",
+            "--match",
+            "*@v*",
+            "--match",
+            "v*",
+            "--abbrev=0",
+        ]);
+        if let Some(parent) = file_path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            cmd.current_dir(parent);
+        }
+        let output = cmd
             .output()
             .context("Failed to run git describe")
             .error_code(error_code::GOMOD_GIT_DESCRIBE)?;
@@ -84,14 +90,7 @@ mod tests {
         assert!(!handler.modifies_file());
     }
 
-    #[test]
-    fn read_version_errors_when_no_tag() {
-        // When no matching tag exists, `read_version` surfaces a
-        // `GOMOD_NO_TAG` error so the caller can apply a strategy-aware
-        // bootstrap (see `versioning::bootstrap_version`).
-        let dir = tempfile::tempdir().unwrap();
-        let repo = dir.path();
-
+    fn init_repo(repo: &Path) {
         for (args, err_msg) in &[
             (vec!["init", "-b", "main"], "git init"),
             (
@@ -112,16 +111,46 @@ mod tests {
                 String::from_utf8_lossy(&out.stderr)
             );
         }
+    }
+
+    #[test]
+    fn read_version_errors_when_no_tag() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        init_repo(repo);
 
         let handler = GoModVersionFile;
-        let original_cwd = std::env::current_dir().unwrap();
-        std::env::set_current_dir(repo).unwrap();
-        let result = handler.read_version(Path::new("go.mod"));
-        std::env::set_current_dir(original_cwd).unwrap();
+        let result = handler.read_version(&repo.join("go.mod"));
 
         assert!(
             result.is_err(),
             "expected error when no tag, got {result:?}"
         );
+    }
+
+    #[test]
+    fn read_version_uses_file_path_parent_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        init_repo(repo);
+
+        let tag_out = Command::new("git")
+            .args(["tag", "v1.2.3"])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        assert!(tag_out.status.success());
+
+        let other_dir = tempfile::tempdir().unwrap();
+        let original_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(other_dir.path()).unwrap();
+
+        let handler = GoModVersionFile;
+        let result = handler.read_version(&repo.join("go.mod"));
+
+        std::env::set_current_dir(original_cwd).unwrap();
+
+        let v = result.expect("should resolve version via file_path parent");
+        assert_eq!(v, "1.2.3");
     }
 }

--- a/src/formats/json.rs
+++ b/src/formats/json.rs
@@ -50,6 +50,36 @@ mod tests {
         assert_eq!(v["private"], true);
         assert_eq!(v["version"], "2.0.0");
     }
+
+    #[test]
+    fn write_preserves_key_order() {
+        let f = write_temp(
+            r#"{"name":"foo","version":"1.0.0","private":true,"description":"x","scripts":{"build":"tsc"}}"#,
+        );
+        let handler = JsonVersionFile;
+        handler.write_version(f.path(), "2.0.0").unwrap();
+        let content = std::fs::read_to_string(f.path()).unwrap();
+
+        let name_pos = content.find("\"name\"").unwrap();
+        let version_pos = content.find("\"version\"").unwrap();
+        let private_pos = content.find("\"private\"").unwrap();
+        let description_pos = content.find("\"description\"").unwrap();
+        let scripts_pos = content.find("\"scripts\"").unwrap();
+
+        assert!(name_pos < version_pos, "name must come before version");
+        assert!(
+            version_pos < private_pos,
+            "version must come before private"
+        );
+        assert!(
+            private_pos < description_pos,
+            "private must come before description"
+        );
+        assert!(
+            description_pos < scripts_pos,
+            "description must come before scripts"
+        );
+    }
 }
 
 impl VersionFile for JsonVersionFile {


### PR DESCRIPTION
Batched fixes from the audit pass. Each commit is one issue.

Closes #426 — `serde_json` now uses the `preserve_order` feature so `to_string_pretty` keeps the original key order on write. Previously `package.json` was scrambled (alphabetical BTreeMap order) on every release. New test `write_preserves_key_order` proves `name`/`version`/`private`/`description`/`scripts` stay in source order.

Closes #427 — the conventional-commits regex no longer uses the `(?m)` flag against the full message. We now match the header line only (`parse_subject(message)`) for `feat:`, `fix:`, and `!:` markers. The `BREAKING CHANGE` footer is the only thing that still scans the body (its semantic per the spec). The previously-buggy test `test_multiline_body_feat_in_body_matches` is inverted into `test_multiline_body_feat_in_body_does_not_match`, plus two new sibling tests for `fix:` and `feat!:` in body.

Closes #429 — `GoModVersionFile::read_version` now sets `current_dir` on the `git describe` call based on `file_path.parent()`. Previously the function ignored the path entirely and ran against the cwd, so in a monorepo all `go.mod` packages resolved to the same tag (whichever the cwd's repo had). New test `read_version_uses_file_path_parent_dir` proves the fix.

Closes #430 — drop nightly toolchain. `rust-toolchain.toml` switches `nightly` → `stable`; all 12 `dtolnay/rust-toolchain@nightly` usages across ci/publish/release workflows switch to `@stable`. Builds clean on stable (edition 2024 / resolver 3 require Rust 1.85+).

Closes #432 — `action.yml` install URL was `FerrLabs/ferrflow` (lowercase). Now `FerrLabs/FerrFlow` matching the canonical repo case.

## Deferred from scope

- #431 (rayon parallel package scan) — skipped. The target loop holds `git2::Repository` (not `Send`/`Sync`), mutates ~7 pieces of shared state across the body, and uses `?` for error propagation. A correct rayon port requires a non-trivial refactor: per-thread `Repository::open`, decouple gather/decide/emit phases, switch errors to `try_fold`. Bigger than the "minimum change" the issue asked for. Will land in its own PR.
- #434 (FormatPreservingEditor refactor) — out of scope per audit note.

## Verification

- `cargo check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 593 passed, 0 failed