### PR TITLE
fix(bench): set default_branch=main on all bench fixtures

### DIFF
--- a/benchmarks/fixtures/definitions/mono-100-1k.json
+++ b/benchmarks/fixtures/definitions/mono-100-1k.json
@@ -1,7 +1,8 @@
 {
   "meta": {
     "name": "mono-100-1k",
-    "description": "100 packages, 1000 commits"
+    "description": "100 packages, 1000 commits",
+    "default_branch": "main"
   },
   "generate": {
     "packages": 100,

--- a/benchmarks/fixtures/definitions/mono-50-5k.json
+++ b/benchmarks/fixtures/definitions/mono-50-5k.json
@@ -1,7 +1,8 @@
 {
   "meta": {
     "name": "mono-50-5k",
-    "description": "50 packages, 5000 commits — stress test git log parsing"
+    "description": "50 packages, 5000 commits — stress test git log parsing",
+    "default_branch": "main"
   },
   "generate": {
     "packages": 50,

--- a/benchmarks/fixtures/definitions/mono-large.json
+++ b/benchmarks/fixtures/definitions/mono-large.json
@@ -1,7 +1,8 @@
 {
   "meta": {
     "name": "mono-large",
-    "description": "200 packages, 10000 commits"
+    "description": "200 packages, 10000 commits",
+    "default_branch": "main"
   },
   "generate": {
     "packages": 200,

--- a/benchmarks/fixtures/definitions/mono-medium.json
+++ b/benchmarks/fixtures/definitions/mono-medium.json
@@ -1,7 +1,8 @@
 {
   "meta": {
     "name": "mono-medium",
-    "description": "50 packages, 500 commits"
+    "description": "50 packages, 500 commits",
+    "default_branch": "main"
   },
   "generate": {
     "packages": 50,

--- a/benchmarks/fixtures/definitions/mono-small.json
+++ b/benchmarks/fixtures/definitions/mono-small.json
@@ -1,7 +1,8 @@
 {
   "meta": {
     "name": "mono-small",
-    "description": "10 packages, 100 commits"
+    "description": "10 packages, 100 commits",
+    "default_branch": "main"
   },
   "generate": {
     "packages": 10,

--- a/benchmarks/fixtures/definitions/single.json
+++ b/benchmarks/fixtures/definitions/single.json
@@ -1,7 +1,8 @@
 {
   "meta": {
     "name": "single",
-    "description": "Single package, 100 commits"
+    "description": "Single package, 100 commits",
+    "default_branch": "main"
   },
   "generate": {
     "packages": 1,


### PR DESCRIPTION
Closes #460.

Verbose CI from #457 finally showed what was happening:

\`\`\`
🦋 error Error: Failed to find where HEAD diverged from \"main\". Does \"main\" exist and it's synced with remote?
🦋 error     at getDivergedCommit (.../@changesets/git/dist/changesets-git.cjs.js:63:11)
\`\`\`

## Root cause

Two pieces conspiring:

1. **[FerrLabs/Fixtures generator](https://github.com/FerrLabs/Fixtures/blob/main/generator/src/generate.rs)** calls \`Repository::init\` without setting \`initial_head\` unless \`meta.default_branch\` is present. Our 6 bench fixtures didn't set it, so the local HEAD lands on whatever the runner's \`init.defaultBranch\` is — currently \`master\` on the FerrLabs runner.

2. **[Benchmarks/scripts/run.sh:setup_dummy_remote](https://github.com/FerrLabs/Benchmarks/blob/main/scripts/run.sh)** pushes \`HEAD\` to the bare origin:

   \`\`\`bash
   git -C \"\$dir\" push -q origin HEAD 2>/dev/null || true
   \`\`\`

   This pushes whatever branch HEAD points at — \`master\`, not \`main\`. So \`refs/heads/main\` never exists on origin OR locally.

When changesets runs \`git merge-base HEAD main\` (its \`baseBranch\` is \`main\` per its config in the fixture's \`tool_configs\`), it errors. Same for semantic-release's \`branches: [\"main\"]\`.

## Fix

Add \`\"default_branch\": \"main\"\` to each fixture's \`meta\`. The generator's [\`init_repo\`](https://github.com/FerrLabs/Fixtures/blob/main/generator/src/generate.rs#L335) then calls \`opts.initial_head(\"main\")\` and the local repo starts on \`main\`. \`setup_dummy_remote\`'s \`push origin HEAD\` lands on \`refs/heads/main\` on origin. Both competitor tools resolve happily.

## Test plan

- [x] Bench artifact's competitor cells populated in the v4.10.x → v4.11 release cycle (no more bare \`SKIP: command failed\`)
- [ ] /performance shows changesets + semantic-release columns alongside ferrflow
- [ ] Once Benchmarks tags v4 and FerrFlow bumps the action pin, standard-version + commit-and-tag-version columns also fill in