### PR TITLE
feat(ci): dispatch ferrflow-released to FerrFlow-Cloud after release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -520,6 +520,7 @@ jobs:
         continue-on-error: true
       - name: Append benchmark results to draft release
         if: needs.benchmark.result == 'success'
+        id: append-bench
         run: |
           BENCH_FILE="benchmark-summary/release-summary.md"
           if [[ ! -f "$BENCH_FILE" ]]; then
@@ -537,5 +538,21 @@ jobs:
           CLEAN_BODY=$(echo "$CURRENT_BODY" | sed '/^## Performance$/,$d')
           printf -v NEW_BODY '%s\n\n%s' "$CLEAN_BODY" "$BENCH"
           gh release edit "$TAG" --notes "$NEW_BODY"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Notify FerrFlow-Cloud of new release
+        if: steps.append-bench.outputs.tag != '' && inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.FERRFLOW_DISPATCH_TOKEN }}
+          TAG: ${{ steps.append-bench.outputs.tag }}
+        run: |
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::warning::FERRFLOW_DISPATCH_TOKEN not set — skipping cross-repo dispatch. Site sync will fire on its 6h schedule instead."
+            exit 0
+          fi
+          gh api -X POST repos/FerrLabs/FerrFlow-Cloud/dispatches \
+            -f event_type="ferrflow-released" \
+            -F client_payload[tag]="$TAG"
+          echo "Dispatched ferrflow-released ($TAG) to FerrLabs/FerrFlow-Cloud"


### PR DESCRIPTION
Closes #454. Companion to [FerrLabs/FerrFlow-Cloud#505](https://github.com/FerrLabs/FerrFlow-Cloud/pull/505).

## Why

FerrFlow-Cloud's `sync-ferrflow.yml` already listens for `repository_dispatch: ferrflow-released`, but nothing currently fires it — so the sync only runs on its 6h cron. End result: a brand-new FerrFlow release can sit for hours before the marketing site reflects the new version, binary size, and bench numbers.

## Fix

A new step in the release job dispatches `ferrflow-released` to FerrLabs/FerrFlow-Cloud as soon as the release notes are finalized:

\`\`\`yaml
- name: Notify FerrFlow-Cloud of new release
  if: steps.append-bench.outputs.tag != '' && inputs.dry_run != 'true'
  env:
    GH_TOKEN: \${{ secrets.FERRFLOW_DISPATCH_TOKEN }}
    TAG: \${{ steps.append-bench.outputs.tag }}
\`\`\`

Reuses the org-level `FERRFLOW_DISPATCH_TOKEN` already used by [FerrLabs/Changelog/dispatch-rebuilds.yml](https://github.com/FerrLabs/Changelog/blob/main/.github/workflows/dispatch-rebuilds.yml). If the secret isn't accessible to this repo, the step logs a warning and exits 0 — the 6h schedule on the other side stays as fallback.

## Test plan

- [ ] Dry-run release: dispatch step is skipped (`inputs.dry_run != 'true'` guard)
- [ ] Release without bench artifact: dispatch step is skipped (\`steps.append-bench.outputs.tag\` is empty)
- [ ] Real release with `FERRFLOW_DISPATCH_TOKEN` accessible: FerrFlow-Cloud's sync-ferrflow.yml runs within minutes
- [ ] Real release without the secret: warning logged, FerrFlow-Cloud's cron catches up within 6h

## Prereq

\`FERRFLOW_DISPATCH_TOKEN\` must be accessible to this repo (as an org-level secret or repo-level). It needs \`repo\` scope (or \`Contents: read\` + \`Actions: write\` on a fine-grained PAT) for \`FerrLabs/FerrFlow-Cloud\`. If it's already org-wide for Changelog, nothing to do.