### PR TITLE
fix(ci): discover cargo-cyclonedx output by glob

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -167,10 +167,26 @@ jobs:
         # platform binary). Attached to the GitHub Release as a sidecar
         # so downstream supply-chain scanners (grype, trivy, JFrog Xray,
         # Anchore) can ingest it at intake.
+        #
+        # We target only the `ferrflow` package (not the `ferrflow-wasm`
+        # workspace member) and discover whatever file cargo-cyclonedx
+        # produced — its default output filename changed in 0.6+ (was
+        # configurable via --override-filename, now via --output-pattern
+        # with a different default).
         run: |
           set -euo pipefail
-          cargo cyclonedx --format json --override-filename sbom
-          mv sbom.cdx.json artifacts/sbom.cdx.json
+          cargo cyclonedx --format json -p ferrflow
+          sbom=$(find . -maxdepth 2 -name '*.cdx.json' \
+            -not -path './artifacts/*' -not -path './target/*' \
+            -type f -print -quit)
+          if [ -z "$sbom" ]; then
+            echo "ERROR: cargo cyclonedx produced no .cdx.json file" >&2
+            find . -maxdepth 3 -name '*.json' -newer Cargo.toml \
+              -not -path './target/*' 2>/dev/null || true
+            exit 1
+          fi
+          echo "Found SBOM at $sbom"
+          mv "$sbom" artifacts/sbom.cdx.json
           echo "SBOM size: $(wc -c < artifacts/sbom.cdx.json) bytes"
 
       - name: Sign SBOM with cosign (keyless)


### PR DESCRIPTION
Closes #536.

The publish workflow assumed cargo-cyclonedx produced `sbom.cdx.json` via `--override-filename sbom`. That flag's semantics changed in cargo-cyclonedx 0.6+ (replaced by `--output-pattern`), so `cargo install --locked cargo-cyclonedx` on a clean runner produces a different filename and the `mv` fails — taking the whole publish job down, including SBOM signing.

Fix: target only the `ferrflow` package (skip `ferrflow-wasm`) and pick up whatever `.cdx.json` was written. Robust to further default-name drift.

No effect on the runtime binary — workflow file only.