### PR TITLE
fix(bench): let semantic-release fall back to origin remote

### DIFF
--- a/benchmarks/fixtures/definitions/mono-100-1k.json
+++ b/benchmarks/fixtures/definitions/mono-100-1k.json
@@ -17,7 +17,7 @@
       ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.0.0/schema.json\",\"changelog\":\"@changesets/cli/changelog\",\"commit\":false,\"fixed\":[],\"linked\":[],\"access\":\"restricted\",\"baseBranch\":\"main\",\"updateInternalDependencies\":\"patch\",\"ignore\":[]}"
     },
     "semantic-release": {
-      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true,\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/example/example.git\"}}",
+      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true}",
       ".releaserc.json": "{\"branches\":[\"main\"],\"plugins\":[\"@semantic-release/commit-analyzer\",\"@semantic-release/release-notes-generator\"]}"
     },
     "standard-version": {

--- a/benchmarks/fixtures/definitions/mono-50-5k.json
+++ b/benchmarks/fixtures/definitions/mono-50-5k.json
@@ -17,7 +17,7 @@
       ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.0.0/schema.json\",\"changelog\":\"@changesets/cli/changelog\",\"commit\":false,\"fixed\":[],\"linked\":[],\"access\":\"restricted\",\"baseBranch\":\"main\",\"updateInternalDependencies\":\"patch\",\"ignore\":[]}"
     },
     "semantic-release": {
-      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true,\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/example/example.git\"}}",
+      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true}",
       ".releaserc.json": "{\"branches\":[\"main\"],\"plugins\":[\"@semantic-release/commit-analyzer\",\"@semantic-release/release-notes-generator\"]}"
     },
     "standard-version": {

--- a/benchmarks/fixtures/definitions/mono-large.json
+++ b/benchmarks/fixtures/definitions/mono-large.json
@@ -17,7 +17,7 @@
       ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.0.0/schema.json\",\"changelog\":\"@changesets/cli/changelog\",\"commit\":false,\"fixed\":[],\"linked\":[],\"access\":\"restricted\",\"baseBranch\":\"main\",\"updateInternalDependencies\":\"patch\",\"ignore\":[]}"
     },
     "semantic-release": {
-      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true,\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/example/example.git\"}}",
+      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true}",
       ".releaserc.json": "{\"branches\":[\"main\"],\"plugins\":[\"@semantic-release/commit-analyzer\",\"@semantic-release/release-notes-generator\"]}"
     },
     "standard-version": {

--- a/benchmarks/fixtures/definitions/mono-medium.json
+++ b/benchmarks/fixtures/definitions/mono-medium.json
@@ -17,7 +17,7 @@
       ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.0.0/schema.json\",\"changelog\":\"@changesets/cli/changelog\",\"commit\":false,\"fixed\":[],\"linked\":[],\"access\":\"restricted\",\"baseBranch\":\"main\",\"updateInternalDependencies\":\"patch\",\"ignore\":[]}"
     },
     "semantic-release": {
-      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true,\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/example/example.git\"}}",
+      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true}",
       ".releaserc.json": "{\"branches\":[\"main\"],\"plugins\":[\"@semantic-release/commit-analyzer\",\"@semantic-release/release-notes-generator\"]}"
     },
     "standard-version": {

--- a/benchmarks/fixtures/definitions/mono-small.json
+++ b/benchmarks/fixtures/definitions/mono-small.json
@@ -17,7 +17,7 @@
       ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.0.0/schema.json\",\"changelog\":\"@changesets/cli/changelog\",\"commit\":false,\"fixed\":[],\"linked\":[],\"access\":\"restricted\",\"baseBranch\":\"main\",\"updateInternalDependencies\":\"patch\",\"ignore\":[]}"
     },
     "semantic-release": {
-      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true,\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/example/example.git\"}}",
+      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true}",
       ".releaserc.json": "{\"branches\":[\"main\"],\"plugins\":[\"@semantic-release/commit-analyzer\",\"@semantic-release/release-notes-generator\"]}"
     },
     "standard-version": {

--- a/benchmarks/fixtures/definitions/single.json
+++ b/benchmarks/fixtures/definitions/single.json
@@ -17,7 +17,7 @@
       ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.0.0/schema.json\",\"changelog\":\"@changesets/cli/changelog\",\"commit\":false,\"fixed\":[],\"linked\":[],\"access\":\"restricted\",\"baseBranch\":\"main\",\"updateInternalDependencies\":\"patch\",\"ignore\":[]}"
     },
     "semantic-release": {
-      "package.json": "{\"name\":\"myapp\",\"version\":\"0.1.0\",\"private\":true,\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/example/example.git\"}}",
+      "package.json": "{\"name\":\"myapp\",\"version\":\"0.1.0\",\"private\":true}",
       ".releaserc.json": "{\"branches\":[\"main\"],\"plugins\":[\"@semantic-release/commit-analyzer\",\"@semantic-release/release-notes-generator\"]}"
     }
   }


### PR DESCRIPTION
Closes #462. Follow-up to #461.

## Bug

#461 unblocked changesets (5/6 fixture cells now produce hyperfine measurements). semantic-release still failed for a different reason that the verbose flag from #457 finally surfaced:

\`\`\`
ExecaError: Command failed with exit code 128: git ls-remote --heads 'https://x-access-token:[secure]@github.com/example/example.git'
remote: Repository not found.
fatal: repository 'https://github.com/example/example.git/' not found
    at async getBranches (.../semantic-release/lib/git.js:69:11)
\`\`\`

The bogus \`repository.url\` I seeded in \`tool_configs.semantic-release.package.json\` (\`git+https://github.com/example/example.git\`) was being picked up by semantic-release and network-checked against the real GitHub — which obviously 404s.

## Fix

semantic-release resolves \`repositoryUrl\` in this order:

1. CLI \`--repositoryUrl\`
2. \`.releaserc\` \`repositoryUrl\`
3. \`package.json\` \`repository.url\`
4. \`git remote get-url origin\`

Drop #3 from the fixtures so the resolver falls through to #4. [Benchmarks/scripts/run.sh:setup_dummy_remote](https://github.com/FerrLabs/Benchmarks/blob/main/scripts/run.sh) already wires \`origin\` to a local bare repo, so semantic-release's \`git ls-remote\` runs against the file:// remote, returns instantly, no network, validation passes.

## Test plan

- [ ] Next FerrFlow main-push bench: semantic-release cells populated for all 6 fixtures
- [ ] /performance ships a semantic-release column with real numbers

## Known remaining issue (out of scope)

\`changesets/single\` still SKIPs with \"Some packages have been changed but no changesets were found.\" — corner case where \`changesets status\` exits 1 on a single-package repo with commits since the last tag but no \`.changeset/*.md\` file. The 5 monorepo fixtures escape this. Tracking separately if/when we care about that cell.