### PR TITLE
ci(bench): enable verbose to surface why competitors fail validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -520,6 +520,7 @@ jobs:
         continue-on-error: true
       - name: Append benchmark results to draft release
         if: needs.benchmark.result == 'success'
+        id: append-bench
         run: |
           BENCH_FILE="benchmark-summary/release-summary.md"
           if [[ ! -f "$BENCH_FILE" ]]; then
@@ -537,5 +538,21 @@ jobs:
           CLEAN_BODY=$(echo "$CURRENT_BODY" | sed '/^## Performance$/,$d')
           printf -v NEW_BODY '%s\n\n%s' "$CLEAN_BODY" "$BENCH"
           gh release edit "$TAG" --notes "$NEW_BODY"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Notify FerrFlow-Cloud of new release
+        if: steps.append-bench.outputs.tag != '' && inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.FERRFLOW_DISPATCH_TOKEN }}
+          TAG: ${{ steps.append-bench.outputs.tag }}
+        run: |
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::warning::FERRFLOW_DISPATCH_TOKEN not set — skipping cross-repo dispatch. Site sync will fire on its 6h schedule instead."
+            exit 0
+          fi
+          gh api -X POST repos/FerrLabs/FerrFlow-Cloud/dispatches \
+            -f event_type="ferrflow-released" \
+            -F client_payload[tag]="$TAG"
+          echo "Dispatched ferrflow-released ($TAG) to FerrLabs/FerrFlow-Cloud"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,6 +464,7 @@ jobs:
           definitions: benchmarks/fixtures/definitions
           ferrflow-token: ${{ secrets.GITHUB_TOKEN }}
           skip-competitors: false
+          verbose: true
         env:
           FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
 


### PR DESCRIPTION
Closes #456.

Pre-flight validation in [FerrLabs/Benchmarks/scripts/run.sh](https://github.com/FerrLabs/Benchmarks/blob/main/scripts/run.sh) hides the actual error behind a bare \`SKIP: command failed\` line unless \`verbose=true\` is set. The v4.9.0 release notes (the first release shipping #453 fixture configs) still show no competitor rows — the CI log just says every cell skipped, with no clue why:

\`\`\`
changesets/npm:  on mono-100-1k...
    SKIP: command failed
\`\`\`

Flipping the flag prints the underlying \`npx\` / \`jq\` / \`git\` error so we can fix the root cause in the next iteration.

Verbose stays on permanently — output volume is one line per skipped cell, and the bare-message variant has now bitten us once. Worth the tiny noise to avoid a debug round-trip next time.

## Out of scope

This PR only enables logging. The actual fix lands once we see the error — likely a tweak to either [FerrLabs/Benchmarks](https://github.com/FerrLabs/Benchmarks) (e.g. \`npm install\` ordering for changesets, or how \`write_tool_configs\` handles \`\$schema\` keys in JSON values) or to the fixture configs added in #453.