### PR TITLE
chore(ci): use ubuntu-latest on public repos (free GitHub runners)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   test:
     name: Test
     if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -43,7 +43,7 @@ jobs:
   security:
     name: Cargo Security
     if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -62,7 +62,7 @@ jobs:
     name: Build Release Binary
     needs: test
     if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -81,7 +81,7 @@ jobs:
   coverage:
     name: Coverage
     if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -102,7 +102,7 @@ jobs:
     name: Generate Fixtures
     needs: test
     if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
@@ -145,7 +145,7 @@ jobs:
   fixture-monorepo:
     name: Fixtures â€” Monorepo
     needs: [build, fixture-generate]
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
@@ -181,7 +181,7 @@ jobs:
   fixture-single:
     name: Fixtures â€” Single Package
     needs: [build, fixture-generate]
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
@@ -217,7 +217,7 @@ jobs:
   fixture-config:
     name: Fixtures â€” Config & Formats
     needs: [build, fixture-generate]
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
@@ -253,7 +253,7 @@ jobs:
   fixture-advanced:
     name: Fixtures â€” Advanced Features
     needs: [build, fixture-generate]
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
@@ -299,7 +299,7 @@ jobs:
   micro-bench-build:
     name: Build micro bench binary
     if: github.event_name == 'pull_request'
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -337,7 +337,7 @@ jobs:
     name: Micro Benchmark - ${{ matrix.group }}
     needs: micro-bench-build
     if: github.event_name == 'pull_request'
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -397,7 +397,7 @@ jobs:
     name: Micro Benchmark (aggregate)
     needs: micro-bench
     if: github.event_name == 'pull_request'
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
@@ -449,7 +449,7 @@ jobs:
   benchmark:
     name: Benchmark
     needs: test
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6
@@ -470,7 +470,7 @@ jobs:
   release:
     name: Release
     needs: [test, fixture-monorepo, fixture-single, fixture-config, fixture-advanced, benchmark]
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     concurrency:
       group: release-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: false

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   conventional:
     name: Conventional commits
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v6
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,7 +80,7 @@ jobs:
   upload:
     name: Upload Release Assets
     needs: build
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write
@@ -131,7 +131,7 @@ jobs:
   publish-crate:
     name: Publish crates.io
     needs: upload
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -140,7 +140,7 @@ jobs:
   publish-npm:
     name: Publish npm
     needs: upload
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -161,7 +161,7 @@ jobs:
   publish-wasm:
     name: Publish @ferrflow/wasm
     needs: upload
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -186,7 +186,7 @@ jobs:
   publish-docker:
     name: Publish Docker
     needs: upload
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
   release:
     name: Upload Assets
     needs: build
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     permissions:
       # Required for publishing results to the GitHub code scanning dashboard.
       security-events: write


### PR DESCRIPTION
Switch GitHub Actions workflows back from the self-hosted `ferrlabs-k8s` runner pool to GitHub's hosted `ubuntu-latest`. The runner migration in #424 (`chore/migrate-runners-to-ferrlabs-k8s`) was over-applied to public OSS repos — those should stay on GitHub-hosted runners.

Rationale:
- Public repos get unlimited free minutes on GitHub-hosted runners
- Stop burning self-hosted capacity for OSS workloads
- No infra dependency for OSS contributors / community PRs
- Match the standard GitHub-free-on-public model

OS-specific matrix entries (Windows / macOS in `publish.yml`) were already GitHub-hosted (ferrlabs-k8s is Linux-only) — only the Linux jobs are affected.

Reusable workflows in `FerrLabs/.github` keep their `runner` input default at `ubuntu-latest`; private consumers will continue to override with `runner: ferrlabs-k8s`.