### PR TITLE
feat(bench): add competitor tool configs to fixture definitions

### DIFF
--- a/benchmarks/fixtures/definitions/mono-100-1k.json
+++ b/benchmarks/fixtures/definitions/mono-100-1k.json
@@ -10,6 +10,20 @@
   "tool_configs": {
     "ferrflow": {
       "ferrflow.json": "{}"
+    },
+    "changesets": {
+      "package.json": "{\"name\":\"root\",\"private\":true,\"workspaces\":[\"packages/*\"]}",
+      ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.0.0/schema.json\",\"changelog\":\"@changesets/cli/changelog\",\"commit\":false,\"fixed\":[],\"linked\":[],\"access\":\"restricted\",\"baseBranch\":\"main\",\"updateInternalDependencies\":\"patch\",\"ignore\":[]}"
+    },
+    "semantic-release": {
+      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true,\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/example/example.git\"}}",
+      ".releaserc.json": "{\"branches\":[\"main\"],\"plugins\":[\"@semantic-release/commit-analyzer\",\"@semantic-release/release-notes-generator\"]}"
+    },
+    "standard-version": {
+      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true}"
+    },
+    "commit-and-tag-version": {
+      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true}"
     }
   }
 }

--- a/benchmarks/fixtures/definitions/mono-50-5k.json
+++ b/benchmarks/fixtures/definitions/mono-50-5k.json
@@ -10,6 +10,20 @@
   "tool_configs": {
     "ferrflow": {
       "ferrflow.json": "{}"
+    },
+    "changesets": {
+      "package.json": "{\"name\":\"root\",\"private\":true,\"workspaces\":[\"packages/*\"]}",
+      ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.0.0/schema.json\",\"changelog\":\"@changesets/cli/changelog\",\"commit\":false,\"fixed\":[],\"linked\":[],\"access\":\"restricted\",\"baseBranch\":\"main\",\"updateInternalDependencies\":\"patch\",\"ignore\":[]}"
+    },
+    "semantic-release": {
+      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true,\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/example/example.git\"}}",
+      ".releaserc.json": "{\"branches\":[\"main\"],\"plugins\":[\"@semantic-release/commit-analyzer\",\"@semantic-release/release-notes-generator\"]}"
+    },
+    "standard-version": {
+      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true}"
+    },
+    "commit-and-tag-version": {
+      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true}"
     }
   }
 }

--- a/benchmarks/fixtures/definitions/mono-large.json
+++ b/benchmarks/fixtures/definitions/mono-large.json
@@ -10,6 +10,20 @@
   "tool_configs": {
     "ferrflow": {
       "ferrflow.json": "{}"
+    },
+    "changesets": {
+      "package.json": "{\"name\":\"root\",\"private\":true,\"workspaces\":[\"packages/*\"]}",
+      ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.0.0/schema.json\",\"changelog\":\"@changesets/cli/changelog\",\"commit\":false,\"fixed\":[],\"linked\":[],\"access\":\"restricted\",\"baseBranch\":\"main\",\"updateInternalDependencies\":\"patch\",\"ignore\":[]}"
+    },
+    "semantic-release": {
+      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true,\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/example/example.git\"}}",
+      ".releaserc.json": "{\"branches\":[\"main\"],\"plugins\":[\"@semantic-release/commit-analyzer\",\"@semantic-release/release-notes-generator\"]}"
+    },
+    "standard-version": {
+      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true}"
+    },
+    "commit-and-tag-version": {
+      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true}"
     }
   }
 }

--- a/benchmarks/fixtures/definitions/mono-medium.json
+++ b/benchmarks/fixtures/definitions/mono-medium.json
@@ -10,6 +10,20 @@
   "tool_configs": {
     "ferrflow": {
       "ferrflow.json": "{}"
+    },
+    "changesets": {
+      "package.json": "{\"name\":\"root\",\"private\":true,\"workspaces\":[\"packages/*\"]}",
+      ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.0.0/schema.json\",\"changelog\":\"@changesets/cli/changelog\",\"commit\":false,\"fixed\":[],\"linked\":[],\"access\":\"restricted\",\"baseBranch\":\"main\",\"updateInternalDependencies\":\"patch\",\"ignore\":[]}"
+    },
+    "semantic-release": {
+      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true,\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/example/example.git\"}}",
+      ".releaserc.json": "{\"branches\":[\"main\"],\"plugins\":[\"@semantic-release/commit-analyzer\",\"@semantic-release/release-notes-generator\"]}"
+    },
+    "standard-version": {
+      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true}"
+    },
+    "commit-and-tag-version": {
+      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true}"
     }
   }
 }

