### PR TITLE
feat(ci): enable competitor benchmarks (semantic-release, changesets) in release run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,7 +463,7 @@ jobs:
           type: full
           definitions: benchmarks/fixtures/definitions
           ferrflow-token: ${{ secrets.GITHUB_TOKEN }}
-          skip-competitors: true
+          skip-competitors: false
         env:
           FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
 


### PR DESCRIPTION
## Why

The full benchmark job (`FerrLabs/Benchmarks@v3` with `type: full`) runs on every `main` push and produces a hyperfine timing table per fixture × per tool, plus binary/install size. The infrastructure has supported comparison against semantic-release / changesets / release-please for a long time, but the FerrFlow CI invoked it with `skip-competitors: true` — so every release shipped with a comparison table that only had one row (FerrFlow itself).

Flipping the flag enables the actual comparison so next release notes include side-by-side timings.

## Cost

The benchmark job is gated by `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` — it never runs on PRs. So enabling competitors adds time to release runs only, not to PR latency.

Approximate added time per release: 5-10 minutes (npm install for each competitor + hyperfine across 4 fixtures × 2 npm-installed competitors). Acceptable given how rarely it triggers.

## Output

Each `main` push (= each release) will now produce:

- PR comment with comparison table (already wired)
- Release notes with comparison table (already wired via `benchmark-release-summary` artifact)
- Updated `hyperfine-baseline` artifact (90-day retention, fetchable via `gh` API for any future public-facing page)

## Follow-up

Once a couple of releases produce real data, open a follow-up to surface the comparison publicly (e.g. `/compare` page on ferrflow.com pulling the artifact at build time).