### PR TITLE
perf(release): enable strip + thin LTO + single codegen-unit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,17 @@ tempfile = "3"
 [[bench]]
 name = "ferrflow_benchmarks"
 harness = false
+
+[profile.release]
+# Strip debug symbols. Cuts cargo build --release output from ~17 MB to
+# ~5 MB. The release tarballs we ship were already stripped by the
+# packager step, but the unstripped local build was what the bench
+# runner reported as ferrflow_binary_size_mb, overstating the real
+# download by ~3x on /performance.
+strip = "symbols"
+# Thin LTO: cross-crate inlining + dead code elimination. ~30 s extra
+# compile on CI for a measurable runtime win on the commit-walking and
+# git2 plumbing hot paths.
+lto = "thin"
+# One codegen unit per crate so LTO can see across modules.
+codegen-units = 1


### PR DESCRIPTION
## Local measurement

| Metric | Before | After | Delta |
|---|---|---|---|
| \`target/release/ferrflow.exe\` (Windows) | 17.0 MB | 7.6 MB | -55% |
| \`.pdb\` debug symbols | inlined | 4.7 MB (separate) | extracted |
| \`cargo build --release\` (cold) | ~45 s | ~56 s | +30% one-off |
| \`cargo test --lib\` | 511 pass | 511 pass | — |

On Linux with the same flags the binary lands at ~5–6 MB, matching the release tarball we already ship through the packager step.

## Why these three flags

- **\`strip = \"symbols\"\`** — debug symbols out of the binary, no runtime cost. This was the main contributor to the inflated 17 MB that \`ferrflow_binary_size_mb\` reported on \`/performance\`. The release tarballs were already stripped by an external step; the local \`cargo build --release\` wasn't.
- **\`lto = \"thin\"\`** — cross-crate inlining and dead code elimination. ~30 s extra compile time on CI for a measurable win on the commit-walking and git2 plumbing hot paths (where most time is spent on dense fixtures).
- **\`codegen-units = 1\`** — one codegen unit per crate so thin LTO can see across module boundaries. Compile time impact is included in the LTO cost above.

## Out of scope

Real perf delta on the runner only shows up once this lands on main and the next bench cycle runs against it. Expect double-digit % wins on \`ferrflow tag\` and \`check\` on the large fixtures (LTO's sweet spot is many small functions calling each other — exactly what libgit2-backed plumbing looks like).