### PR TITLE
refactor(monorepo): first wave of run.rs split (#467)

### DIFF
--- a/src/monorepo/run/drafts.rs
+++ b/src/monorepo/run/drafts.rs
@@ -1,0 +1,62 @@
+use anyhow::Result;
+use colored::Colorize;
+use git2::Repository;
+use std::path::Path;
+
+use crate::config::Config;
+use crate::formats::read_version;
+
+use super::super::preview::build_forge_instance;
+
+/// When the run didn't bump anything (no new commits since the last
+/// release) but a previous run left draft releases dangling on the
+/// forge, publish them now so the release cycle terminates.
+///
+/// Skipped on draft / dry-run mode (we don't want to publish anything
+/// the user explicitly opted into keeping as a draft). Per-package
+/// errors are logged but never abort the run.
+pub(super) fn publish_pending_drafts(
+    repo: &Repository,
+    config: &Config,
+    root: &Path,
+    verbose: bool,
+    shared_outputs: &mut Vec<String>,
+) -> Result<()> {
+    let Some(forge_instance) = build_forge_instance(repo, config) else {
+        return Ok(());
+    };
+    for pkg in &config.packages {
+        let Some(vf) = pkg.versioned_files.first() else {
+            continue;
+        };
+        let Ok(version) = read_version(vf, root) else {
+            continue;
+        };
+        let tag = pkg.tag_for_version(&config.workspace, config.is_monorepo(), &version);
+        match forge_instance.find_draft_release(&tag) {
+            Ok(Some(release_id)) => match forge_instance.publish_release(release_id) {
+                Ok(()) => {
+                    shared_outputs.push(format!(
+                        "✓ Published draft {} {}",
+                        forge_instance.release_noun(),
+                        tag.cyan()
+                    ));
+                }
+                Err(err) => eprintln!(
+                    "{}",
+                    format!("  Warning: failed to publish draft for {tag}: {err}").yellow()
+                ),
+            },
+            Ok(None) => {}
+            Err(err) => {
+                if verbose {
+                    eprintln!(
+                        "{}",
+                        format!("  Warning: failed to check draft release {tag}: {err}").yellow()
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/monorepo/run/forced.rs
+++ b/src/monorepo/run/forced.rs
@@ -1,0 +1,158 @@
+use anyhow::Result;
+
+/// Parsed `--force-version` input.
+///
+/// `name` is `Some` only when the input was `NAME@VERSION` (mandatory in
+/// monorepo mode). `version` excludes any leading `v` prefix —
+/// callers can `strip_prefix('v')` once at use time if needed but
+/// validation has already accepted both forms.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct Forced<'a> {
+    pub name: Option<&'a str>,
+    pub version: &'a str,
+}
+
+/// Parse and validate the `--force-version` CLI input.
+///
+/// Returns `Ok(None)` when the user didn't pass `--force-version` at all.
+/// Returns an error when:
+/// - the input is malformed (empty name or empty version in `NAME@VERSION`)
+/// - the input is bare `VERSION` but the config is a monorepo
+/// - the version part doesn't parse as semver (with or without leading `v`)
+pub(super) fn parse_forced_version<'a>(
+    force_version: Option<&'a str>,
+    is_monorepo: bool,
+) -> Result<Option<Forced<'a>>> {
+    let Some(fv) = force_version else {
+        return Ok(None);
+    };
+    let parsed = if let Some(at_pos) = fv.find('@') {
+        let name = &fv[..at_pos];
+        let version = &fv[at_pos + 1..];
+        if name.is_empty() || version.is_empty() {
+            anyhow::bail!("Invalid --force-version format: expected NAME@VERSION, got {fv:?}");
+        }
+        Forced {
+            name: Some(name),
+            version,
+        }
+    } else {
+        if is_monorepo {
+            anyhow::bail!(
+                "In a monorepo, --force-version requires NAME@VERSION format (e.g. api@1.2.3)"
+            );
+        }
+        Forced {
+            name: None,
+            version: fv,
+        }
+    };
+    let clean = parsed.version.strip_prefix('v').unwrap_or(parsed.version);
+    if semver::Version::parse(clean).is_err() {
+        anyhow::bail!(
+            "Invalid version in --force-version: {:?} is not valid semver",
+            parsed.version
+        );
+    }
+    Ok(Some(parsed))
+}
+
+/// Resolve the forced version applicable to a given package.
+///
+/// In single-package mode (`Forced.name == None`) every package matches.
+/// In monorepo mode only the targeted package gets the forced version.
+pub(super) fn forced_version_for<'a>(
+    forced: &Option<Forced<'a>>,
+    pkg_name: &str,
+) -> Option<&'a str> {
+    let forced = forced.as_ref()?;
+    match forced.name {
+        Some(target) if target != pkg_name => None,
+        _ => Some(forced.version),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_none_returns_none() {
+        let r = parse_forced_version(None, false).unwrap();
+        assert!(r.is_none());
+    }
+
+    #[test]
+    fn parse_bare_version_in_single_package_mode() {
+        let r = parse_forced_version(Some("1.2.3"), false).unwrap().unwrap();
+        assert_eq!(r.name, None);
+        assert_eq!(r.version, "1.2.3");
+    }
+
+    #[test]
+    fn parse_bare_version_with_v_prefix_in_single_package_mode() {
+        let r = parse_forced_version(Some("v1.2.3"), false)
+            .unwrap()
+            .unwrap();
+        assert_eq!(r.version, "v1.2.3");
+    }
+
+    #[test]
+    fn parse_bare_version_in_monorepo_fails() {
+        let err = parse_forced_version(Some("1.2.3"), true).unwrap_err();
+        assert!(err.to_string().contains("NAME@VERSION"));
+    }
+
+    #[test]
+    fn parse_name_at_version() {
+        let r = parse_forced_version(Some("api@1.2.3"), true)
+            .unwrap()
+            .unwrap();
+        assert_eq!(r.name, Some("api"));
+        assert_eq!(r.version, "1.2.3");
+    }
+
+    #[test]
+    fn parse_empty_name_fails() {
+        let err = parse_forced_version(Some("@1.2.3"), true).unwrap_err();
+        assert!(err.to_string().contains("expected NAME@VERSION"));
+    }
+
+    #[test]
+    fn parse_empty_version_fails() {
+        let err = parse_forced_version(Some("api@"), true).unwrap_err();
+        assert!(err.to_string().contains("expected NAME@VERSION"));
+    }
+
+    #[test]
+    fn parse_invalid_semver_fails() {
+        let err = parse_forced_version(Some("api@not-a-version"), true).unwrap_err();
+        assert!(err.to_string().contains("not valid semver"));
+    }
+
+    #[test]
+    fn forced_version_for_targets_named_package() {
+        let f = Some(Forced {
+            name: Some("api"),
+            version: "1.2.3",
+        });
+        assert_eq!(forced_version_for(&f, "api"), Some("1.2.3"));
+        assert_eq!(forced_version_for(&f, "site"), None);
+    }
+
+    #[test]
+    fn forced_version_for_applies_to_all_packages_when_unnamed() {
+        let f = Some(Forced {
+            name: None,
+            version: "1.2.3",
+        });
+        assert_eq!(forced_version_for(&f, "api"), Some("1.2.3"));
+        assert_eq!(forced_version_for(&f, "anything"), Some("1.2.3"));
+    }
+
+    #[test]
+    fn forced_version_for_returns_none_when_no_force() {
+        let f: Option<Forced<'_>> = None;
+        assert_eq!(forced_version_for(&f, "api"), None);
+    }
+}

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -29,6 +29,13 @@ use super::util::{
     tags_for_package,
 };
 
+mod drafts;
+mod forced;
+mod summary;
+use drafts::publish_pending_drafts;
+use forced::{Forced, forced_version_for, parse_forced_version};
+use summary::{TagToCreate, print_outputs, write_github_step_summary};
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn run_release_logic(
     root: &Path,
@@ -114,54 +121,19 @@ pub(super) fn run_release_logic(
     let mut json_packages: Vec<CheckPackage> = Vec::new();
     let mut files_to_commit: Vec<String> = Vec::new();
     let mut files_per_package: HashMap<String, Vec<String>> = HashMap::new();
-    let mut tags_to_create: Vec<(String, String, String, String, String, i32, bool)> = Vec::new();
+    let mut tags_to_create: Vec<TagToCreate> = Vec::new();
     let mut hook_contexts: Vec<(HookContext, usize)> = Vec::new(); // (ctx, pkg_index)
     let mut bumped_names: HashSet<String> = HashSet::new();
 
     let mut pkg_outputs: Vec<(String, Vec<String>)> = Vec::new();
     let mut shared_outputs: Vec<String> = Vec::new();
 
-    let forced: Option<(Option<&str>, &str)> = if let Some(fv) = force_version {
-        if let Some(at_pos) = fv.find('@') {
-            let name = &fv[..at_pos];
-            let version = &fv[at_pos + 1..];
-            if name.is_empty() || version.is_empty() {
-                anyhow::bail!("Invalid --force-version format: expected NAME@VERSION, got {fv:?}");
-            }
-            Some((Some(name), version))
-        } else {
-            if config.is_monorepo() {
-                anyhow::bail!(
-                    "In a monorepo, --force-version requires NAME@VERSION format (e.g. api@1.2.3)"
-                );
-            }
-            Some((None, fv))
-        }
-    } else {
-        None
-    };
-
-    if let Some((_, ver)) = &forced {
-        let clean = ver.strip_prefix('v').unwrap_or(ver);
-        if semver::Version::parse(clean).is_err() {
-            anyhow::bail!("Invalid version in --force-version: {ver:?} is not valid semver");
-        }
-    }
+    let forced: Option<Forced<'_>> = parse_forced_version(force_version, config.is_monorepo())?;
 
     for (pkg_idx, pkg) in config.packages.iter().enumerate() {
         let tag_search_prefix = pkg.tag_prefix(&config.workspace, config.is_monorepo());
 
-        let forced_ver_for_pkg = forced.and_then(|(name, ver)| {
-            if let Some(target_name) = name {
-                if pkg.name == target_name {
-                    Some(ver)
-                } else {
-                    None
-                }
-            } else {
-                Some(ver)
-            }
-        });
+        let forced_ver_for_pkg = forced_version_for(&forced, &pkg.name);
 
         let mut touched = is_package_touched(pkg, &changed_files, config.is_monorepo());
 
@@ -1028,20 +1000,7 @@ pub(super) fn run_release_logic(
                 shared_outputs.push("✓ Pushed floating tags".to_string());
             }
 
-            if let Ok(summary_path) = std::env::var("GITHUB_STEP_SUMMARY") {
-                use std::io::Write;
-                if let Ok(mut file) = std::fs::OpenOptions::new()
-                    .create(true)
-                    .append(true)
-                    .open(&summary_path)
-                {
-                    let _ = writeln!(file, "## Released\n");
-                    for (tag_name, _, body, _, _, _, _) in &tags_to_create {
-                        let _ = writeln!(file, "### {tag_name}\n");
-                        let _ = writeln!(file, "{body}");
-                    }
-                }
-            }
+            write_github_step_summary(&tags_to_create);
         }
 
         if config.workspace.anonymous_telemetry {
@@ -1091,61 +1050,11 @@ pub(super) fn run_release_logic(
         }
     }
 
-    if !any_bumped
-        && !draft
-        && !dry_run
-        && let Some(forge_instance) = build_forge_instance(&repo, config)
-    {
-        for pkg in &config.packages {
-            let Some(vf) = pkg.versioned_files.first() else {
-                continue;
-            };
-            let Ok(version) = read_version(vf, root) else {
-                continue;
-            };
-            let tag = pkg.tag_for_version(&config.workspace, config.is_monorepo(), &version);
-            match forge_instance.find_draft_release(&tag) {
-                Ok(Some(release_id)) => match forge_instance.publish_release(release_id) {
-                    Ok(()) => {
-                        shared_outputs.push(format!(
-                            "✓ Published draft {} {}",
-                            forge_instance.release_noun(),
-                            tag.cyan()
-                        ));
-                    }
-                    Err(err) => eprintln!(
-                        "{}",
-                        format!("  Warning: failed to publish draft for {tag}: {err}").yellow()
-                    ),
-                },
-                Ok(None) => {}
-                Err(err) => {
-                    if verbose {
-                        eprintln!(
-                            "{}",
-                            format!("  Warning: failed to check draft release {tag}: {err}")
-                                .yellow()
-                        );
-                    }
-                }
-            }
-        }
+    if !any_bumped && !draft && !dry_run {
+        publish_pending_drafts(&repo, config, root, verbose, &mut shared_outputs)?;
     }
 
-    for (i, (_, lines)) in pkg_outputs.iter().enumerate() {
-        if i > 0 {
-            println!();
-        }
-        for line in lines {
-            println!("{line}");
-        }
-    }
-    if !shared_outputs.is_empty() {
-        println!();
-        for line in &shared_outputs {
-            println!("{line}");
-        }
-    }
+    print_outputs(&pkg_outputs, &shared_outputs);
 
     if !any_bumped && !verbose {
         println!("{}", "Nothing to release.".dimmed());

--- a/src/monorepo/run/summary.rs
+++ b/src/monorepo/run/summary.rs
@@ -1,0 +1,50 @@
+/// Tag tuple used by the release loop: (tag_name, message, body,
+/// pkg_name, version, commit_count, is_prerelease).
+pub(super) type TagToCreate = (String, String, String, String, String, i32, bool);
+
+/// Print the per-package output lines collected during the run,
+/// followed by the shared cross-package output lines, in the exact
+/// formatting the orchestrator used to do inline.
+///
+/// `pkg_outputs` entries are `(pkg_name, lines)`. The name is unused at
+/// print time today but kept for future grouping needs.
+pub(super) fn print_outputs(pkg_outputs: &[(String, Vec<String>)], shared_outputs: &[String]) {
+    for (i, (_, lines)) in pkg_outputs.iter().enumerate() {
+        if i > 0 {
+            println!();
+        }
+        for line in lines {
+            println!("{line}");
+        }
+    }
+    if !shared_outputs.is_empty() {
+        println!();
+        for line in shared_outputs {
+            println!("{line}");
+        }
+    }
+}
+
+/// Write the per-tag release blurb to `$GITHUB_STEP_SUMMARY` when the
+/// environment variable is set (GitHub Actions). Silent no-op otherwise.
+///
+/// Kept out of the main orchestrator so the entry function reads as a
+/// pipeline of stages instead of stage + side-effect appendix.
+pub(super) fn write_github_step_summary(tags: &[TagToCreate]) {
+    let Ok(summary_path) = std::env::var("GITHUB_STEP_SUMMARY") else {
+        return;
+    };
+    use std::io::Write;
+    let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&summary_path)
+    else {
+        return;
+    };
+    let _ = writeln!(file, "## Released\n");
+    for (tag_name, _, body, _, _, _, _) in tags {
+        let _ = writeln!(file, "### {tag_name}\n");
+        let _ = writeln!(file, "{body}");
+    }
+}


### PR DESCRIPTION
Closes part of #467.

## What

Mechanical extract-method passes on the easy boundaries while keeping the per-package iteration body and the release commit phase in place. Reduces run/mod.rs from **1155 → 1064** lines and ships 3 new focused submodules. Behavior is unchanged: 511 lib tests + 613 binary tests pass.

\`\`\`
run.rs  →  run/mod.rs    orchestrator (still does the heavy lifting)
           run/forced.rs --force-version parsing + per-package
                         resolution, plus 10 unit tests covering
                         malformed input, monorepo-mode rules, and
                         semver validation
           run/summary.rs print_outputs + write_github_step_summary
                         + the TagToCreate type alias the orchestrator
                         uses for tags_to_create
           run/drafts.rs  publish_pending_drafts — promote leftover
                         draft releases when the run had no new bumps
\`\`\`

## What's NOT in this wave

The harder phases — per-package version compute, hooks dispatch, release commit mode handling, tag-creation + forge publish — still mutate eight shared accumulators across the orchestrator's body:

\`any_bumped\`, \`json_packages\`, \`files_to_commit\`, \`files_per_package\`, \`tags_to_create\`, \`hook_contexts\`, \`bumped_names\`, \`pkg_outputs\` + \`shared_outputs\`.

Extracting them cleanly requires either a \`RunState\` struct passed mut-borrowed through phase fns, or a pipeline where each stage returns its contribution and the orchestrator assembles. Both are doable but warrant their own session — the release flow has had two production bugs this month already (E2006, default branch) that came from this exact interleaved-state region. I'd rather not bundle that with a feature batch.

The #467 issue stays open with the unfinished scope.

## Test plan

- [x] \`cargo test\` — 511 lib + 613 bin pass (no behavior change)
- [x] \`cargo clippy --no-deps -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [ ] Next release tagged at this branch produces the same release commit + tags as before (sanity check on the orchestrator's outputs through the extracted helpers)