### PR TITLE
perf(tags): amortize HEAD reachability across multi-package callers

### DIFF
--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -22,7 +22,8 @@ pub use push::{
 pub use repo::{get_repo_root, open_repo, resolve_current_branch};
 pub use retry::is_push_rejected_error;
 pub use tags::{
-    collect_all_tags, create_or_move_tag, create_tag, find_highest_semver_tag, find_last_tag_name,
+    build_head_ancestors, collect_all_tags, create_or_move_tag, create_tag,
+    find_highest_semver_tag_with_cache, find_last_tag_name, find_last_tag_name_with_cache,
     get_tag_message, tag_exists,
 };
 

--- a/src/git/tags.rs
+++ b/src/git/tags.rs
@@ -1,11 +1,48 @@
 use anyhow::Result;
 use git2::Repository;
 use std::cell::RefCell;
+use std::collections::HashSet;
 
 use crate::config::OrphanedTagStrategy;
 use crate::error_code::{self, ErrorCodeExt};
 
 use super::commits::signature;
+
+/// Build the set of commit OIDs reachable from HEAD via a single revwalk.
+///
+/// On a monorepo with N packages, `find_last_tag` (and its siblings) is
+/// called once per package. Each call used to invoke
+/// `repo.graph_descendant_of(head, oid)` per matching tag, which itself
+/// walks the commit graph until it hits the target. On dense histories
+/// (mono-large: 200 pkgs × 10k commits), this turns into N independent
+/// O(commits) walks — 1815 ms for `ferrflow tag` was almost all this.
+///
+/// Building the ancestor set up front collapses that into one walk +
+/// O(1) hash lookups per tag. Callers in the per-package loop pass
+/// `Some(&set)`; single-shot callers (status, query, single-package
+/// release) pass `None` and pay the original cost.
+pub fn build_head_ancestors(repo: &Repository) -> Result<HashSet<git2::Oid>> {
+    let head_oid = repo.head()?.peel_to_commit()?.id();
+    let mut walk = repo.revwalk()?;
+    walk.push(head_oid)?;
+    let mut set: HashSet<git2::Oid> = HashSet::new();
+    for oid in walk.flatten() {
+        set.insert(oid);
+    }
+    Ok(set)
+}
+
+fn is_reachable(
+    repo: &Repository,
+    head: git2::Oid,
+    commit_oid: git2::Oid,
+    cache: Option<&HashSet<git2::Oid>>,
+) -> bool {
+    if let Some(set) = cache {
+        return set.contains(&commit_oid);
+    }
+    head == commit_oid || repo.graph_descendant_of(head, commit_oid).unwrap_or(false)
+}
 
 pub(super) struct TagMatch {
     pub name: String,
@@ -69,6 +106,15 @@ pub(super) fn find_last_tag(
     prefix: &str,
     strategy: OrphanedTagStrategy,
 ) -> Result<Option<TagMatch>> {
+    find_last_tag_with_cache(repo, prefix, strategy, None)
+}
+
+pub(super) fn find_last_tag_with_cache(
+    repo: &Repository,
+    prefix: &str,
+    strategy: OrphanedTagStrategy,
+    ancestors: Option<&HashSet<git2::Oid>>,
+) -> Result<Option<TagMatch>> {
     let head = repo.head()?.peel_to_commit()?.id();
     let latest: RefCell<Option<TagMatch>> = RefCell::new(None);
     let warnings: RefCell<Vec<String>> = RefCell::new(Vec::new());
@@ -100,8 +146,7 @@ pub(super) fn find_last_tag(
             }
         };
 
-        let reachable =
-            head == commit_oid || repo.graph_descendant_of(head, commit_oid).unwrap_or(false);
+        let reachable = is_reachable(repo, head, commit_oid, ancestors);
 
         let (effective_oid, effective_time) = if reachable {
             (commit_oid, commit.time().seconds())
@@ -177,10 +222,31 @@ pub fn find_last_tag_name(
     Ok(find_last_tag(repo, prefix, strategy)?.map(|t| t.name))
 }
 
+pub fn find_last_tag_name_with_cache(
+    repo: &Repository,
+    prefix: &str,
+    strategy: OrphanedTagStrategy,
+    ancestors: Option<&HashSet<git2::Oid>>,
+) -> Result<Option<String>> {
+    Ok(find_last_tag_with_cache(repo, prefix, strategy, ancestors)?.map(|t| t.name))
+}
+
+// Kept as a public no-cache convenience for single-shot callers (and the
+// existing test suite). The cached variant below is the perf path.
+#[allow(dead_code)]
 pub fn find_highest_semver_tag(
     repo: &Repository,
     prefix: &str,
     strategy: OrphanedTagStrategy,
+) -> Result<Option<(String, String)>> {
+    find_highest_semver_tag_with_cache(repo, prefix, strategy, None)
+}
+
+pub fn find_highest_semver_tag_with_cache(
+    repo: &Repository,
+    prefix: &str,
+    strategy: OrphanedTagStrategy,
+    ancestors: Option<&HashSet<git2::Oid>>,
 ) -> Result<Option<(String, String)>> {
     let head = repo.head()?.peel_to_commit()?.id();
     let highest: RefCell<Option<(String, semver::Version)>> = RefCell::new(None);
@@ -213,8 +279,7 @@ pub fn find_highest_semver_tag(
             Ok(c) => c,
             Err(_) => return true,
         };
-        let reachable =
-            head == commit_oid || repo.graph_descendant_of(head, commit_oid).unwrap_or(false);
+        let reachable = is_reachable(repo, head, commit_oid, ancestors);
         if !reachable {
             match strategy {
                 OrphanedTagStrategy::Warn => return true,
@@ -254,6 +319,15 @@ pub(super) fn find_last_stable_tag(
     prefix: &str,
     strategy: OrphanedTagStrategy,
 ) -> Result<Option<TagMatch>> {
+    find_last_stable_tag_with_cache(repo, prefix, strategy, None)
+}
+
+pub(super) fn find_last_stable_tag_with_cache(
+    repo: &Repository,
+    prefix: &str,
+    strategy: OrphanedTagStrategy,
+    ancestors: Option<&HashSet<git2::Oid>>,
+) -> Result<Option<TagMatch>> {
     let head = repo.head()?.peel_to_commit()?.id();
     let latest: RefCell<Option<TagMatch>> = RefCell::new(None);
 
@@ -278,8 +352,7 @@ pub(super) fn find_last_stable_tag(
             Err(_) => return true,
         };
 
-        let reachable =
-            head == commit_oid || repo.graph_descendant_of(head, commit_oid).unwrap_or(false);
+        let reachable = is_reachable(repo, head, commit_oid, ancestors);
 
         let (effective_oid, effective_time) = if reachable {
             (commit_oid, commit.time().seconds())

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -1,7 +1,7 @@
 use super::auth::{credentials_callback, extract_url_password};
 use super::push::{fetch_and_rebase, parse_ls_remote_tags};
 use super::retry::{is_transient_git_error, retry_transient};
-use super::tags::{find_last_tag, is_floating_tag, is_prerelease_tag};
+use super::tags::{find_highest_semver_tag, find_last_tag, is_floating_tag, is_prerelease_tag};
 use super::*;
 use crate::config::OrphanedTagStrategy;
 use crate::error_code;

--- a/src/monorepo/run.rs
+++ b/src/monorepo/run.rs
@@ -78,6 +78,12 @@ pub(super) fn run_release_logic(
         .unwrap_or_default();
 
     let all_tags = collect_all_tags(&repo);
+    // Build the HEAD ancestor set once so the per-package find_*_tag calls
+    // below can skip their per-tag graph_descendant_of walk. On dense
+    // monorepos (mono-large: 200 pkg × 10k commits) this is the
+    // difference between 1.8 s and a couple hundred ms for the tag-bound
+    // commands.
+    let head_ancestors = crate::git::build_head_ancestors(&repo).ok();
 
     let target_branch = if prerelease_ctx.is_prerelease() {
         current_branch.clone()
@@ -196,10 +202,11 @@ pub(super) fn run_release_logic(
         );
 
         let file_version = read_version(vf, root).ok();
-        let tag_version = crate::git::find_highest_semver_tag(
+        let tag_version = crate::git::find_highest_semver_tag_with_cache(
             &repo,
             &tag_search_prefix,
             config.workspace.orphaned_tag_strategy,
+            head_ancestors.as_ref(),
         )?
         .map(|(_tag, version)| version);
         let current_version = match (tag_version, file_version) {

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,7 +1,10 @@
 use crate::config::Config;
 use crate::error_code::{self, ErrorCodeExt};
 use crate::formats::read_version;
-use crate::git::{find_last_tag_name, get_repo_root, open_repo};
+use crate::git::{
+    build_head_ancestors, find_last_tag_name, find_last_tag_name_with_cache, get_repo_root,
+    open_repo,
+};
 use anyhow::Result;
 use serde::Serialize;
 
@@ -165,14 +168,24 @@ pub fn tag(config_path: Option<&std::path::Path>, package: Option<&str>, json: b
             println!("{}", last_tag.unwrap_or_else(|| "none".to_string()));
         }
     } else {
+        // Build the HEAD ancestor set ONCE across the multi-package loop.
+        // Without this, each find_last_tag_name call did its own
+        // graph_descendant_of against HEAD per matching tag — on a dense
+        // monorepo (200 pkg × 10k commits) that turned `ferrflow tag` into
+        // a 1.8 s walk-fest. A single revwalk amortizes to O(pkg) hash hits.
+        let ancestors = build_head_ancestors(&repo).ok();
         let entries: Vec<TagEntry> = config
             .packages
             .iter()
             .map(|pkg| {
                 let prefix = pkg.tag_prefix(&config.workspace, config.is_monorepo());
-                let tag =
-                    find_last_tag_name(&repo, &prefix, config.workspace.orphaned_tag_strategy)
-                        .unwrap_or(None);
+                let tag = find_last_tag_name_with_cache(
+                    &repo,
+                    &prefix,
+                    config.workspace.orphaned_tag_strategy,
+                    ancestors.as_ref(),
+                )
+                .unwrap_or(None);
                 TagEntry {
                     name: pkg.name.clone(),
                     tag,


### PR DESCRIPTION
Closes #465.

## What

\`ferrflow tag\` on the [mono-large bench fixture](https://github.com/FerrLabs/FerrFlow/blob/main/benchmarks/fixtures/definitions/mono-large.json) (200 pkg × 10k commits) was sitting at **1815 ms** while \`release --dry-run\` on the same fixture is 196 ms. The gap on a read-only query was anomalous.

## Why

Inside the multi-package loop in [\`query::tag\`](src/query.rs) and the per-package loop in [\`monorepo::run\`](src/monorepo/run.rs), each iteration called a \`find_*_tag\` function that internally invoked \`repo.graph_descendant_of(head, commit_oid)\` per matching tag. On a dense history that walks the commit graph until it hits the tag's commit — \~10 000 steps for a tag on the initial commit. Times 200 packages, ~2M libgit2 ODB ops per command.

## How

- New \`build_head_ancestors(repo) -> HashSet<Oid>\` in [\`src/git/tags.rs\`](src/git/tags.rs) that does ONE revwalk from HEAD into a hash set.
- New \`_with_cache\` variants of \`find_last_tag\`, \`find_last_tag_name\`, \`find_highest_semver_tag\`, \`find_last_stable_tag\` that consult the cache in O(1) when provided.
- Plumbed through \`query::tag\`'s multi-package branch and \`monorepo::run\`'s per-package loop.
- Single-shot callers (status, query::version, single-package release) keep the existing API and pay the original cost.

The \`is_reachable(repo, head, commit_oid, cache)\` helper centralises the cache-or-walk choice so every \`find_*_tag\` call site stays one line of behavior-preserving change.

## Test plan

- [x] \`cargo test --lib\` — 511 pass (no behavior change for non-cache path)
- [x] \`cargo clippy --no-deps -- -D warnings\` clean
- [ ] Next push-main bench cycle measures the delta on /performance
- [ ] Expect mono-large \`ferrflow tag\`: \~1815 ms → \~150-200 ms (\~10× win)
- [ ] Single-package fixtures unchanged (cache built but only one find_* call)

Stacks cleanly on top of #464 (release profile flags). Independent of #466 (monorepo::run.rs split) which is purely structural.