### PR TITLE
perf(tags): pre-collect tags into TagIndex to amortize tag_foreach across packages

### DIFF
--- a/src/git/commits.rs
+++ b/src/git/commits.rs
@@ -13,32 +13,7 @@ pub fn get_commits_since_last_tag(
     strategy: OrphanedTagStrategy,
 ) -> Result<Vec<GitLog>> {
     let last_tag_oid = find_last_tag_commit(repo, tag_prefix, strategy)?;
-
-    let mut walk = repo.revwalk()?;
-    walk.push_head()?;
-    walk.set_sorting(Sort::TOPOLOGICAL | Sort::TIME)?;
-
-    let mut commits = Vec::new();
-    for oid in walk {
-        let oid = oid?;
-        if let Some(stop) = last_tag_oid
-            && oid == stop
-        {
-            break;
-        }
-        if let Ok(commit) = repo.find_commit(oid) {
-            let message = commit.message().unwrap_or("").to_string();
-            if message.contains("[skip ci]") {
-                continue;
-            }
-            commits.push(GitLog {
-                hash: oid.to_string()[..8].to_string(),
-                message,
-            });
-        }
-    }
-
-    Ok(commits)
+    get_commits_since_oid(repo, last_tag_oid)
 }
 
 pub fn get_commits_since_last_stable_tag(
@@ -47,7 +22,17 @@ pub fn get_commits_since_last_stable_tag(
     strategy: OrphanedTagStrategy,
 ) -> Result<Vec<GitLog>> {
     let last_tag_oid = find_last_stable_tag(repo, tag_prefix, strategy)?.map(|t| t.commit_oid);
+    get_commits_since_oid(repo, last_tag_oid)
+}
 
+/// Walk commits from HEAD back to `last_tag_oid` (exclusive). Callers in
+/// the multi-package monorepo loop resolve the OID once via `TagIndex`
+/// and reuse this helper, sparing the per-package `tag_foreach` scan
+/// that `find_last_tag_commit` would otherwise re-run.
+pub fn get_commits_since_oid(
+    repo: &Repository,
+    last_tag_oid: Option<git2::Oid>,
+) -> Result<Vec<GitLog>> {
     let mut walk = repo.revwalk()?;
     walk.push_head()?;
     walk.set_sorting(Sort::TOPOLOGICAL | Sort::TIME)?;

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -47,13 +47,25 @@ pub fn get_changed_files_since_tag(
     tag_prefix: &str,
     strategy: OrphanedTagStrategy,
 ) -> Result<Vec<String>> {
+    let last_tag_oid = find_last_tag_commit(repo, tag_prefix, strategy)?;
+    get_changed_files_since_oid(repo, last_tag_oid)
+}
+
+/// Same as [`get_changed_files_since_tag`] but skips the tag lookup —
+/// callers in the multi-package monorepo loop resolve the OID once via
+/// `TagIndex` instead of paying for an independent `tag_foreach` per
+/// package.
+pub fn get_changed_files_since_oid(
+    repo: &Repository,
+    last_tag_oid: Option<git2::Oid>,
+) -> Result<Vec<String>> {
     let head = match repo.head() {
         Ok(h) => h.peel_to_commit()?,
         Err(_) => return Ok(vec![]),
     };
     let head_tree = head.tree()?;
 
-    let old_tree = if let Some(tag_oid) = find_last_tag_commit(repo, tag_prefix, strategy)? {
+    let old_tree = if let Some(tag_oid) = last_tag_oid {
         let tag_commit = repo.find_commit(tag_oid)?;
         Some(tag_commit.tree()?)
     } else {

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -11,9 +11,9 @@ pub use auth::get_remote_url;
 #[allow(unused_imports)]
 pub use commits::{
     GitLog, create_branch_and_commit, create_branch_and_commits, create_commit,
-    get_commits_since_last_stable_tag, get_commits_since_last_tag,
+    get_commits_since_last_stable_tag, get_commits_since_last_tag, get_commits_since_oid,
 };
-pub use diff::{get_changed_files, get_changed_files_since_tag};
+pub use diff::{get_changed_files, get_changed_files_since_oid, get_changed_files_since_tag};
 pub use fetch::fetch_tags;
 #[allow(unused_imports)]
 pub use push::{
@@ -22,7 +22,7 @@ pub use push::{
 pub use repo::{get_repo_root, open_repo, resolve_current_branch};
 pub use retry::is_push_rejected_error;
 pub use tags::{
-    build_head_ancestors, collect_all_tags, create_or_move_tag, create_tag,
+    TagIndex, build_head_ancestors, collect_all_tags, create_or_move_tag, create_tag,
     find_highest_semver_tag_with_cache, find_last_tag_name, find_last_tag_name_with_cache,
     get_tag_message, tag_exists,
 };

--- a/src/git/tags.rs
+++ b/src/git/tags.rs
@@ -32,6 +32,162 @@ pub fn build_head_ancestors(repo: &Repository) -> Result<HashSet<git2::Oid>> {
     Ok(set)
 }
 
+/// Pre-collected tag index with HEAD reachability information.
+///
+/// Built once at the start of a multi-package operation (monorepo
+/// release, `ferrflow tag` listing, etc.), then queried per package.
+/// Avoids both the per-tag `graph_descendant_of` walk (already addressed
+/// by `build_head_ancestors`) AND the per-call `tag_foreach` scan that
+/// was still dominating on dense histories: 200 packages × ~200 tags ×
+/// callback overhead ≈ several hundred ms on mono-large.
+///
+/// The fast path covers `OrphanedTagStrategy::Warn` (default and most
+/// common). Callers needing tree-hash or message recovery for orphan
+/// tags fall back to the per-call `find_*_tag_with_cache` path which
+/// still uses the ancestor set but doesn't benefit from the pre-scan.
+pub struct TagIndex {
+    entries: Vec<TagIndexEntry>,
+    pub ancestors: HashSet<git2::Oid>,
+}
+
+struct TagIndexEntry {
+    name: String,
+    commit_oid: git2::Oid,
+    time: i64,
+    reachable: bool,
+}
+
+impl TagIndex {
+    pub fn build(repo: &Repository) -> Result<Self> {
+        let head = repo.head()?.peel_to_commit()?.id();
+        let mut walk = repo.revwalk()?;
+        walk.push(head)?;
+        let mut ancestors: HashSet<git2::Oid> = HashSet::new();
+        for oid in walk.flatten() {
+            ancestors.insert(oid);
+        }
+
+        let entries: RefCell<Vec<TagIndexEntry>> = RefCell::new(Vec::new());
+        repo.tag_foreach(|oid, name| {
+            let name = String::from_utf8_lossy(name);
+            let tag_name = name.trim_start_matches("refs/tags/").to_string();
+            let commit_oid = if let Ok(tag_obj) = repo.find_tag(oid) {
+                tag_obj.target_id()
+            } else {
+                oid
+            };
+            if let Ok(commit) = repo.find_commit(commit_oid) {
+                let reachable = head == commit_oid || ancestors.contains(&commit_oid);
+                entries.borrow_mut().push(TagIndexEntry {
+                    name: tag_name,
+                    commit_oid,
+                    time: commit.time().seconds(),
+                    reachable,
+                });
+            }
+            true
+        })?;
+        Ok(Self {
+            entries: entries.into_inner(),
+            ancestors,
+        })
+    }
+
+    /// Fast-path version of `find_last_tag_name` for the Warn strategy.
+    /// Returns None when the caller asked for orphan recovery — caller
+    /// should fall back to `find_last_tag_name_with_cache` in that case.
+    pub fn find_last_tag_name(
+        &self,
+        prefix: &str,
+        strategy: OrphanedTagStrategy,
+    ) -> Option<String> {
+        if !matches!(strategy, OrphanedTagStrategy::Warn) {
+            return None;
+        }
+        self.entries
+            .iter()
+            .filter(|e| {
+                e.reachable && e.name.starts_with(prefix) && !is_floating_tag(&e.name, prefix)
+            })
+            .max_by_key(|e| e.time)
+            .map(|e| e.name.clone())
+    }
+
+    /// Fast-path version of `find_highest_semver_tag` for the Warn strategy.
+    pub fn find_highest_semver_tag(
+        &self,
+        prefix: &str,
+        strategy: OrphanedTagStrategy,
+    ) -> Option<(String, String)> {
+        if !matches!(strategy, OrphanedTagStrategy::Warn) {
+            return None;
+        }
+        let mut best: Option<(&str, semver::Version)> = None;
+        for entry in &self.entries {
+            if !entry.reachable
+                || !entry.name.starts_with(prefix)
+                || is_prerelease_tag(&entry.name, prefix)
+                || is_floating_tag(&entry.name, prefix)
+            {
+                continue;
+            }
+            let version_str = entry
+                .name
+                .strip_prefix(prefix)
+                .map(|s| s.strip_prefix('v').unwrap_or(s))
+                .unwrap_or(&entry.name);
+            let parsed = match semver::Version::parse(version_str) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            match &best {
+                Some((_, existing)) if *existing >= parsed => {}
+                _ => best = Some((entry.name.as_str(), parsed)),
+            }
+        }
+        best.map(|(name, version)| (name.to_string(), version.to_string()))
+    }
+
+    /// Fast-path lookup of the commit OID of the most recent matching tag.
+    pub fn find_last_tag_commit(
+        &self,
+        prefix: &str,
+        strategy: OrphanedTagStrategy,
+    ) -> Option<git2::Oid> {
+        if !matches!(strategy, OrphanedTagStrategy::Warn) {
+            return None;
+        }
+        self.entries
+            .iter()
+            .filter(|e| {
+                e.reachable && e.name.starts_with(prefix) && !is_floating_tag(&e.name, prefix)
+            })
+            .max_by_key(|e| e.time)
+            .map(|e| e.commit_oid)
+    }
+
+    /// Fast-path lookup of the most recent stable (non-prerelease) tag's commit.
+    pub fn find_last_stable_tag_commit(
+        &self,
+        prefix: &str,
+        strategy: OrphanedTagStrategy,
+    ) -> Option<git2::Oid> {
+        if !matches!(strategy, OrphanedTagStrategy::Warn) {
+            return None;
+        }
+        self.entries
+            .iter()
+            .filter(|e| {
+                e.reachable
+                    && e.name.starts_with(prefix)
+                    && !is_prerelease_tag(&e.name, prefix)
+                    && !is_floating_tag(&e.name, prefix)
+            })
+            .max_by_key(|e| e.time)
+            .map(|e| e.commit_oid)
+    }
+}
+
 fn is_reachable(
     repo: &Repository,
     head: git2::Oid,

--- a/src/monorepo/run.rs
+++ b/src/monorepo/run.rs
@@ -4,15 +4,18 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use crate::changelog::{build_section, update_changelog};
-use crate::config::{Config, ReleaseCommitMode, ReleaseCommitScope, VersioningStrategy};
+use crate::config::{
+    Config, OrphanedTagStrategy, ReleaseCommitMode, ReleaseCommitScope, VersioningStrategy,
+};
 use crate::conventional_commits::{BumpType, determine_bump};
 use crate::error_code::{self, ErrorCodeExt};
 use crate::formats::{get_handler, read_version, write_version};
 use crate::git::{
     collect_all_tags, create_branch_and_commit, create_branch_and_commits, create_commit,
     create_or_move_tag, create_tag, fetch_tags, force_push_tags, get_changed_files,
-    get_changed_files_since_tag, get_commits_since_last_stable_tag, get_commits_since_last_tag,
-    get_tag_message, open_repo, push, push_branch, push_tags, tag_exists,
+    get_changed_files_since_oid, get_changed_files_since_tag, get_commits_since_last_stable_tag,
+    get_commits_since_last_tag, get_commits_since_oid, get_tag_message, open_repo, push,
+    push_branch, push_tags, tag_exists,
 };
 use crate::hooks::{HookContext, HookPoint, resolve_hook, resolve_on_failure, run_hook};
 use crate::prerelease::PrereleaseContext;
@@ -84,6 +87,12 @@ pub(super) fn run_release_logic(
     // difference between 1.8 s and a couple hundred ms for the tag-bound
     // commands.
     let head_ancestors = crate::git::build_head_ancestors(&repo).ok();
+    // Pre-collect all tags + their commit OIDs in one tag_foreach scan
+    // so the per-package find_*_tag / get_*_since_tag calls below don't
+    // each repeat that scan. Coupled with the ancestor set, the per-pkg
+    // lookups collapse from O(tags) callbacks + O(commits) walk to O(1)
+    // hash hits.
+    let tag_index = crate::git::TagIndex::build(&repo).ok();
 
     let target_branch = if prerelease_ctx.is_prerelease() {
         current_branch.clone()
@@ -157,11 +166,14 @@ pub(super) fn run_release_logic(
         let mut touched = is_package_touched(pkg, &changed_files, config.is_monorepo());
 
         if !touched && config.workspace.recover_missed_releases && config.is_monorepo() {
-            let files_since_tag = get_changed_files_since_tag(
-                &repo,
-                &tag_search_prefix,
-                config.workspace.orphaned_tag_strategy,
-            )?;
+            let strategy = config.workspace.orphaned_tag_strategy;
+            let files_since_tag =
+                if let (Some(idx), OrphanedTagStrategy::Warn) = (tag_index.as_ref(), strategy) {
+                    let last_oid = idx.find_last_tag_commit(&tag_search_prefix, strategy);
+                    get_changed_files_since_oid(&repo, last_oid)?
+                } else {
+                    get_changed_files_since_tag(&repo, &tag_search_prefix, strategy)?
+                };
             if is_package_touched(pkg, &files_since_tag, true) {
                 touched = true;
                 if verbose && !json {
@@ -202,13 +214,22 @@ pub(super) fn run_release_logic(
         );
 
         let file_version = read_version(vf, root).ok();
-        let tag_version = crate::git::find_highest_semver_tag_with_cache(
-            &repo,
-            &tag_search_prefix,
-            config.workspace.orphaned_tag_strategy,
-            head_ancestors.as_ref(),
-        )?
-        .map(|(_tag, version)| version);
+        let strategy = config.workspace.orphaned_tag_strategy;
+        // Fast path via the pre-built TagIndex for Warn (default); otherwise
+        // fall back to the per-call form that still uses the ancestor cache.
+        let tag_version =
+            if let (Some(idx), OrphanedTagStrategy::Warn) = (tag_index.as_ref(), strategy) {
+                idx.find_highest_semver_tag(&tag_search_prefix, strategy)
+                    .map(|(_tag, version)| version)
+            } else {
+                crate::git::find_highest_semver_tag_with_cache(
+                    &repo,
+                    &tag_search_prefix,
+                    strategy,
+                    head_ancestors.as_ref(),
+                )?
+                .map(|(_tag, version)| version)
+            };
         let current_version = match (tag_version, file_version) {
             (Some(tag), Some(file)) => pick_higher_semver(&file, &tag),
             (Some(tag), None) => tag,
@@ -216,37 +237,39 @@ pub(super) fn run_release_logic(
             (None, None) => crate::versioning::bootstrap_version(pkg_strategy),
         };
 
+        // Helpers that route through TagIndex when the strategy allows it,
+        // falling back to the per-call slow path. Returns commits walked
+        // back to the last (stable or any) tag for the current package.
+        let commits_since_stable = || -> Result<Vec<crate::git::GitLog>> {
+            if let (Some(idx), OrphanedTagStrategy::Warn) = (tag_index.as_ref(), strategy) {
+                let stop = idx.find_last_stable_tag_commit(&tag_search_prefix, strategy);
+                get_commits_since_oid(&repo, stop)
+            } else {
+                get_commits_since_last_stable_tag(&repo, &tag_search_prefix, strategy)
+            }
+        };
+        let commits_since_any = || -> Result<Vec<crate::git::GitLog>> {
+            if let (Some(idx), OrphanedTagStrategy::Warn) = (tag_index.as_ref(), strategy) {
+                let stop = idx.find_last_tag_commit(&tag_search_prefix, strategy);
+                get_commits_since_oid(&repo, stop)
+            } else {
+                get_commits_since_last_tag(&repo, &tag_search_prefix, strategy)
+            }
+        };
+
         let (new_version, is_prerelease, commits, bump) = if let Some(fv) = forced_ver_for_pkg {
             let clean = fv.strip_prefix('v').unwrap_or(fv);
             let commits = if !prerelease_ctx.is_prerelease() {
-                get_commits_since_last_stable_tag(
-                    &repo,
-                    &tag_search_prefix,
-                    config.workspace.orphaned_tag_strategy,
-                )
-                .unwrap_or_default()
+                commits_since_stable().unwrap_or_default()
             } else {
-                get_commits_since_last_tag(
-                    &repo,
-                    &tag_search_prefix,
-                    config.workspace.orphaned_tag_strategy,
-                )
-                .unwrap_or_default()
+                commits_since_any().unwrap_or_default()
             };
             (clean.to_string(), false, commits, BumpType::None)
         } else {
             let commits = if !prerelease_ctx.is_prerelease() {
-                get_commits_since_last_stable_tag(
-                    &repo,
-                    &tag_search_prefix,
-                    config.workspace.orphaned_tag_strategy,
-                )?
+                commits_since_stable()?
             } else {
-                get_commits_since_last_tag(
-                    &repo,
-                    &tag_search_prefix,
-                    config.workspace.orphaned_tag_strategy,
-                )?
+                commits_since_any()?
             };
 
             if commits.is_empty() {

--- a/src/query.rs
+++ b/src/query.rs
@@ -2,8 +2,7 @@ use crate::config::Config;
 use crate::error_code::{self, ErrorCodeExt};
 use crate::formats::read_version;
 use crate::git::{
-    build_head_ancestors, find_last_tag_name, find_last_tag_name_with_cache, get_repo_root,
-    open_repo,
+    TagIndex, find_last_tag_name, find_last_tag_name_with_cache, get_repo_root, open_repo,
 };
 use anyhow::Result;
 use serde::Serialize;
@@ -168,24 +167,39 @@ pub fn tag(config_path: Option<&std::path::Path>, package: Option<&str>, json: b
             println!("{}", last_tag.unwrap_or_else(|| "none".to_string()));
         }
     } else {
-        // Build the HEAD ancestor set ONCE across the multi-package loop.
-        // Without this, each find_last_tag_name call did its own
-        // graph_descendant_of against HEAD per matching tag — on a dense
-        // monorepo (200 pkg × 10k commits) that turned `ferrflow tag` into
-        // a 1.8 s walk-fest. A single revwalk amortizes to O(pkg) hash hits.
-        let ancestors = build_head_ancestors(&repo).ok();
+        // Build the tag index ONCE across the multi-package loop. Without
+        // it, each find_last_tag_name call ran tag_foreach independently
+        // (200 pkg × 200 tag callbacks ≈ 40k invocations) plus per-tag
+        // graph_descendant_of (now O(1) via the embedded ancestor set).
+        // The index pre-resolves both, leaving per-package work as a
+        // linear scan over already-resolved entries.
+        let strategy = config.workspace.orphaned_tag_strategy;
+        let index = TagIndex::build(&repo).ok();
         let entries: Vec<TagEntry> = config
             .packages
             .iter()
             .map(|pkg| {
                 let prefix = pkg.tag_prefix(&config.workspace, config.is_monorepo());
-                let tag = find_last_tag_name_with_cache(
-                    &repo,
-                    &prefix,
-                    config.workspace.orphaned_tag_strategy,
-                    ancestors.as_ref(),
-                )
-                .unwrap_or(None);
+                // Fast path via the index for the Warn strategy; tree-hash /
+                // message recovery falls back to the slow per-call form
+                // which still uses the embedded ancestor set.
+                let tag = match index.as_ref().and_then(|idx| {
+                    idx.find_last_tag_name(&prefix, strategy)
+                        .map(Some)
+                        .or_else(|| {
+                            // Non-Warn strategy: index returns None, fall back
+                            find_last_tag_name_with_cache(
+                                &repo,
+                                &prefix,
+                                strategy,
+                                Some(&idx.ancestors),
+                            )
+                            .ok()
+                        })
+                }) {
+                    Some(t) => t,
+                    None => find_last_tag_name(&repo, &prefix, strategy).unwrap_or(None),
+                };
                 TagEntry {
                     name: pkg.name.clone(),
                     tag,


### PR DESCRIPTION
Closes #468, #471. Follow-up to #466.

## What

After #466 (HEAD ancestor cache), \`ferrflow tag\` on mono-large dropped from 1815 ms → 800 ms — a 2.3× win but short of the predicted 10×. The remaining cost was \`tag_foreach\` itself running N times: 200 packages × 200 tag callbacks × callback work ≈ several hundred ms.

## How

\`TagIndex::build(repo)\` pre-resolves every tag in a single \`tag_foreach\`:
- annotated → commit OID via \`find_tag\`
- commit time + reachability against the ancestor set

Per-package lookups then iterate the pre-built \`Vec<TagIndexEntry>\` — pure CPU on already-resolved data, no more libgit2 callbacks per call. Methods provided:

\`\`\`rust
index.find_last_tag_name(prefix, strategy)
index.find_highest_semver_tag(prefix, strategy)
index.find_last_tag_commit(prefix, strategy)
index.find_last_stable_tag_commit(prefix, strategy)
\`\`\`

Fast path only fires for \`OrphanedTagStrategy::Warn\` (default). Tree-hash / message recovery still falls through to the per-call slow form (which itself uses the ancestor cache from #466).

## Plumbing

- \`query::tag\` multi-package branch — \`ferrflow tag\`
- \`monorepo::run\` per-package loop:
  - \`find_highest_semver_tag\` (version baseline lookup)
  - \`get_changed_files_since_oid\` (recover-missed-releases path)
  - \`get_commits_since_oid\` (release commit walk, both stable and any-tag)

Companion helpers \`get_changed_files_since_oid\` and \`get_commits_since_oid\` take a pre-resolved \`Option<Oid>\` so callers with index results skip the redundant \`find_*_tag_commit\` step.

## Test plan

- [x] \`cargo test --lib\` — 511 pass (no behavior change for non-cache path)
- [x] \`cargo clippy --no-deps -- -D warnings\` clean
- [ ] Next bench cycle on /performance measures the delta
- [ ] Expect mono-large \`ferrflow tag\`: 800 ms → ~150-250 ms (TagIndex build is ~30 ms one-shot, then ~1 ms per pkg vs ~4 ms)
- [ ] Expect mono-large \`release --dry-run\`: 196 ms → ~100 ms (same plumbing reach)