### PR TITLE
fix(git): reset checkout-persisted extraheader so bot token pushes the release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,7 +622,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "5.0.2"
+version = "5.2.1"
 dependencies = [
  "anyhow",
  "cargo-husky",

--- a/action.yml
+++ b/action.yml
@@ -87,23 +87,6 @@ runs:
 
         echo "$INSTALL_DIR" >> "$GITHUB_PATH"
 
-    - name: Strip cached GITHUB_TOKEN credentials
-      # actions/checkout writes `AUTHORIZATION: basic <GITHUB_TOKEN>` into
-      # the repo's git extraheader. When ferrflow later swaps in the App
-      # installation token via OIDC, that extraheader still wins on every
-      # `git push` / `git fetch` — so the push authenticates as
-      # github-actions[bot] (not ferrflow[bot]) and is rejected by any
-      # branch ruleset that lists ferrflow[bot] in its bypass actors.
-      #
-      # Dropping the cache here means ferrflow's URL-rewrite path
-      # (`build_authenticated_url` in src/git.rs) takes over and the bot
-      # identity is what reaches the server. Idempotent: a no-op when the
-      # caller already set `persist-credentials: false` on the checkout.
-      if: inputs.bot == 'true'
-      shell: bash
-      run: |
-        git config --unset-all http.https://github.com/.extraheader || true
-
     # Git identity (`user.name` / `user.email`) is now set by the
     # binary itself in `ensure_bot_token`, so the action no longer
     # configures it. Self-hosters running their own App can override

--- a/src/git/auth.rs
+++ b/src/git/auth.rs
@@ -42,7 +42,23 @@ pub(super) fn configure_git_command(cmd: &mut Command, url: &str) {
             escaped_user, escaped_token
         );
         cmd.arg("-c").arg(format!("credential.helper={}", helper));
+        if let Some(server) = server_config_url(url) {
+            cmd.arg("-c").arg(format!("http.{server}.extraheader="));
+        }
     }
+}
+
+pub(super) fn server_config_url(url: &str) -> Option<String> {
+    let (scheme, rest) = url.split_once("://")?;
+    if scheme.is_empty() {
+        return None;
+    }
+    let authority = rest.split(['/', '?', '#']).next()?;
+    let host = authority.rsplit('@').next().unwrap_or(authority);
+    if host.is_empty() {
+        return None;
+    }
+    Some(format!("{scheme}://{host}/"))
 }
 
 pub(super) fn scrub_trace_env(cmd: &mut Command) {

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -1,4 +1,4 @@
-use super::auth::{configure_git_command, extract_url_password, token_for_url};
+use super::auth::{configure_git_command, extract_url_password, server_config_url, token_for_url};
 use super::push::{fetch_and_rebase, parse_ls_remote_tags};
 use super::repo::Repository;
 use super::retry::{is_transient_git_error, retry_transient};
@@ -751,6 +751,51 @@ fn configure_git_command_strips_git_trace_env() {
     assert!(removed.contains("GIT_TRACE"));
     assert!(removed.contains("GIT_CURL_VERBOSE"));
     assert!(removed.contains("GIT_TRACE_CURL"));
+}
+
+#[test]
+fn configure_git_command_resets_checkout_extraheader_when_authenticated() {
+    let _guard = EnvGuard::new().set("FERRFLOW_TOKEN", "ff_secret");
+    let mut cmd = std::process::Command::new("git");
+    configure_git_command(&mut cmd, "https://github.com/owner/repo.git");
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        args.iter()
+            .any(|a| a == "http.https://github.com/.extraheader="),
+        "expected the persisted checkout extraheader to be reset to empty, got {args:?}"
+    );
+}
+
+#[test]
+fn configure_git_command_does_not_reset_extraheader_without_token() {
+    let _guard = EnvGuard::new()
+        .unset("FERRFLOW_TOKEN")
+        .unset("GITHUB_TOKEN")
+        .unset("GITLAB_TOKEN");
+    let mut cmd = std::process::Command::new("git");
+    configure_git_command(&mut cmd, "https://github.com/owner/repo.git");
+    assert!(
+        !cmd.get_args()
+            .any(|a| a.to_string_lossy().contains("extraheader")),
+        "must not touch extraheader when ferrflow has no token of its own"
+    );
+}
+
+#[test]
+fn server_config_url_derives_the_checkout_key() {
+    assert_eq!(
+        server_config_url("https://github.com/owner/repo.git").as_deref(),
+        Some("https://github.com/")
+    );
+    assert_eq!(
+        server_config_url("https://x-access-token:tok@ghe.acme.dev:8443/o/r.git").as_deref(),
+        Some("https://ghe.acme.dev:8443/")
+    );
+    assert_eq!(server_config_url("git@github.com:owner/repo.git"), None);
+    assert_eq!(server_config_url("not a url"), None);
 }
 
 #[test]


### PR DESCRIPTION
Closes #538

`actions/checkout` persists the workflow `GITHUB_TOKEN` as an `http.<server>.extraheader`. An HTTP extraheader outranks a `credential.helper`, so ferrflow's OIDC App token (set via `configure_git_command`) was ignored and every `bot: true` push went out as `github-actions[bot]` — rejected by any ruleset that bypasses only `ferrflow[bot]`.

`configure_git_command` now appends `-c http.<server>.extraheader=` (empty) whenever it injects ferrflow's credential. Git treats an empty higher-priority extraheader as a reset of the whole list, clearing whatever `actions/checkout` wrote in any config scope or `includeIf`'d file. ferrflow's bot token becomes the only credential on the wire.

This supersedes the shell strip step in `action.yml` (only cleared repo-local config, missed checkout@v6's separate credential file) — removed.

Tests: reset arg emitted when authenticated, absent without a token; `server_config_url` derives the checkout key (userinfo + port handling, SSH/garbage → None).