### PR TITLE
fix(release): make push_tags idempotent against pre-existing remote tags

### DIFF
--- a/src/git/push.rs
+++ b/src/git/push.rs
@@ -1,6 +1,8 @@
 use anyhow::{Context, Result};
 use git2::{PushOptions, RemoteCallbacks, Repository, Sort};
 use std::cell::RefCell;
+use std::collections::HashMap;
+use std::path::Path;
 use std::rc::Rc;
 
 use crate::error_code::{self, ErrorCodeExt};
@@ -8,6 +10,70 @@ use crate::error_code::{self, ErrorCodeExt};
 use super::auth::{authenticated_remote_url, credentials_callback, get_authenticated_remote};
 use super::fetch::make_fetch_options;
 use super::retry::retry_transient;
+
+fn local_tag_target_sha(repo: &Repository, tag: &str) -> Result<String> {
+    let tag_ref = repo
+        .find_reference(&format!("refs/tags/{tag}"))
+        .with_context(|| format!("local tag '{tag}' not found"))?;
+    let commit = tag_ref
+        .peel_to_commit()
+        .with_context(|| format!("could not resolve tag '{tag}' to a commit"))?;
+    Ok(commit.id().to_string())
+}
+
+pub(super) fn parse_ls_remote_tags(stdout: &str) -> HashMap<String, String> {
+    let mut tag_objects: HashMap<String, String> = HashMap::new();
+    let mut dereferenced: HashMap<String, String> = HashMap::new();
+    for line in stdout.lines() {
+        let Some((sha, refname)) = line.split_once('\t') else {
+            continue;
+        };
+        let Some(name) = refname.strip_prefix("refs/tags/") else {
+            continue;
+        };
+        if let Some(base) = name.strip_suffix("^{}") {
+            dereferenced.insert(base.to_string(), sha.trim().to_string());
+        } else {
+            tag_objects.insert(name.to_string(), sha.trim().to_string());
+        }
+    }
+    let mut out = tag_objects;
+    for (name, sha) in dereferenced {
+        out.insert(name, sha);
+    }
+    out
+}
+
+pub(super) fn remote_tag_target_shas(
+    workdir: &Path,
+    push_url: &str,
+    tags: &[&str],
+) -> Result<HashMap<String, String>> {
+    if tags.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let mut cmd = std::process::Command::new("git");
+    cmd.current_dir(workdir)
+        .arg("ls-remote")
+        .arg("--tags")
+        .arg(push_url);
+    for tag in tags {
+        cmd.arg(format!("refs/tags/{tag}"));
+    }
+    let output = cmd
+        .output()
+        .with_context(|| "spawn `git ls-remote --tags` failed (is git in PATH?)")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow::anyhow!(
+            "git ls-remote --tags failed: {}",
+            stderr.trim()
+        ));
+    }
+    Ok(parse_ls_remote_tags(&String::from_utf8_lossy(
+        &output.stdout,
+    )))
+}
 
 pub fn force_push_tags(repo: &Repository, remote_name: &str, tags: &[&str]) -> Result<()> {
     if tags.is_empty() {
@@ -121,10 +187,59 @@ fn shell_push_tags(repo: &Repository, remote_name: &str, tags: &[&str], force: b
         .to_string();
     let push_url = authenticated_remote_url(&raw_url).unwrap_or(raw_url);
 
+    let remote_shas = remote_tag_target_shas(workdir, &push_url, tags).unwrap_or_else(|err| {
+        eprintln!(
+            "  Warning: could not enumerate remote tag state ({err}); falling back to a plain push"
+        );
+        HashMap::new()
+    });
+
+    let mut to_push: Vec<&str> = Vec::with_capacity(tags.len());
+    let mut already_synced: Vec<&str> = Vec::new();
+    let mut diverged: Vec<(String, String, String)> = Vec::new();
+    for tag in tags {
+        let local_sha = local_tag_target_sha(repo, tag)?;
+        match remote_shas.get(*tag) {
+            Some(remote_sha) if remote_sha == &local_sha => already_synced.push(*tag),
+            Some(remote_sha) if !force => {
+                diverged.push(((*tag).to_string(), local_sha, remote_sha.clone()));
+            }
+            _ => to_push.push(*tag),
+        }
+    }
+
+    if !already_synced.is_empty() {
+        eprintln!(
+            "  ↻ Already on remote at the same commit: {}",
+            already_synced.join(", ")
+        );
+    }
+    if !diverged.is_empty() {
+        let joined = diverged
+            .iter()
+            .map(|(t, l, r)| {
+                format!(
+                    "{t} (local {} != remote {})",
+                    &l[..7.min(l.len())],
+                    &r[..7.min(r.len())]
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(anyhow::anyhow!(
+            "Tag(s) already exist on remote pointing to a different commit: {joined}. \
+             This usually means a previous release run partially succeeded — \
+             delete the divergent remote tag(s) and retry, or use --force if you really want to overwrite."
+        ));
+    }
+    if to_push.is_empty() {
+        return Ok(());
+    }
+
     let prefix = if force { "+" } else { "" };
     let mut cmd = std::process::Command::new("git");
     cmd.current_dir(workdir).arg("push").arg(&push_url);
-    for tag in tags {
+    for tag in &to_push {
         cmd.arg(format!("{prefix}refs/tags/{tag}:refs/tags/{tag}"));
     }
 

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -1,5 +1,5 @@
 use super::auth::{credentials_callback, extract_url_password};
-use super::push::fetch_and_rebase;
+use super::push::{fetch_and_rebase, parse_ls_remote_tags};
 use super::retry::{is_transient_git_error, retry_transient};
 use super::tags::{find_last_tag, is_floating_tag, is_prerelease_tag};
 use super::*;
@@ -82,6 +82,56 @@ fn retry_transient_returns_immediately_on_terminal_error() {
     });
     assert!(result.is_err());
     assert_eq!(attempts.get(), 1);
+}
+
+#[test]
+fn parse_ls_remote_tags_returns_empty_for_empty_input() {
+    let map = parse_ls_remote_tags("");
+    assert!(map.is_empty());
+}
+
+#[test]
+fn parse_ls_remote_tags_extracts_lightweight_tag_sha() {
+    // Lightweight tag — only the bare line, no ^{} deref entry.
+    let input = "0123456789abcdef0123456789abcdef01234567\trefs/tags/site@v0.13.0\n";
+    let map = parse_ls_remote_tags(input);
+    assert_eq!(
+        map.get("site@v0.13.0").map(String::as_str),
+        Some("0123456789abcdef0123456789abcdef01234567")
+    );
+}
+
+#[test]
+fn parse_ls_remote_tags_prefers_dereferenced_commit_for_annotated_tag() {
+    // Annotated tags: ls-remote emits two lines — the tag object SHA, and
+    // the commit it points to with `^{}`. We must prefer the commit so it
+    // can be compared with the local commit SHA from peel_to_commit().
+    let input = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\trefs/tags/site@v0.13.0\n\
+                 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\trefs/tags/site@v0.13.0^{}\n";
+    let map = parse_ls_remote_tags(input);
+    assert_eq!(
+        map.get("site@v0.13.0").map(String::as_str),
+        Some("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+    );
+}
+
+#[test]
+fn parse_ls_remote_tags_handles_multiple_tags_mixed_types() {
+    let input = "1111111111111111111111111111111111111111\trefs/tags/lightweight-tag\n\
+                 2222222222222222222222222222222222222222\trefs/tags/annotated-tag\n\
+                 3333333333333333333333333333333333333333\trefs/tags/annotated-tag^{}\n\
+                 4444444444444444444444444444444444444444\trefs/heads/main\n";
+    let map = parse_ls_remote_tags(input);
+    assert_eq!(map.len(), 2);
+    assert_eq!(
+        map.get("lightweight-tag").map(String::as_str),
+        Some("1111111111111111111111111111111111111111")
+    );
+    assert_eq!(
+        map.get("annotated-tag").map(String::as_str),
+        Some("3333333333333333333333333333333333333333"),
+        "annotated tag should resolve to the dereferenced commit, not the tag object"
+    );
 }
 
 fn init_repo() -> (tempfile::TempDir, Repository) {


### PR DESCRIPTION
Closes #458.

## Bug

A partial \`ferrflow release\` run that succeeds at \`create_release\` — which auto-creates the tag on the remote via the GitHub API for non-draft releases — but fails BEFORE \`push_tags\`, or any rerun afterwards, dies with E2006:

\`\`\`
error[E2006]: E2006
  Failed to push tags: To https://github.com/FerrLabs/FerrLens-Cloud
 ! [rejected]        site@v0.13.0 -> site@v0.13.0 (already exists)
\`\`\`

The pipeline isn't recoverable without manually deleting the remote tag. \`recoverMissedReleases\` doesn't help — that flag is for re-detecting un-tagged commits during the bump phase, not push collisions.

## Fix

\`push_tags\` / \`force_push_tags\` now \`ls-remote --tags\` first and classify each:

| Remote state | Regular push | Force push |
|---|---|---|
| Not present | push | push |
| Same commit as local | skip silently | skip silently |
| Different commit | error with both SHAs + hint | force-overwrite |

One \`ls-remote\` round-trip covers all tags. If the call fails (offline, auth missing), the code falls back to a plain push so callers don't lose existing behavior.

The skip path logs \`↻ Already on remote at the same commit: …\` so it's obvious when a retry was a no-op rather than a fresh push.

## Test plan

- [x] \`cargo test --lib\` — 511 passing including 4 new ones for \`parse_ls_remote_tags\` covering lightweight, annotated (\`^{}\` line), mixed, and empty inputs
- [x] \`cargo clippy -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [ ] Manual smoke: take a repo where v0.13.0 already exists on the remote at the bumped commit, run \`ferrflow release\` — expect \"Already on remote at the same commit\" + \"Pushed tags\" + clean exit
- [ ] Manual smoke: create a divergent remote tag (point to a different commit) — expect the new error with both SHAs

## Out of scope

The deeper question of WHY \`create_release\` is auto-creating the remote tag before \`push_tags\` runs — the order at [src/monorepo/run.rs:809→959→991](https://github.com/FerrLabs/FerrFlow/blob/main/src/monorepo/run.rs) creates local tags, then creates GitHub releases (which materialize the tag on the remote for non-drafts), then pushes the tag. Reordering to push first would also fix this class of bug, but is a larger refactor — and the idempotency check is the right safety net regardless of order.