### PR TITLE
feat(commit): configurable commit-skip markers, subject-only matching

### DIFF
--- a/benches/ferrflow_benchmarks.rs
+++ b/benches/ferrflow_benchmarks.rs
@@ -285,7 +285,13 @@ fn bench_git_operations(c: &mut Criterion) {
         c.bench_function(label, |b| {
             b.iter(|| {
                 black_box(
-                    get_commits_since_last_tag(&repo, "v", OrphanedTagStrategy::Warn).unwrap(),
+                    get_commits_since_last_tag(
+                        &repo,
+                        "v",
+                        OrphanedTagStrategy::Warn,
+                        &ferrflow::config::default_commit_skip_markers(),
+                    )
+                    .unwrap(),
                 );
             });
         });
@@ -408,8 +414,13 @@ fn bench_full_check_flow(c: &mut Criterion) {
         c.bench_function(label, |b| {
             b.iter(|| {
                 let config = Config::load(_dir.path(), None).unwrap();
-                let commits =
-                    get_commits_since_last_tag(&repo, "v", OrphanedTagStrategy::Warn).unwrap();
+                let commits = get_commits_since_last_tag(
+                    &repo,
+                    "v",
+                    OrphanedTagStrategy::Warn,
+                    &ferrflow::config::default_commit_skip_markers(),
+                )
+                .unwrap();
                 for commit in &commits {
                     black_box(determine_bump(&commit.message));
                 }

--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -70,6 +70,11 @@
           "type": "boolean",
           "description": "Append [skip ci] to the release commit message. Defaults to true in 'commit' mode, false in 'pr' mode."
         },
+        "commitSkipMarkers": {
+          "type": "array",
+          "description": "Markers in a commit subject line that cause FerrFlow to skip the commit when computing the next version. Matched case-insensitively, subject line only. Defaults to ['[skip ci]', '[ci skip]', '[no ci]', '[skip actions]', '[actions skip]'].",
+          "items": { "type": "string" }
+        },
         "floatingTags": {
           "type": "array",
           "description": "Floating tag levels to create/move on each release. Each level produces a tag pointing to the latest matching release (e.g. 'major' creates a v1 tag for v1.2.3).",

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -33,8 +33,13 @@ pub fn generate_only(config_path: Option<&Path>, dry_run: bool) -> Result<()> {
 
     for pkg in &config.packages {
         let tag_prefix = format!("{}@v", pkg.name);
-        let commits =
-            get_commits_since_last_tag(&repo, &tag_prefix, config.workspace.orphaned_tag_strategy)?;
+        let skip_markers = config.workspace.effective_commit_skip_markers();
+        let commits = get_commits_since_last_tag(
+            &repo,
+            &tag_prefix,
+            config.workspace.orphaned_tag_strategy,
+            &skip_markers,
+        )?;
 
         if commits.is_empty() {
             continue;

--- a/src/config/format.rs
+++ b/src/config/format.rs
@@ -49,6 +49,7 @@ const CAMEL_CASE_KEYS: &[&str] = &[
     "release_commit_scope",
     "auto_merge_releases",
     "skip_ci",
+    "commit_skip_markers",
     "pre_bump",
     "post_bump",
     "pre_commit",

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -22,7 +22,8 @@ pub use types::{
     BranchChannelConfig, ChannelValue, ForgeKind, HooksConfig, OnFailure, OrphanedTagStrategy,
     PrereleaseIdentifier, ReleaseCommitMode, ReleaseCommitScope,
 };
-pub use workspace::WorkspaceConfig;
+#[allow(unused_imports)]
+pub use workspace::{WorkspaceConfig, default_commit_skip_markers};
 
 use format::{CONFIG_FORMATS, DotfileFormat, Json5Format, JsonFormat, TomlFormat};
 #[cfg(feature = "cli")]

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -28,6 +28,8 @@ pub struct WorkspaceConfig {
     pub auto_merge_releases: bool,
     #[serde(default, alias = "skipCi")]
     pub skip_ci: Option<bool>,
+    #[serde(default, alias = "commitSkipMarkers")]
+    pub commit_skip_markers: Option<Vec<String>>,
     #[serde(default, alias = "floatingTags")]
     pub floating_tags: Vec<FloatingTagLevel>,
     #[serde(default, alias = "orphanedTagStrategy")]
@@ -45,6 +47,22 @@ impl WorkspaceConfig {
         self.skip_ci
             .unwrap_or(self.release_commit_mode == ReleaseCommitMode::Commit)
     }
+
+    pub fn effective_commit_skip_markers(&self) -> Vec<String> {
+        self.commit_skip_markers
+            .clone()
+            .unwrap_or_else(default_commit_skip_markers)
+    }
+}
+
+pub fn default_commit_skip_markers() -> Vec<String> {
+    vec![
+        "[skip ci]".to_string(),
+        "[ci skip]".to_string(),
+        "[no ci]".to_string(),
+        "[skip actions]".to_string(),
+        "[actions skip]".to_string(),
+    ]
 }
 
 fn default_auto_merge() -> bool {

--- a/src/git/commits.rs
+++ b/src/git/commits.rs
@@ -13,23 +13,26 @@ pub fn get_commits_since_last_tag(
     repo: &Repository,
     tag_prefix: &str,
     strategy: OrphanedTagStrategy,
+    skip_markers: &[String],
 ) -> Result<Vec<GitLog>> {
     let last_tag_oid = find_last_tag_commit(repo, tag_prefix, strategy)?;
-    get_commits_since_oid(repo, last_tag_oid)
+    get_commits_since_oid(repo, last_tag_oid, skip_markers)
 }
 
 pub fn get_commits_since_last_stable_tag(
     repo: &Repository,
     tag_prefix: &str,
     strategy: OrphanedTagStrategy,
+    skip_markers: &[String],
 ) -> Result<Vec<GitLog>> {
     let last_tag_oid = find_last_stable_tag(repo, tag_prefix, strategy)?.map(|t| t.commit_oid);
-    get_commits_since_oid(repo, last_tag_oid)
+    get_commits_since_oid(repo, last_tag_oid, skip_markers)
 }
 
 pub fn get_commits_since_oid(
     repo: &Repository,
     last_tag_oid: Option<ObjectId>,
+    skip_markers: &[String],
 ) -> Result<Vec<GitLog>> {
     let head = repo.head_id()?.detach();
     let mut platform = repo.rev_walk([head]).sorting(Sorting::BreadthFirst);
@@ -50,7 +53,7 @@ pub fn get_commits_since_oid(
             Err(_) => continue,
         };
         let message = String::from_utf8_lossy(raw).into_owned();
-        if message.contains("[skip ci]") {
+        if subject_has_skip_marker(&message, skip_markers) {
             continue;
         }
         commits.push(GitLog {
@@ -60,6 +63,25 @@ pub fn get_commits_since_oid(
     }
 
     Ok(commits)
+}
+
+/// Returns true if the commit subject (first line) contains any of the
+/// configured skip markers, matched case-insensitively.
+///
+/// We scope to the subject line so a commit *body* that quotes or
+/// documents a marker (e.g. release notes referencing `[skip ci]`)
+/// isn't silently dropped.
+pub fn subject_has_skip_marker(message: &str, skip_markers: &[String]) -> bool {
+    if skip_markers.is_empty() {
+        return false;
+    }
+    let subject = message.lines().next().unwrap_or("").to_ascii_lowercase();
+    if subject.is_empty() {
+        return false;
+    }
+    skip_markers
+        .iter()
+        .any(|m| subject.contains(&m.to_ascii_lowercase()))
 }
 
 pub fn create_commit(repo: &Repository, files: &[&str], message: &str) -> Result<()> {

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -16,6 +16,7 @@ pub use auth::get_remote_url;
 pub use commits::{
     GitLog, create_branch_and_commit, create_branch_and_commits, create_commit,
     get_commits_since_last_stable_tag, get_commits_since_last_tag, get_commits_since_oid,
+    subject_has_skip_marker,
 };
 pub use diff::{get_changed_files, get_changed_files_since_oid, get_changed_files_since_tag};
 pub use fetch::fetch_tags;

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -414,7 +414,13 @@ fn get_commits_since_last_tag_no_tags() {
     create_commit_in_repo(&repo, dir.path(), "a.txt", "feat: first");
     create_commit_in_repo(&repo, dir.path(), "b.txt", "fix: second");
 
-    let commits = get_commits_since_last_tag(&repo, "v", OrphanedTagStrategy::Warn).unwrap();
+    let commits = get_commits_since_last_tag(
+        &repo,
+        "v",
+        OrphanedTagStrategy::Warn,
+        &crate::config::default_commit_skip_markers(),
+    )
+    .unwrap();
     assert_eq!(commits.len(), 2);
     assert_eq!(commits[0].message.trim(), "fix: second");
     assert_eq!(commits[1].message.trim(), "feat: first");
@@ -428,7 +434,13 @@ fn get_commits_since_last_tag_with_tag() {
     create_commit_in_repo(&repo, dir.path(), "b.txt", "fix: second");
     create_commit_in_repo(&repo, dir.path(), "c.txt", "feat: third");
 
-    let commits = get_commits_since_last_tag(&repo, "v", OrphanedTagStrategy::Warn).unwrap();
+    let commits = get_commits_since_last_tag(
+        &repo,
+        "v",
+        OrphanedTagStrategy::Warn,
+        &crate::config::default_commit_skip_markers(),
+    )
+    .unwrap();
     assert_eq!(commits.len(), 2);
     // Most recent first (topological order)
     assert!(commits[0].message.contains("third"));
@@ -443,9 +455,115 @@ fn get_commits_skips_skip_ci() {
     create_commit_in_repo(&repo, dir.path(), "b.txt", "chore(release): bump [skip ci]");
     create_commit_in_repo(&repo, dir.path(), "c.txt", "feat: real change");
 
-    let commits = get_commits_since_last_tag(&repo, "v", OrphanedTagStrategy::Warn).unwrap();
+    let commits = get_commits_since_last_tag(
+        &repo,
+        "v",
+        OrphanedTagStrategy::Warn,
+        &crate::config::default_commit_skip_markers(),
+    )
+    .unwrap();
     assert_eq!(commits.len(), 1);
     assert!(commits[0].message.contains("real change"));
+}
+
+#[test]
+fn get_commits_skips_ci_skip_variant() {
+    let (dir, repo) = init_repo();
+    create_commit_in_repo(&repo, dir.path(), "a.txt", "feat: first");
+    create_lightweight_tag(&repo, "v1.0.0");
+    create_commit_in_repo(&repo, dir.path(), "b.txt", "chore(release): bump [ci skip]");
+    create_commit_in_repo(&repo, dir.path(), "c.txt", "feat: real change");
+
+    let commits = get_commits_since_last_tag(
+        &repo,
+        "v",
+        OrphanedTagStrategy::Warn,
+        &crate::config::default_commit_skip_markers(),
+    )
+    .unwrap();
+    assert_eq!(commits.len(), 1);
+    assert!(commits[0].message.contains("real change"));
+}
+
+#[test]
+fn get_commits_skip_marker_is_case_insensitive() {
+    let (dir, repo) = init_repo();
+    create_commit_in_repo(&repo, dir.path(), "a.txt", "feat: first");
+    create_lightweight_tag(&repo, "v1.0.0");
+    create_commit_in_repo(&repo, dir.path(), "b.txt", "chore(release): bump [SKIP CI]");
+
+    let commits = get_commits_since_last_tag(
+        &repo,
+        "v",
+        OrphanedTagStrategy::Warn,
+        &crate::config::default_commit_skip_markers(),
+    )
+    .unwrap();
+    assert_eq!(commits.len(), 0);
+}
+
+#[test]
+fn get_commits_skip_marker_ignored_in_body() {
+    let (dir, repo) = init_repo();
+    create_commit_in_repo(&repo, dir.path(), "a.txt", "feat: first");
+    create_lightweight_tag(&repo, "v1.0.0");
+    create_commit_in_repo(
+        &repo,
+        dir.path(),
+        "b.txt",
+        "feat: document CI behavior\n\nThis commit explains how [skip ci] works.",
+    );
+
+    let commits = get_commits_since_last_tag(
+        &repo,
+        "v",
+        OrphanedTagStrategy::Warn,
+        &crate::config::default_commit_skip_markers(),
+    )
+    .unwrap();
+    assert_eq!(commits.len(), 1);
+}
+
+#[test]
+fn get_commits_skip_markers_can_be_overridden() {
+    let (dir, repo) = init_repo();
+    create_commit_in_repo(&repo, dir.path(), "a.txt", "feat: first");
+    create_lightweight_tag(&repo, "v1.0.0");
+    create_commit_in_repo(&repo, dir.path(), "b.txt", "feat: real [skip ci]");
+
+    let custom = vec!["[no release]".to_string()];
+    let commits =
+        get_commits_since_last_tag(&repo, "v", OrphanedTagStrategy::Warn, &custom).unwrap();
+    assert_eq!(
+        commits.len(),
+        1,
+        "[skip ci] not in custom set, should not skip"
+    );
+}
+
+#[test]
+fn subject_has_skip_marker_subject_only() {
+    use crate::git::subject_has_skip_marker;
+    let markers = crate::config::default_commit_skip_markers();
+    assert!(subject_has_skip_marker("chore: bump [skip ci]", &markers));
+    assert!(subject_has_skip_marker("chore: bump [SKIP CI]", &markers));
+    assert!(subject_has_skip_marker("chore: bump [ci skip]", &markers));
+    assert!(subject_has_skip_marker("chore: bump [no ci]", &markers));
+    assert!(subject_has_skip_marker(
+        "chore: bump [skip actions]",
+        &markers
+    ));
+    assert!(subject_has_skip_marker(
+        "chore: bump [actions skip]",
+        &markers
+    ));
+    assert!(!subject_has_skip_marker(
+        "feat: documentation\n\nbody mentions [skip ci] only",
+        &markers
+    ));
+    assert!(!subject_has_skip_marker("feat: normal commit", &markers));
+    assert!(!subject_has_skip_marker("", &markers));
+    assert!(!subject_has_skip_marker("anything", &[]));
 }
 
 // -----------------------------------------------------------------------
@@ -974,7 +1092,13 @@ fn get_commits_since_orphaned_tag_with_recovery() {
     let (repo, dir) = create_orphaned_tag_scenario("v1.0.0");
     create_commit_in_repo(&repo, dir.path(), "b.txt", "feat: new feature");
 
-    let commits = get_commits_since_last_tag(&repo, "v", OrphanedTagStrategy::TreeHash).unwrap();
+    let commits = get_commits_since_last_tag(
+        &repo,
+        "v",
+        OrphanedTagStrategy::TreeHash,
+        &crate::config::default_commit_skip_markers(),
+    )
+    .unwrap();
     assert_eq!(commits.len(), 1);
     assert!(commits[0].message.contains("new feature"));
 }
@@ -991,11 +1115,23 @@ fn get_commits_since_last_stable_tag_skips_prereleases() {
     create_commit_in_repo(&repo, dir.path(), "d.txt", "fix: last fix");
 
     // Stable commits should include everything since v1.0.0
-    let commits = get_commits_since_last_stable_tag(&repo, "v", OrphanedTagStrategy::Warn).unwrap();
+    let commits = get_commits_since_last_stable_tag(
+        &repo,
+        "v",
+        OrphanedTagStrategy::Warn,
+        &crate::config::default_commit_skip_markers(),
+    )
+    .unwrap();
     assert_eq!(commits.len(), 3);
 
     // Regular commits should include only since v2.0.0-beta.2
-    let commits = get_commits_since_last_tag(&repo, "v", OrphanedTagStrategy::Warn).unwrap();
+    let commits = get_commits_since_last_tag(
+        &repo,
+        "v",
+        OrphanedTagStrategy::Warn,
+        &crate::config::default_commit_skip_markers(),
+    )
+    .unwrap();
     assert_eq!(commits.len(), 1);
 }
 

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -221,20 +221,26 @@ pub(super) fn run_release_logic(
         // Helpers that route through TagIndex when the strategy allows it,
         // falling back to the per-call slow path. Returns commits walked
         // back to the last (stable or any) tag for the current package.
+        let skip_markers = config.workspace.effective_commit_skip_markers();
         let commits_since_stable = || -> Result<Vec<crate::git::GitLog>> {
             if let (Some(idx), OrphanedTagStrategy::Warn) = (tag_index.as_ref(), strategy) {
                 let stop = idx.find_last_stable_tag_commit(&tag_search_prefix, strategy);
-                get_commits_since_oid(&repo, stop)
+                get_commits_since_oid(&repo, stop, &skip_markers)
             } else {
-                get_commits_since_last_stable_tag(&repo, &tag_search_prefix, strategy)
+                get_commits_since_last_stable_tag(
+                    &repo,
+                    &tag_search_prefix,
+                    strategy,
+                    &skip_markers,
+                )
             }
         };
         let commits_since_any = || -> Result<Vec<crate::git::GitLog>> {
             if let (Some(idx), OrphanedTagStrategy::Warn) = (tag_index.as_ref(), strategy) {
                 let stop = idx.find_last_tag_commit(&tag_search_prefix, strategy);
-                get_commits_since_oid(&repo, stop)
+                get_commits_since_oid(&repo, stop, &skip_markers)
             } else {
-                get_commits_since_last_tag(&repo, &tag_search_prefix, strategy)
+                get_commits_since_last_tag(&repo, &tag_search_prefix, strategy, &skip_markers)
             }
         };
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -49,10 +49,12 @@ pub fn run(config_path: Option<&std::path::Path>, output: &OutputFormat) -> Resu
             "unknown".to_string()
         };
 
+        let skip_markers = config.workspace.effective_commit_skip_markers();
         let commits = get_commits_since_last_tag(
             &repo,
             &tag_search_prefix,
             config.workspace.orphaned_tag_strategy,
+            &skip_markers,
         )?;
         let has_changes = commits
             .iter()


### PR DESCRIPTION
Closes #527.

## What

- New \`workspace.commitSkipMarkers\` config field, defaulting to: \`[skip ci]\`, \`[ci skip]\`, \`[no ci]\`, \`[skip actions]\`, \`[actions skip]\`.
- Matching is **case-insensitive** and **subject-line only** — a body that quotes/documents a marker no longer drops the commit.
- Schema + docs updated (EN + FR + schema mirror in FerrFlow-Cloud).

## Why

Before this PR \`src/git/commits.rs:53\` did a hardcoded \`message.contains(\"[skip ci]\")\` against the full message body. Two problems flagged in #527:

1. Authors who write \`[ci skip]\` (GitHub Actions honors it, so do most CI providers) had that commit silently counted toward the version bump and the changelog.
2. A commit whose *body* mentions \`[skip ci]\` (release notes, docs about CI behavior) was silently excluded.

## API change

\`get_commits_since_oid\`, \`get_commits_since_last_tag\`, \`get_commits_since_last_stable_tag\` now take a \`skip_markers: &[String]\` parameter. All in-tree callers (changelog, monorepo run loop, status, tests, benches) updated.

## Tests

- Existing \`get_commits_skips_skip_ci\` still passes.
- New: \`[ci skip]\` variant, case-insensitive match, body-only mention is ignored, custom marker set overrides default.
- New: unit tests for \`subject_has_skip_marker\` covering all default markers + empty inputs.

\`cargo test --features cli\` → 529 passed. \`cargo clippy --features cli -- -D warnings\` → clean.