### PR TITLE
fix(release): wait via list+filter and self-heal missing draft

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,22 +116,47 @@ jobs:
           subject-path: artifacts/*
       - name: Wait for draft release to be visible
         # Defense against the race where this workflow (push:tags) fires
-        # before `ferrflow release --draft` (running in the CI workflow on
-        # the same commit) has finished the create-release API call. We
-        # poll up to ~2.5 min — the API call normally completes within a
-        # few seconds, this only saves us from eventual-consistency lag.
+        # before `ferrflow release --draft` (running in the CI workflow
+        # on the same commit) has finished the create-release API call.
+        # We poll up to ~5 min, then fall back to creating the draft
+        # release ourselves as a self-healing measure.
+        #
+        # Why list+filter instead of `gh release view "$TAG"` or `gh api
+        # /releases/tags/$TAG`:
+        # - The REST endpoint `/releases/tags/{tag}` excludes drafts
+        #   entirely (returns 404). Verified locally on v4.7.2.
+        # - `gh release view "$TAG"` finds drafts but in v4.7.2's failed
+        #   Publish run it returned 404 in the runner anyway, possibly
+        #   due to gh-CLI version skew or token scope. We can't pin
+        #   the runner gh version reliably.
+        # - `GET /releases?per_page=100` returns drafts when authed and
+        #   is the most stable surface for "does this draft exist?".
+        #
+        # Self-heal: if the wait window expires, we attempt to create
+        # the release ourselves before failing. Covers the case where
+        # ferrflow's create_release call in CI silently warned-and-
+        # continued (see monorepo.rs:1339, follow-up filed at #439-fix).
         run: |
           TAG="${{ github.ref_name }}"
-          for i in $(seq 1 30); do
-            if gh release view "$TAG" >/dev/null 2>&1; then
-              echo "Release $TAG visible after $((i*5))s"
+          REPO="${{ github.repository }}"
+          for i in $(seq 1 60); do
+            ID=$(gh api "repos/$REPO/releases?per_page=100" \
+                   --jq ".[] | select(.tag_name == \"$TAG\") | .id" 2>/dev/null \
+                   | head -n1)
+            if [ -n "$ID" ]; then
+              echo "Release $TAG visible after $((i*5))s (id=$ID)"
               exit 0
             fi
-            echo "Release $TAG not yet visible, retrying in 5s ($i/30)..."
+            echo "Release $TAG not yet visible, retrying in 5s ($i/60)..."
             sleep 5
           done
-          echo "::error::Release $TAG never appeared after 150s — see ferrflow release log"
-          exit 1
+          echo "::warning::Release $TAG never appeared after 300s — creating it now as self-heal"
+          gh release create "$TAG" \
+            --draft \
+            --title "$TAG" \
+            --notes "Release notes will be filled by the post-publish step." \
+            --target "${{ github.sha }}"
+          echo "Created draft release $TAG via self-heal"
         env:
           GH_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}
       - name: Upload assets to draft release


### PR DESCRIPTION
## Summary

The `Wait for draft release to be visible` step in `.github/workflows/publish.yml` has been silently breaking the release pipeline since #438 (v4.7.0). v4.7.0 and v4.7.1 published with **0 assets**; v4.7.2 stayed in draft state. Downstream consumers (`FerrLabs/FerrFlow@v4` resolving to `releases/latest/download/ferrflow-linux-x64.tar.gz`) hit 404 — FerrGames-Cloud has 10 PRs sitting on main since 2026-05-13T17:22 with no release because of this.

## Root cause

The wait step polled `gh release view "$TAG"` which, in the v4.7.2 Publish run, returned 404 for the freshly-created draft despite the draft existing in the GitHub UI. Verified locally: `gh release view v4.7.2 --repo FerrLabs/FerrFlow` finds the draft, `gh api .../releases/tags/v4.7.2` returns 404 (the REST endpoint excludes drafts entirely). The CLI behavior in the runner appears version-skewed.

Compounding bug: `monorepo.rs:1339` swallows `create_release` failures as warnings, so a transient API error during `ferrflow release --draft` lets the workflow push the tag without ever creating the release. Filed as a follow-up in the comment.

## Fix

1. **Switch to list+filter via `gh api /releases?per_page=100 --jq '.[] | select(.tag_name == "$TAG") | .id'`** — the only stable surface that lists drafts when authenticated.
2. **Extend the poll window from 150 s to 300 s** — covers slower API propagation observed in past failures.
3. **Self-heal**: if the wait expires without finding the draft, the step now creates the release itself instead of failing the whole publish. Covers the case where ferrflow's create_release silently warned-and-continued.

## Test plan

- [x] CI green (no functional change to anything but the wait step)
- [ ] On merge to main, ferrflow auto-cuts v4.7.3 — verify the wait step finds the draft within seconds
- [ ] Verify v4.7.3 release ends up with all 6 assets (linux x64/arm64, darwin x64/arm64, windows x64, completions)
- [ ] Verify `https://github.com/FerrLabs/FerrFlow/releases/latest/download/ferrflow-linux-x64.tar.gz` returns 200
- [ ] Re-trigger FerrGames-Cloud's main CI release step → succeeds, ships the 10 backlog PRs
