### PR TITLE
refactor(release): extract execute phase into run/execute.rs

### DIFF
--- a/src/monorepo/run/execute.rs
+++ b/src/monorepo/run/execute.rs
@@ -1,0 +1,517 @@
+use anyhow::Result;
+use colored::Colorize;
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::config::{Config, ReleaseCommitMode, ReleaseCommitScope};
+use crate::error_code::{self, ErrorCodeExt};
+use crate::git::{
+    Repository, create_branch_and_commit, create_branch_and_commits, create_commit,
+    create_or_move_tag, create_tag, force_push_tags, get_tag_message, push, push_branch, push_tags,
+    tag_exists,
+};
+use crate::hooks::{HookContext, HookPoint, resolve_hook, resolve_on_failure, run_hook};
+use crate::telemetry;
+use crate::versioning::truncate_version;
+
+use super::summary::{TagToCreate, write_github_step_summary};
+use crate::monorepo::preview::build_forge_instance;
+use crate::monorepo::util::{auto_stage_new_files, collect_dirty_files};
+
+/// Inputs threaded through the execution phase. Bundling these as one
+/// `&mut ReleasePlan` keeps the per-step function signatures readable —
+/// the planning phase used to declare 14 mutable locals and pass them
+/// piecewise across each git/forge operation.
+///
+/// Lifetime: borrows from the caller's locals; lives only for the
+/// duration of a single `run_release_logic` invocation.
+pub(super) struct ReleasePlan<'a> {
+    pub repo: &'a Repository,
+    pub config: &'a Config,
+    pub root: &'a Path,
+    pub target_branch: &'a str,
+    pub dry_run: bool,
+    pub verbose: bool,
+    pub force: bool,
+    pub draft: bool,
+    pub tags_to_create: &'a [TagToCreate],
+    pub hook_contexts: &'a [(HookContext, usize)],
+    pub files_to_commit: &'a mut Vec<String>,
+    pub files_per_package: &'a mut HashMap<String, Vec<String>>,
+    pub pkg_outputs: &'a mut Vec<(String, Vec<String>)>,
+    pub shared_outputs: &'a mut Vec<String>,
+}
+
+/// Run the commit / branch+PR / tag / floating-tag / forge-release /
+/// push phase of a release, given the per-package decisions already
+/// captured into `plan.tags_to_create`.
+///
+/// Behaviour-preserving extraction from `run_release_logic` — see #529.
+pub(super) fn execute_release(plan: &mut ReleasePlan<'_>) -> Result<()> {
+    run_pre_commit_hooks(plan)?;
+
+    // Snapshot files_to_commit AFTER pre-commit hooks may have appended
+    // auto-staged paths. Clone to own the strings — `plan` itself stays
+    // mutably borrowable by the commit/push helpers below.
+    let files_snapshot: Vec<String> = plan.files_to_commit.clone();
+    let mode = plan.config.workspace.release_commit_mode;
+    let scope = plan.config.workspace.release_commit_scope;
+
+    let release_parts: Vec<String> = plan
+        .tags_to_create
+        .iter()
+        .map(|(_, _, _, name, ver, _, _)| format!("{name} v{ver}"))
+        .collect();
+    let skip_ci = if plan.config.workspace.effective_skip_ci() {
+        " [skip ci]"
+    } else {
+        ""
+    };
+    let commit_msg = format!("chore(release): {}{skip_ci}", release_parts.join(", "));
+    let mut floating_tag_names: Vec<String> = Vec::new();
+
+    if !plan.dry_run {
+        let file_refs: Vec<&str> = files_snapshot.iter().map(String::as_str).collect();
+        run_commit_or_pr(
+            plan,
+            mode,
+            scope,
+            &file_refs,
+            &commit_msg,
+            &release_parts,
+            skip_ci,
+        )?;
+        create_release_tags(plan)?;
+        create_and_move_floating_tags(plan, &mut floating_tag_names)?;
+    }
+
+    run_pre_publish_hooks(plan)?;
+
+    if !plan.dry_run {
+        push_and_publish(plan, mode, &floating_tag_names)?;
+    }
+
+    emit_release_telemetry(plan);
+    run_post_publish_hooks(plan)?;
+
+    Ok(())
+}
+
+fn run_pre_commit_hooks(plan: &mut ReleasePlan<'_>) -> Result<()> {
+    for (ctx, pkg_idx) in plan.hook_contexts {
+        let pkg = &plan.config.packages[*pkg_idx];
+        let ws_hooks = plan.config.workspace.hooks.as_ref();
+        let pkg_hooks = pkg.hooks.as_ref();
+        let on_failure = resolve_on_failure(pkg_hooks, ws_hooks);
+        if let Some(cmd) = resolve_hook(pkg_hooks, ws_hooks, HookPoint::PreCommit) {
+            let before = collect_dirty_files(plan.repo);
+            run_hook(
+                HookPoint::PreCommit,
+                &cmd,
+                ctx,
+                on_failure,
+                plan.dry_run,
+                plan.verbose,
+                plan.root,
+            )?;
+            if !plan.dry_run {
+                let len_before = plan.files_to_commit.len();
+                auto_stage_new_files(plan.repo, &before, plan.files_to_commit);
+                let pkg_files = plan.files_per_package.entry(pkg.name.clone()).or_default();
+                for f in &plan.files_to_commit[len_before..] {
+                    pkg_files.push(f.clone());
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn run_commit_or_pr(
+    plan: &mut ReleasePlan<'_>,
+    mode: ReleaseCommitMode,
+    scope: ReleaseCommitScope,
+    file_refs: &[&str],
+    commit_msg: &str,
+    release_parts: &[String],
+    skip_ci: &str,
+) -> Result<()> {
+    match mode {
+        ReleaseCommitMode::Commit => {
+            if scope == ReleaseCommitScope::PerPackage && plan.tags_to_create.len() > 1 {
+                for (_, _, _, pkg_name, ver, _, _) in plan.tags_to_create {
+                    if let Some(pkg_files) = plan.files_per_package.get(pkg_name) {
+                        let refs: Vec<&str> = pkg_files.iter().map(String::as_str).collect();
+                        let msg = format!("chore(release): {pkg_name} v{ver}{skip_ci}");
+                        create_commit(plan.repo, &refs, &msg)?;
+                    }
+                }
+                plan.shared_outputs
+                    .push("✓ Committed release changes (per-package)".to_string());
+            } else {
+                create_commit(plan.repo, file_refs, commit_msg)?;
+                plan.shared_outputs
+                    .push("✓ Committed release changes".to_string());
+            }
+        }
+        ReleaseCommitMode::Pr => {
+            let branch_name = format!(
+                "release/{}",
+                release_parts
+                    .first()
+                    .map(|s| s.replace(' ', "-"))
+                    .unwrap_or_else(|| "bump".to_string())
+            );
+            if scope == ReleaseCommitScope::PerPackage && plan.tags_to_create.len() > 1 {
+                let commit_list: Vec<(Vec<&str>, String)> = plan
+                    .tags_to_create
+                    .iter()
+                    .filter_map(|(_, _, _, pkg_name, ver, _, _)| {
+                        plan.files_per_package.get(pkg_name).map(|pf| {
+                            let refs: Vec<&str> = pf.iter().map(String::as_str).collect();
+                            let msg = format!("chore(release): {pkg_name} v{ver}{skip_ci}");
+                            (refs, msg)
+                        })
+                    })
+                    .collect();
+                let commit_refs: Vec<(&[&str], &str)> = commit_list
+                    .iter()
+                    .map(|(f, m)| (f.as_slice(), m.as_str()))
+                    .collect();
+                create_branch_and_commits(plan.repo, &branch_name, &commit_refs)?;
+            } else {
+                create_branch_and_commit(plan.repo, &branch_name, file_refs, commit_msg)?;
+            }
+            push_branch(plan.repo, &plan.config.workspace.remote, &branch_name)?;
+            plan.shared_outputs
+                .push(format!("✓ Pushed branch {}", branch_name.cyan()));
+
+            if let Some(forge_instance) = build_forge_instance(plan.repo, plan.config) {
+                let pr_title = format!("chore(release): {}", release_parts.join(", "));
+                let pr_body = format!(
+                    "Automated release commit.\n\n{}",
+                    plan.tags_to_create
+                        .iter()
+                        .map(|(tag, _, _, _, _, _, _)| format!("- `{tag}`"))
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                );
+                match forge_instance.create_merge_request(
+                    &branch_name,
+                    plan.target_branch,
+                    &pr_title,
+                    &pr_body,
+                ) {
+                    Ok(mr) => {
+                        plan.shared_outputs.push(format!(
+                            "✓ Created {} #{}",
+                            forge_instance.mr_noun(),
+                            mr.id.to_string().cyan()
+                        ));
+                        if plan.config.workspace.auto_merge_releases {
+                            match forge_instance.enable_auto_merge(&mr) {
+                                Ok(()) => {
+                                    plan.shared_outputs.push("✓ Auto-merge enabled".to_string())
+                                }
+                                Err(err) => eprintln!(
+                                    "{}",
+                                    format!("  Warning: failed to enable auto-merge: {err}")
+                                        .yellow()
+                                ),
+                            }
+                        }
+                    }
+                    Err(err) => eprintln!(
+                        "{}",
+                        format!(
+                            "  Warning: failed to create {}: {err}",
+                            forge_instance.mr_noun()
+                        )
+                        .yellow()
+                    ),
+                }
+            }
+        }
+        ReleaseCommitMode::None => {}
+    }
+    Ok(())
+}
+
+fn create_release_tags(plan: &mut ReleasePlan<'_>) -> Result<()> {
+    for (tag_name, tag_msg, _, pkg_name, _, _, _) in plan.tags_to_create {
+        create_tag(plan.repo, tag_name, tag_msg)?;
+        if let Some((_, lines)) = plan
+            .pkg_outputs
+            .iter_mut()
+            .rev()
+            .find(|(n, _)| n == pkg_name)
+        {
+            lines.push(format!("  ✓ Created tag {}", tag_name.cyan()));
+        }
+    }
+    Ok(())
+}
+
+fn create_and_move_floating_tags(
+    plan: &mut ReleasePlan<'_>,
+    floating_tag_names: &mut Vec<String>,
+) -> Result<()> {
+    for (_, _, _, pkg_name, new_version, _, is_pre) in plan.tags_to_create {
+        if *is_pre {
+            continue;
+        }
+        let pkg = plan
+            .config
+            .packages
+            .iter()
+            .find(|p| &p.name == pkg_name)
+            .ok_or_else(|| anyhow::anyhow!("package '{pkg_name}' not found in config"))
+            .error_code(error_code::MONOREPO_PACKAGE_NOT_FOUND)?;
+        let levels = pkg.effective_floating_tags(&plan.config.workspace);
+        for level in levels {
+            if let Some(truncated) = truncate_version(new_version, *level) {
+                let float_tag = pkg.tag_for_version(
+                    &plan.config.workspace,
+                    plan.config.is_monorepo(),
+                    &truncated,
+                );
+                if tag_exists(plan.repo, &float_tag)
+                    && let Some(old_msg) = get_tag_message(plan.repo, &float_tag)
+                    && let Some(old_ver) = old_msg.strip_prefix("Release ")
+                    && semver::Version::parse(old_ver.trim_start_matches('v'))
+                        .ok()
+                        .zip(semver::Version::parse(new_version.trim_start_matches('v')).ok())
+                        .is_some_and(|(old, new)| new < old)
+                {
+                    if !plan.force {
+                        Err(anyhow::anyhow!(
+                            "Floating tag {} would move backward ({} → {}). Use --force to override.",
+                            float_tag,
+                            old_ver,
+                            new_version,
+                        ))
+                        .error_code(error_code::MONOREPO_PUSH_FAILED)?;
+                    }
+                    eprintln!(
+                        "{}",
+                        format!(
+                            "  ⚠ Floating tag {} moves backward ({} → {})",
+                            float_tag, old_ver, new_version,
+                        )
+                        .yellow()
+                    );
+                }
+                let msg = format!("Release {new_version}");
+                let moved = create_or_move_tag(plan.repo, &float_tag, &msg)?;
+                let verb = if moved { "Moved" } else { "Created" };
+                if let Some((_, lines)) = plan
+                    .pkg_outputs
+                    .iter_mut()
+                    .rev()
+                    .find(|(n, _)| n == pkg_name)
+                {
+                    lines.push(format!("  ✓ {} floating tag {}", verb, float_tag.cyan()));
+                }
+                floating_tag_names.push(float_tag);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn run_pre_publish_hooks(plan: &mut ReleasePlan<'_>) -> Result<()> {
+    for (ctx, pkg_idx) in plan.hook_contexts {
+        let pkg = &plan.config.packages[*pkg_idx];
+        let ws_hooks = plan.config.workspace.hooks.as_ref();
+        let pkg_hooks = pkg.hooks.as_ref();
+        let on_failure = resolve_on_failure(pkg_hooks, ws_hooks);
+        if let Some(cmd) = resolve_hook(pkg_hooks, ws_hooks, HookPoint::PrePublish) {
+            run_hook(
+                HookPoint::PrePublish,
+                &cmd,
+                ctx,
+                on_failure,
+                plan.dry_run,
+                plan.verbose,
+                plan.root,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn push_and_publish(
+    plan: &mut ReleasePlan<'_>,
+    mode: ReleaseCommitMode,
+    floating_tag_names: &[String],
+) -> Result<()> {
+    let tag_refs: Vec<&str> = plan
+        .tags_to_create
+        .iter()
+        .map(|(t, _, _, _, _, _, _)| t.as_str())
+        .collect();
+
+    if let ReleaseCommitMode::Commit = mode {
+        push(
+            plan.repo,
+            &plan.config.workspace.remote,
+            plan.target_branch,
+            &[],
+        )?;
+        plan.shared_outputs.push(format!(
+            "✓ Pushed and verified on {}/{}",
+            plan.config.workspace.remote, plan.target_branch
+        ));
+    }
+
+    let target_sha = plan.repo.head_id().ok().map(|id| id.to_string());
+
+    if let Some(forge_instance) = build_forge_instance(plan.repo, plan.config) {
+        for (tag_name, _, body, pkg_name, _, _, is_pre) in plan.tags_to_create {
+            if !plan.draft {
+                match forge_instance.find_draft_release(tag_name) {
+                    Ok(Some(release_id)) => match forge_instance.publish_release(release_id) {
+                        Ok(()) => {
+                            if let Some((_, lines)) = plan
+                                .pkg_outputs
+                                .iter_mut()
+                                .rev()
+                                .find(|(n, _)| n == pkg_name)
+                            {
+                                lines.push(format!(
+                                    "  ✓ Published draft {} {}",
+                                    forge_instance.release_noun(),
+                                    tag_name.cyan()
+                                ));
+                            }
+                            continue;
+                        }
+                        Err(err) => eprintln!(
+                            "{}",
+                            format!("  Warning: failed to publish draft for {tag_name}: {err}")
+                                .yellow()
+                        ),
+                    },
+                    Ok(None) => {}
+                    Err(err) => {
+                        if plan.verbose {
+                            eprintln!(
+                                "{}",
+                                format!(
+                                    "  Warning: failed to check for draft release {tag_name}: {err}"
+                                )
+                                .yellow()
+                            );
+                        }
+                    }
+                }
+            }
+
+            match forge_instance.create_release(
+                tag_name,
+                body,
+                *is_pre,
+                plan.draft,
+                target_sha.as_deref(),
+            ) {
+                Ok(()) => {
+                    if let Some((_, lines)) = plan
+                        .pkg_outputs
+                        .iter_mut()
+                        .rev()
+                        .find(|(n, _)| n == pkg_name)
+                    {
+                        let noun = forge_instance.release_noun();
+                        if plan.draft {
+                            lines.push(format!("  ✓ Draft {} {}", noun, tag_name.cyan()));
+                        } else {
+                            lines.push(format!("  ✓ {} {}", noun, tag_name.cyan()));
+                        }
+                    }
+                }
+                Err(err) => eprintln!(
+                    "{}",
+                    format!(
+                        "  Warning: failed to create {} for {tag_name}: {err}",
+                        forge_instance.release_noun()
+                    )
+                    .yellow()
+                ),
+            }
+        }
+    }
+
+    if !tag_refs.is_empty() {
+        push_tags(plan.repo, &plan.config.workspace.remote, &tag_refs)?;
+        plan.shared_outputs.push("✓ Pushed tags".to_string());
+    }
+
+    if !floating_tag_names.is_empty() {
+        let float_refs: Vec<&str> = floating_tag_names.iter().map(String::as_str).collect();
+        force_push_tags(plan.repo, &plan.config.workspace.remote, &float_refs)?;
+        plan.shared_outputs
+            .push("✓ Pushed floating tags".to_string());
+    }
+
+    write_github_step_summary(plan.tags_to_create);
+    Ok(())
+}
+
+fn emit_release_telemetry(plan: &ReleasePlan<'_>) {
+    if !plan.config.workspace.anonymous_telemetry {
+        return;
+    }
+    for (_, _, _, pkg_name, version, commit_count, _) in plan.tags_to_create {
+        telemetry::send_event(
+            telemetry::EventType::Release,
+            None,
+            Some(*commit_count),
+            Some(pkg_name.clone()),
+            Some(version.clone()),
+        );
+    }
+}
+
+fn run_post_publish_hooks(plan: &mut ReleasePlan<'_>) -> Result<()> {
+    for (ctx, pkg_idx) in plan.hook_contexts {
+        let pkg = &plan.config.packages[*pkg_idx];
+        let ws_hooks = plan.config.workspace.hooks.as_ref();
+        let pkg_hooks = pkg.hooks.as_ref();
+        let on_failure = resolve_on_failure(pkg_hooks, ws_hooks);
+        if let Some(cmd) = resolve_hook(pkg_hooks, ws_hooks, HookPoint::PostPublish) {
+            run_hook(
+                HookPoint::PostPublish,
+                &cmd,
+                ctx,
+                on_failure,
+                plan.dry_run,
+                plan.verbose,
+                plan.root,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Dry-run hook trace: when nothing will actually fire (no commit, no
+/// tag push), still print what the user's PreCommit/PrePublish/PostPublish
+/// hooks WOULD have run. Mirrors the old inline `else if dry_run &&
+/// any_bumped` branch.
+pub(super) fn print_dry_run_hooks(plan: &ReleasePlan<'_>) -> Result<()> {
+    for (ctx, pkg_idx) in plan.hook_contexts {
+        let pkg = &plan.config.packages[*pkg_idx];
+        let ws_hooks = plan.config.workspace.hooks.as_ref();
+        let pkg_hooks = pkg.hooks.as_ref();
+        let on_failure = resolve_on_failure(pkg_hooks, ws_hooks);
+        for point in [
+            HookPoint::PreCommit,
+            HookPoint::PrePublish,
+            HookPoint::PostPublish,
+        ] {
+            if let Some(cmd) = resolve_hook(pkg_hooks, ws_hooks, point) {
+                run_hook(point, &cmd, ctx, on_failure, true, plan.verbose, plan.root)?;
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -4,25 +4,19 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use crate::changelog::{build_section, update_changelog};
-use crate::config::{
-    Config, OrphanedTagStrategy, ReleaseCommitMode, ReleaseCommitScope, VersioningStrategy,
-};
+use crate::config::{Config, OrphanedTagStrategy, VersioningStrategy};
 use crate::conventional_commits::{BumpType, determine_bump};
-use crate::error_code::{self, ErrorCodeExt};
 use crate::formats::{get_handler, read_version, write_version};
 use crate::git::{
-    collect_all_tags, create_branch_and_commit, create_branch_and_commits, create_commit,
-    create_or_move_tag, create_tag, fetch_tags, force_push_tags, get_changed_files,
-    get_changed_files_since_oid, get_changed_files_since_tag, get_commits_since_last_stable_tag,
-    get_commits_since_last_tag, get_commits_since_oid, get_tag_message, open_repo, push,
-    push_branch, push_tags, tag_exists,
+    collect_all_tags, fetch_tags, get_changed_files, get_changed_files_since_oid,
+    get_changed_files_since_tag, get_commits_since_last_stable_tag, get_commits_since_last_tag,
+    get_commits_since_oid, open_repo, tag_exists,
 };
 use crate::hooks::{HookContext, HookPoint, resolve_hook, resolve_on_failure, run_hook};
 use crate::prerelease::PrereleaseContext;
 use crate::telemetry;
 use crate::versioning::{compute_next_version, truncate_version};
 
-use super::preview::build_forge_instance;
 use super::types::{CheckCommit, CheckPackage, CheckResult};
 use super::util::{
     auto_stage_new_files, collect_dirty_files, is_package_touched, pick_higher_semver,
@@ -31,11 +25,13 @@ use super::util::{
 
 mod cascade;
 mod drafts;
+mod execute;
 mod forced;
 mod summary;
 use drafts::publish_pending_drafts;
+use execute::{ReleasePlan, execute_release, print_dry_run_hooks};
 use forced::{Forced, forced_version_for, parse_forced_version};
-use summary::{TagToCreate, print_outputs, write_github_step_summary};
+use summary::{TagToCreate, print_outputs};
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn run_release_logic(
@@ -564,386 +560,41 @@ pub(super) fn run_release_logic(
     }
 
     if any_bumped && !tags_to_create.is_empty() {
-        for (ctx, pkg_idx) in &hook_contexts {
-            let pkg = &config.packages[*pkg_idx];
-            let ws_hooks = config.workspace.hooks.as_ref();
-            let pkg_hooks = pkg.hooks.as_ref();
-            let on_failure = resolve_on_failure(pkg_hooks, ws_hooks);
-            if let Some(cmd) = resolve_hook(pkg_hooks, ws_hooks, HookPoint::PreCommit) {
-                let before = collect_dirty_files(&repo);
-                run_hook(
-                    HookPoint::PreCommit,
-                    &cmd,
-                    ctx,
-                    on_failure,
-                    dry_run,
-                    verbose,
-                    root,
-                )?;
-                if !dry_run {
-                    let len_before = files_to_commit.len();
-                    auto_stage_new_files(&repo, &before, &mut files_to_commit);
-                    let pkg_files = files_per_package.entry(pkg.name.clone()).or_default();
-                    for f in &files_to_commit[len_before..] {
-                        pkg_files.push(f.clone());
-                    }
-                }
-            }
-        }
-
-        let file_refs: Vec<&str> = files_to_commit.iter().map(String::as_str).collect();
-        let mode = config.workspace.release_commit_mode;
-        let scope = config.workspace.release_commit_scope;
-
-        let release_parts: Vec<String> = tags_to_create
-            .iter()
-            .map(|(_, _, _, name, ver, _, _)| format!("{name} v{ver}"))
-            .collect();
-        let skip_ci = if config.workspace.effective_skip_ci() {
-            " [skip ci]"
-        } else {
-            ""
+        let mut plan = ReleasePlan {
+            repo: &repo,
+            config,
+            root,
+            target_branch: &target_branch,
+            dry_run,
+            verbose,
+            force,
+            draft,
+            tags_to_create: &tags_to_create,
+            hook_contexts: &hook_contexts,
+            files_to_commit: &mut files_to_commit,
+            files_per_package: &mut files_per_package,
+            pkg_outputs: &mut pkg_outputs,
+            shared_outputs: &mut shared_outputs,
         };
-        let commit_msg = format!("chore(release): {}{skip_ci}", release_parts.join(", "));
-        let mut floating_tag_names: Vec<String> = Vec::new();
-
-        if !dry_run {
-            match mode {
-                ReleaseCommitMode::Commit => {
-                    if scope == ReleaseCommitScope::PerPackage && tags_to_create.len() > 1 {
-                        for (_, _, _, pkg_name, ver, _, _) in &tags_to_create {
-                            if let Some(pkg_files) = files_per_package.get(pkg_name) {
-                                let refs: Vec<&str> =
-                                    pkg_files.iter().map(String::as_str).collect();
-                                let msg = format!("chore(release): {pkg_name} v{ver}{skip_ci}");
-                                create_commit(&repo, &refs, &msg)?;
-                            }
-                        }
-                        shared_outputs
-                            .push("✓ Committed release changes (per-package)".to_string());
-                    } else {
-                        create_commit(&repo, &file_refs, &commit_msg)?;
-                        shared_outputs.push("✓ Committed release changes".to_string());
-                    }
-                }
-                ReleaseCommitMode::Pr => {
-                    let branch_name = format!(
-                        "release/{}",
-                        release_parts
-                            .first()
-                            .map(|s| s.replace(' ', "-"))
-                            .unwrap_or_else(|| "bump".to_string())
-                    );
-                    if scope == ReleaseCommitScope::PerPackage && tags_to_create.len() > 1 {
-                        let commit_list: Vec<(Vec<&str>, String)> = tags_to_create
-                            .iter()
-                            .filter_map(|(_, _, _, pkg_name, ver, _, _)| {
-                                files_per_package.get(pkg_name).map(|pf| {
-                                    let refs: Vec<&str> = pf.iter().map(String::as_str).collect();
-                                    let msg = format!("chore(release): {pkg_name} v{ver}{skip_ci}");
-                                    (refs, msg)
-                                })
-                            })
-                            .collect();
-                        let commit_refs: Vec<(&[&str], &str)> = commit_list
-                            .iter()
-                            .map(|(f, m)| (f.as_slice(), m.as_str()))
-                            .collect();
-                        create_branch_and_commits(&repo, &branch_name, &commit_refs)?;
-                    } else {
-                        create_branch_and_commit(&repo, &branch_name, &file_refs, &commit_msg)?;
-                    }
-                    push_branch(&repo, &config.workspace.remote, &branch_name)?;
-                    shared_outputs.push(format!("✓ Pushed branch {}", branch_name.cyan()));
-
-                    if let Some(forge_instance) = build_forge_instance(&repo, config) {
-                        let pr_title = format!("chore(release): {}", release_parts.join(", "));
-                        let pr_body = format!(
-                            "Automated release commit.\n\n{}",
-                            tags_to_create
-                                .iter()
-                                .map(|(tag, _, _, _, _, _, _)| format!("- `{tag}`"))
-                                .collect::<Vec<_>>()
-                                .join("\n")
-                        );
-                        match forge_instance.create_merge_request(
-                            &branch_name,
-                            &target_branch,
-                            &pr_title,
-                            &pr_body,
-                        ) {
-                            Ok(mr) => {
-                                shared_outputs.push(format!(
-                                    "✓ Created {} #{}",
-                                    forge_instance.mr_noun(),
-                                    mr.id.to_string().cyan()
-                                ));
-                                if config.workspace.auto_merge_releases {
-                                    match forge_instance.enable_auto_merge(&mr) {
-                                        Ok(()) => {
-                                            shared_outputs.push("✓ Auto-merge enabled".to_string())
-                                        }
-                                        Err(err) => eprintln!(
-                                            "{}",
-                                            format!(
-                                                "  Warning: failed to enable auto-merge: {err}"
-                                            )
-                                            .yellow()
-                                        ),
-                                    }
-                                }
-                            }
-                            Err(err) => eprintln!(
-                                "{}",
-                                format!(
-                                    "  Warning: failed to create {}: {err}",
-                                    forge_instance.mr_noun()
-                                )
-                                .yellow()
-                            ),
-                        }
-                    }
-                }
-                ReleaseCommitMode::None => {}
-            }
-
-            for (tag_name, tag_msg, _, pkg_name, _, _, _) in &tags_to_create {
-                create_tag(&repo, tag_name, tag_msg)?;
-                if let Some((_, lines)) = pkg_outputs.iter_mut().rev().find(|(n, _)| n == pkg_name)
-                {
-                    lines.push(format!("  ✓ Created tag {}", tag_name.cyan()));
-                }
-            }
-
-            for (_, _, _, pkg_name, new_version, _, is_pre) in &tags_to_create {
-                if *is_pre {
-                    continue;
-                }
-                let pkg = config
-                    .packages
-                    .iter()
-                    .find(|p| &p.name == pkg_name)
-                    .ok_or_else(|| anyhow::anyhow!("package '{pkg_name}' not found in config"))
-                    .error_code(error_code::MONOREPO_PACKAGE_NOT_FOUND)?;
-                let levels = pkg.effective_floating_tags(&config.workspace);
-                for level in levels {
-                    if let Some(truncated) = truncate_version(new_version, *level) {
-                        let float_tag = pkg.tag_for_version(
-                            &config.workspace,
-                            config.is_monorepo(),
-                            &truncated,
-                        );
-                        if tag_exists(&repo, &float_tag)
-                            && let Some(old_msg) = get_tag_message(&repo, &float_tag)
-                            && let Some(old_ver) = old_msg.strip_prefix("Release ")
-                            && semver::Version::parse(old_ver.trim_start_matches('v'))
-                                .ok()
-                                .zip(
-                                    semver::Version::parse(new_version.trim_start_matches('v'))
-                                        .ok(),
-                                )
-                                .is_some_and(|(old, new)| new < old)
-                        {
-                            if !force {
-                                Err(anyhow::anyhow!(
-                                    "Floating tag {} would move backward ({} → {}). Use --force to override.",
-                                    float_tag,
-                                    old_ver,
-                                    new_version,
-                                ))
-                                .error_code(error_code::MONOREPO_PUSH_FAILED)?;
-                            }
-                            eprintln!(
-                                "{}",
-                                format!(
-                                    "  ⚠ Floating tag {} moves backward ({} → {})",
-                                    float_tag, old_ver, new_version,
-                                )
-                                .yellow()
-                            );
-                        }
-                        let msg = format!("Release {new_version}");
-                        let moved = create_or_move_tag(&repo, &float_tag, &msg)?;
-                        let verb = if moved { "Moved" } else { "Created" };
-                        if let Some((_, lines)) =
-                            pkg_outputs.iter_mut().rev().find(|(n, _)| n == pkg_name)
-                        {
-                            lines.push(format!("  ✓ {} floating tag {}", verb, float_tag.cyan()));
-                        }
-                        floating_tag_names.push(float_tag);
-                    }
-                }
-            }
-        }
-
-        for (ctx, pkg_idx) in &hook_contexts {
-            let pkg = &config.packages[*pkg_idx];
-            let ws_hooks = config.workspace.hooks.as_ref();
-            let pkg_hooks = pkg.hooks.as_ref();
-            let on_failure = resolve_on_failure(pkg_hooks, ws_hooks);
-            if let Some(cmd) = resolve_hook(pkg_hooks, ws_hooks, HookPoint::PrePublish) {
-                run_hook(
-                    HookPoint::PrePublish,
-                    &cmd,
-                    ctx,
-                    on_failure,
-                    dry_run,
-                    verbose,
-                    root,
-                )?;
-            }
-        }
-
-        if !dry_run {
-            let tag_refs: Vec<&str> = tags_to_create
-                .iter()
-                .map(|(t, _, _, _, _, _, _)| t.as_str())
-                .collect();
-
-            if let ReleaseCommitMode::Commit = mode {
-                push(&repo, &config.workspace.remote, &target_branch, &[])?;
-                shared_outputs.push(format!(
-                    "✓ Pushed and verified on {}/{}",
-                    config.workspace.remote, target_branch
-                ));
-            }
-
-            let target_sha = repo.head_id().ok().map(|id| id.to_string());
-
-            if let Some(forge_instance) = build_forge_instance(&repo, config) {
-                for (tag_name, _, body, pkg_name, _, _, is_pre) in &tags_to_create {
-                    if !draft {
-                        match forge_instance.find_draft_release(tag_name) {
-                            Ok(Some(release_id)) => {
-                                match forge_instance.publish_release(release_id) {
-                                    Ok(()) => {
-                                        if let Some((_, lines)) = pkg_outputs
-                                            .iter_mut()
-                                            .rev()
-                                            .find(|(n, _)| n == pkg_name)
-                                        {
-                                            lines.push(format!(
-                                                "  ✓ Published draft {} {}",
-                                                forge_instance.release_noun(),
-                                                tag_name.cyan()
-                                            ));
-                                        }
-                                        continue;
-                                    }
-                                    Err(err) => eprintln!(
-                                        "{}",
-                                        format!(
-                                            "  Warning: failed to publish draft for {tag_name}: {err}"
-                                        )
-                                        .yellow()
-                                    ),
-                                }
-                            }
-                            Ok(None) => {}
-                            Err(err) => {
-                                if verbose {
-                                    eprintln!(
-                                        "{}",
-                                        format!(
-                                            "  Warning: failed to check for draft release {tag_name}: {err}"
-                                        )
-                                        .yellow()
-                                    );
-                                }
-                            }
-                        }
-                    }
-
-                    match forge_instance.create_release(
-                        tag_name,
-                        body,
-                        *is_pre,
-                        draft,
-                        target_sha.as_deref(),
-                    ) {
-                        Ok(()) => {
-                            if let Some((_, lines)) =
-                                pkg_outputs.iter_mut().rev().find(|(n, _)| n == pkg_name)
-                            {
-                                let noun = forge_instance.release_noun();
-                                if draft {
-                                    lines.push(format!("  ✓ Draft {} {}", noun, tag_name.cyan()));
-                                } else {
-                                    lines.push(format!("  ✓ {} {}", noun, tag_name.cyan()));
-                                }
-                            }
-                        }
-                        Err(err) => eprintln!(
-                            "{}",
-                            format!(
-                                "  Warning: failed to create {} for {tag_name}: {err}",
-                                forge_instance.release_noun()
-                            )
-                            .yellow()
-                        ),
-                    }
-                }
-            }
-
-            if !tag_refs.is_empty() {
-                push_tags(&repo, &config.workspace.remote, &tag_refs)?;
-                shared_outputs.push("✓ Pushed tags".to_string());
-            }
-
-            if !floating_tag_names.is_empty() {
-                let float_refs: Vec<&str> = floating_tag_names.iter().map(String::as_str).collect();
-                force_push_tags(&repo, &config.workspace.remote, &float_refs)?;
-                shared_outputs.push("✓ Pushed floating tags".to_string());
-            }
-
-            write_github_step_summary(&tags_to_create);
-        }
-
-        if config.workspace.anonymous_telemetry {
-            for (_, _, _, pkg_name, version, commit_count, _) in &tags_to_create {
-                telemetry::send_event(
-                    telemetry::EventType::Release,
-                    None,
-                    Some(*commit_count),
-                    Some(pkg_name.clone()),
-                    Some(version.clone()),
-                );
-            }
-        }
-
-        for (ctx, pkg_idx) in &hook_contexts {
-            let pkg = &config.packages[*pkg_idx];
-            let ws_hooks = config.workspace.hooks.as_ref();
-            let pkg_hooks = pkg.hooks.as_ref();
-            let on_failure = resolve_on_failure(pkg_hooks, ws_hooks);
-            if let Some(cmd) = resolve_hook(pkg_hooks, ws_hooks, HookPoint::PostPublish) {
-                run_hook(
-                    HookPoint::PostPublish,
-                    &cmd,
-                    ctx,
-                    on_failure,
-                    dry_run,
-                    verbose,
-                    root,
-                )?;
-            }
-        }
+        execute_release(&mut plan)?;
     } else if dry_run && any_bumped {
-        for (ctx, pkg_idx) in &hook_contexts {
-            let pkg = &config.packages[*pkg_idx];
-            let ws_hooks = config.workspace.hooks.as_ref();
-            let pkg_hooks = pkg.hooks.as_ref();
-            let on_failure = resolve_on_failure(pkg_hooks, ws_hooks);
-            for point in [
-                HookPoint::PreCommit,
-                HookPoint::PrePublish,
-                HookPoint::PostPublish,
-            ] {
-                if let Some(cmd) = resolve_hook(pkg_hooks, ws_hooks, point) {
-                    run_hook(point, &cmd, ctx, on_failure, true, verbose, root)?;
-                }
-            }
-        }
+        let plan = ReleasePlan {
+            repo: &repo,
+            config,
+            root,
+            target_branch: &target_branch,
+            dry_run,
+            verbose,
+            force,
+            draft,
+            tags_to_create: &tags_to_create,
+            hook_contexts: &hook_contexts,
+            files_to_commit: &mut files_to_commit,
+            files_per_package: &mut files_per_package,
+            pkg_outputs: &mut pkg_outputs,
+            shared_outputs: &mut shared_outputs,
+        };
+        print_dry_run_hooks(&plan)?;
     }
 
     if !any_bumped && !draft && !dry_run {


### PR DESCRIPTION
Closes #529.

Pure extraction — no behaviour change. The 117 fixture-based CI suites are the gate.

## Summary

\`run_release_logic\` was a ~960-line god-function. The commit/branch+PR/tag/floating-tag/forge-release/push leg moves into a dedicated \`src/monorepo/run/execute.rs\` behind a \`ReleasePlan\` struct that bundles the 14 cross-step locals the planning phase used to thread piecewise.

## Shape

\`execute.rs\` has one orchestrator (\`execute_release\`) calling eight focused helpers, each responsible for a single step:

- \`run_pre_commit_hooks\`
- \`run_commit_or_pr\`
- \`create_release_tags\`
- \`create_and_move_floating_tags\`
- \`run_pre_publish_hooks\`
- \`push_and_publish\`
- \`emit_release_telemetry\`
- \`run_post_publish_hooks\`

Plus \`print_dry_run_hooks\` for the dry-run-only trace path that used to live as an inline \`else if dry_run && any_bumped\` branch.

\`ReleasePlan\` borrows the accumulators (\`tags_to_create\`, \`hook_contexts\`, \`files_to_commit\`, \`files_per_package\`, \`pkg_outputs\`, \`shared_outputs\`) so each helper takes a single \`&mut ReleasePlan\` instead of 8-12 args.

## Numbers

- \`src/monorepo/run/mod.rs\`: 960 → 611 lines (−349, −36%)
- New \`src/monorepo/run/execute.rs\`: 503 lines, broken into 9 focused functions

## Test plan

- [x] \`cargo build\`, \`cargo clippy --features cli -- -D warnings\`, \`cargo fmt --check\` all green
- [x] 514 lib + 619 bin tests pass
- [x] Manual smoke: \`ferrflow release --dry-run\` on a single-package repo with feat commit on top of v1.0.0 still prints \`1.0.0 → 1.1.0 (minor)\`
- [ ] CI fixture suites pass unchanged (the actual gate, run on this PR)

## Out of scope

The issue's second item — lifting the per-package planning loop body into a \`plan_package()\` returning an outcome enum — stays open for a follow-up PR. Keeping this one as a pure extraction makes it reviewable.