### PR TITLE
ci(bench): bump FerrLabs/Benchmarks pin from v3 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,7 +458,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
-      - uses: FerrLabs/Benchmarks@v3
+      - uses: FerrLabs/Benchmarks@v4
         with:
           type: full
           definitions: benchmarks/fixtures/definitions


### PR DESCRIPTION
Closes [#118 on Benchmarks](https://github.com/FerrLabs/Benchmarks/issues/118).

v4 of [FerrLabs/Benchmarks](https://github.com/FerrLabs/Benchmarks/releases/tag/v4.0.0) ships three things that the FerrFlow perf page has been waiting for:

- **`install_sizes` on `latest.json`** — unblocks the Install footprint section on [ferrflow.com/performance](https://ferrflow.com/performance) that's been conditional on this field landing in the data.
- **`standard-version` + `commit-and-tag-version`** competitor tools added to `tools.json` — perf table grows from 3 to 5 competitor columns.
- **Footer drop** — no more `*Binary size: 17.0 MB — ferrflow ferrflow 4.8.1*` line in release notes (double-prefixed + stale version).

Just the pin bump. No code changes needed in this repo.

## Known issue on the Benchmarks side

v4.0.0 had to be tagged manually because ferrflow[bot] can't push the release commit to Benchmarks's `main` (branch protection rule, [FerrLabs/Benchmarks#119](https://github.com/FerrLabs/Benchmarks/issues/119)). Doesn't affect this PR — the tag is published, the action resolves it normally.