### PR TITLE
docs: fix non-existent ghcr.io/ferrflow image namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npm install -D @ferrlabs/ferrflow
 **Docker**
 
 ```bash
-docker run ghcr.io/ferrflow/ferrflow:latest check
+docker run ghcr.io/ferrlabs/ferrflow:latest check
 ```
 
 **Pre-built binaries**
@@ -509,7 +509,7 @@ FerrFlow follows the [Conventional Commits](https://www.conventionalcommits.org/
 
 ```yaml
 release:
-  image: ghcr.io/ferrflow/ferrflow:latest
+  image: ghcr.io/ferrlabs/ferrflow:latest
   script:
     - ferrflow release
   rules:


### PR DESCRIPTION
`ghcr.io/ferrflow/ferrflow` → `ghcr.io/ferrlabs/ferrflow` in the README docker-run and GitLab-CI examples. The image is published under `ghcr.io/ferrlabs/*`; the old path doesn't resolve.

Closes 543