--- a/benchmarks/fixtures/definitions/mono-small.json
+++ b/benchmarks/fixtures/definitions/mono-small.json
@@ -10,6 +10,20 @@
   "tool_configs": {
     "ferrflow": {
       "ferrflow.json": "{}"
+    },
+    "changesets": {
+      "package.json": "{\"name\":\"root\",\"private\":true,\"workspaces\":[\"packages/*\"]}",
+      ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.0.0/schema.json\",\"changelog\":\"@changesets/cli/changelog\",\"commit\":false,\"fixed\":[],\"linked\":[],\"access\":\"restricted\",\"baseBranch\":\"main\",\"updateInternalDependencies\":\"patch\",\"ignore\":[]}"
+    },
+    "semantic-release": {
+      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true,\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/example/example.git\"}}",
+      ".releaserc.json": "{\"branches\":[\"main\"],\"plugins\":[\"@semantic-release/commit-analyzer\",\"@semantic-release/release-notes-generator\"]}"
+    },
+    "standard-version": {
+      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true}"
+    },
+    "commit-and-tag-version": {
+      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true}"
     }
   }
 }

--- a/benchmarks/fixtures/definitions/single.json
+++ b/benchmarks/fixtures/definitions/single.json
@@ -10,6 +10,14 @@
   "tool_configs": {
     "ferrflow": {
       "ferrflow.json": "{\"package\":[{\"name\":\"myapp\",\"path\":\".\",\"changelog\":\"CHANGELOG.md\",\"versioned_files\":[{\"path\":\"package.json\",\"format\":\"json\"}]}]}"
+    },
+    "changesets": {
+      "package.json": "{\"name\":\"myapp\",\"version\":\"0.1.0\",\"private\":true}",
+      ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.0.0/schema.json\",\"changelog\":\"@changesets/cli/changelog\",\"commit\":false,\"fixed\":[],\"linked\":[],\"access\":\"restricted\",\"baseBranch\":\"main\",\"updateInternalDependencies\":\"patch\",\"ignore\":[]}"
+    },
+    "semantic-release": {
+      "package.json": "{\"name\":\"myapp\",\"version\":\"0.1.0\",\"private\":true,\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/example/example.git\"}}",
+      ".releaserc.json": "{\"branches\":[\"main\"],\"plugins\":[\"@semantic-release/commit-analyzer\",\"@semantic-release/release-notes-generator\"]}"
     }
   }
 }


### PR DESCRIPTION
Closes #452.

#451 enabled competitor benchmarks (`skip-competitors: false`) but the fixture definitions only declared `tool_configs.ferrflow`. The runner's pre-flight check (`eval "$full_cmd" >/dev/null 2>&1`) then failed silently for every non-ferrflow tool — missing `.releaserc.json`, missing root `package.json` with `workspaces`, etc. — so the bench cell was skipped. End result: [ferrflow.com/performance](https://ferrflow.com/performance) kept showing only ferrflow rows and the "snapshot captured before competitor benchmarks landed" banner.

## What's in this PR

Each of the 6 fixture definitions under `benchmarks/fixtures/definitions/` now declares `tool_configs` for:

- `changesets` — root `package.json` with `workspaces: ["packages/*"]` (mono) + `.changeset/config.json`
- `semantic-release` — root `package.json` with `repository.url` + `.releaserc.json` declaring `commit-analyzer` and `release-notes-generator` plugins (no npm/github publishers since we run `--dry-run --no-ci`)
- `standard-version` / `commit-and-tag-version` — root `package.json` with `version` field (the monorepo fixtures don't ship one by default)

`single.json` keeps the existing generator-produced `package.json` for `standard-version` / `commit-and-tag-version` (it's already valid for them), and only overrides it for tools that need extra fields.

## Out of scope

- **`release-please`** — needs the GitHub API to resolve the latest release; there's no offline `--dry-run` mode that hyperfine can time fairly. The runner still measures its npm install size at the end of `run.sh` (currently dropped on the floor by the aggregation step). Surfacing that on `/performance` is a follow-up.
- The "Heads up" banner on `/performance` is conditional on `!hasCompetitors`; it will disappear automatically once the next sync brings down a `benchmarks.json` with competitor rows.

## Test plan

- [ ] Next push to main triggers the `benchmark` job in `ci.yml`
- [ ] `FerrLabs/Benchmarks@v3` runs `run.sh` with `skip-competitors: false`; competitor commands now pass pre-flight validation
- [ ] The uploaded `hyperfine-baseline` artifact contains rows for `ferrflow`, `changesets`, `semantic-release`, `standard-version`, `commit-and-tag-version`
- [ ] `FerrLabs/FerrFlow-Cloud` `sync-ferrflow.yml` copies the new `benchmarks.json` to `packages/site/src/data/`
- [ ] `/performance` renders 5 columns; the "Heads up" banner is gone