### PR TITLE
fix(bench): seed .changeset/initial.md so changesets/single benches like the others

### DIFF
--- a/benchmarks/fixtures/definitions/single.json
+++ b/benchmarks/fixtures/definitions/single.json
@@ -14,7 +14,8 @@
     },
     "changesets": {
       "package.json": "{\"name\":\"myapp\",\"version\":\"0.1.0\",\"private\":true}",
-      ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.0.0/schema.json\",\"changelog\":\"@changesets/cli/changelog\",\"commit\":false,\"fixed\":[],\"linked\":[],\"access\":\"restricted\",\"baseBranch\":\"main\",\"updateInternalDependencies\":\"patch\",\"ignore\":[]}"
+      ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.0.0/schema.json\",\"changelog\":\"@changesets/cli/changelog\",\"commit\":false,\"fixed\":[],\"linked\":[],\"access\":\"restricted\",\"baseBranch\":\"main\",\"updateInternalDependencies\":\"patch\",\"ignore\":[]}",
+      ".changeset/initial.md": "---\n\"myapp\": patch\n---\n\nseed changeset so `changesets status` exits 0 on this single-package fixture\n"
     },
     "semantic-release": {
       "package.json": "{\"name\":\"myapp\",\"version\":\"0.1.0\",\"private\":true}",


### PR DESCRIPTION
Closes #470.

Adds a single `patch` changeset for `myapp` to the single fixture's `tool_configs.changesets` so `changesets status` exits 0 and the runner can measure it. The 5 monorepo fixtures slip past this because their per-package tags shield each pkg from changesets' status scan; the single fixture doesn't have that shield.

Next bench cycle should populate the `single-changesets-npm-check` row on /performance alongside the 5 monorepo ones already there.