### PR TITLE
fix(release): wire --force-unlock CLI flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,6 +58,11 @@ pub enum Commands {
         /// without --draft will detect and publish existing drafts automatically.
         #[arg(long)]
         draft: bool,
+        /// Break an existing `.git/ferrflow.lock` before acquiring it.
+        /// Use only when you're sure no other `ferrflow release` is running —
+        /// for example, after a crash that left the lockfile behind.
+        #[arg(long)]
+        force_unlock: bool,
     },
     /// Generate/update CHANGELOG.md only
     Changelog,
@@ -143,6 +148,7 @@ impl Cli {
                 force_version,
                 channel,
                 draft,
+                force_unlock,
             } => crate::monorepo::release(
                 self.config.as_deref(),
                 self.dry_run,
@@ -151,6 +157,7 @@ impl Cli {
                 force_version.as_deref(),
                 channel.as_deref(),
                 draft,
+                force_unlock,
             ),
             Commands::Changelog => {
                 crate::changelog::generate_only(self.config.as_deref(), self.dry_run)
@@ -232,9 +239,19 @@ mod tests {
                 force: false,
                 force_version: None,
                 channel: None,
-                draft: false
+                draft: false,
+                force_unlock: false,
             }
         ));
+    }
+
+    #[test]
+    fn parse_release_force_unlock() {
+        let cli = parse(&["ferrflow", "release", "--force-unlock"]);
+        match cli.command {
+            Commands::Release { force_unlock, .. } => assert!(force_unlock),
+            _ => panic!("expected Release"),
+        }
     }
 
     #[test]

--- a/src/monorepo/check.rs
+++ b/src/monorepo/check.rs
@@ -27,7 +27,7 @@ pub fn check(
     }
 
     let result = run_release_logic(
-        &root, &config, true, verbose, json, false, None, channel, false,
+        &root, &config, true, verbose, json, false, None, channel, false, false,
     );
 
     if comment {

--- a/src/monorepo/release.rs
+++ b/src/monorepo/release.rs
@@ -9,6 +9,7 @@ use super::run::run_release_logic;
 
 const MAX_RELEASE_REGENERATE_ATTEMPTS: usize = 3;
 
+#[allow(clippy::too_many_arguments)]
 pub fn release(
     config_path: Option<&Path>,
     dry_run: bool,
@@ -17,6 +18,7 @@ pub fn release(
     force_version: Option<&str>,
     channel: Option<&str>,
     draft: bool,
+    force_unlock: bool,
 ) -> Result<()> {
     crate::bot_token::ensure_bot_token()?;
     let repo = open_repo(&std::env::current_dir()?)?;
@@ -48,6 +50,7 @@ pub fn release(
             force_version,
             channel,
             draft,
+            force_unlock,
         );
     }
 
@@ -68,6 +71,7 @@ pub fn release(
             force_version,
             channel,
             draft,
+            force_unlock,
         );
 
         match result {

--- a/src/monorepo/run/lock.rs
+++ b/src/monorepo/run/lock.rs
@@ -91,7 +91,6 @@ impl ReleaseLock {
 
     /// Force-acquire the lock, ignoring any existing one. Used by
     /// `--force-unlock` for manual recovery.
-    #[allow(dead_code)]
     pub fn acquire_force(repo_root: &Path) -> Result<Self> {
         let path = repo_root.join(".git").join("ferrflow.lock");
         if path.exists() {

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -45,6 +45,7 @@ pub(super) fn run_release_logic(
     force_version: Option<&str>,
     channel: Option<&str>,
     draft: bool,
+    force_unlock: bool,
 ) -> Result<()> {
     if config.packages.is_empty() {
         if json {
@@ -69,6 +70,8 @@ pub(super) fn run_release_logic(
     // get a clear error instead of racing on git refs. See #514.
     let _release_lock = if dry_run {
         None
+    } else if force_unlock {
+        Some(lock::ReleaseLock::acquire_force(root)?)
     } else {
         Some(lock::ReleaseLock::acquire(root)?)
     };


### PR DESCRIPTION
The error returned when `.git/ferrflow.lock` is held tells the user to
"run with --force-unlock", but that flag was never wired into the CLI —
`ReleaseLock::acquire_force` existed but had no caller and was guarded
with `#[allow(dead_code)]`.

Adds `--force-unlock` to `ferrflow release`. When set, the release run
takes over an existing `.git/ferrflow.lock` instead of bailing out.
Useful after a crash that left the lockfile behind (the 30-min stale-TTL
takeover still handles most cases automatically; this is the manual
escape hatch the error message already advertised).

`check` always runs dry, so the flag has no effect there and is hardcoded
to `false` in the `run_release_logic` call.

Refs #514.

## Test plan
- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 1166 passed, including new `parse_release_force_unlock`
- [x] Existing `force_unlock_takes_over_active_lock` lock-level test still passes