### PR TITLE
feat(release): crash-resume checkpoint

### DIFF
--- a/src/monorepo/run/checkpoint.rs
+++ b/src/monorepo/run/checkpoint.rs
@@ -1,0 +1,274 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::error_code::{self, ErrorCodeExt};
+
+const CHECKPOINT_FILENAME: &str = "ferrflow.checkpoint.json";
+const CHECKPOINT_SCHEMA: u32 = 1;
+
+/// Coarse-grained sequence of release phases, ordered by the side
+/// effects they produce. The checkpoint records the highest phase that
+/// completed successfully so a resume can skip back up to that point.
+///
+/// Why coarse-grained? The release pipeline already groups related side
+/// effects (all tags created together, all tags pushed together, all
+/// releases created together). Tracking finer per-tag state means
+/// duplicating the orchestration logic in two places — release-time and
+/// resume-time — and a mid-batch crash inside any single step (e.g.
+/// 5 of 10 tags pushed) is rare in practice and still recoverable
+/// because the underlying git/forge operations are idempotent: pushing
+/// an already-existing tag, or creating an already-existing release, is
+/// a no-op that the existing code already handles gracefully. So we
+/// rewind to the start of the *phase*, not the start of the *item*.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Phase {
+    Pending,
+    CommitDone,
+    TagsCreated,
+    Pushed,
+    ReleasesCreated,
+    PostPublishDone,
+}
+
+/// On-disk crash-resume marker for `ferrflow release`.
+///
+/// Written progressively at `.git/ferrflow.checkpoint.json` as each
+/// phase of the release succeeds. On the next run we load it back, and
+/// if HEAD still matches we skip every phase up to and including the
+/// recorded one. Cleared on successful completion of the release.
+///
+/// HEAD-pinning is what makes the resume safe: if the user (or another
+/// process) advanced HEAD between runs, the recorded commit_sha won't
+/// match anymore and we refuse to auto-resume — the user has to delete
+/// the checkpoint manually or rerun against the recorded commit. This
+/// avoids the worst failure mode (replaying old tags onto a new commit
+/// graph). See #549.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Checkpoint {
+    pub schema_version: u32,
+    /// The HEAD commit SHA observed when the release started — what the
+    /// in-progress release was operating on. Used to detect "HEAD
+    /// moved" on resume.
+    pub head_sha: String,
+    /// Unix-epoch seconds, for telemetry / debug. Not used by the
+    /// resume policy itself.
+    pub started_at: u64,
+    /// Highest phase that finished without erroring.
+    pub phase: Phase,
+    /// The release commit's SHA, populated once the commit phase
+    /// finishes. Surfaces in the resume log line so the user can verify
+    /// the resume is operating on what they expect.
+    pub commit_sha: Option<String>,
+    /// Tags that this release expects to create. Recorded at start so a
+    /// resume can sanity-check that the in-flight release matches the
+    /// tag set we'd recompute today.
+    pub tag_names: Vec<String>,
+}
+
+impl Checkpoint {
+    pub fn new(head_sha: String, tag_names: Vec<String>) -> Self {
+        Self {
+            schema_version: CHECKPOINT_SCHEMA,
+            head_sha,
+            started_at: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+            phase: Phase::Pending,
+            commit_sha: None,
+            tag_names,
+        }
+    }
+
+    pub fn path(repo_root: &Path) -> PathBuf {
+        repo_root.join(".git").join(CHECKPOINT_FILENAME)
+    }
+
+    /// Returns Ok(Some(_)) when a parseable checkpoint exists, Ok(None)
+    /// when the file is absent, and Err on a corrupt file — callers
+    /// should surface the corruption to the user rather than silently
+    /// nuking work-in-progress.
+    pub fn load(repo_root: &Path) -> Result<Option<Self>> {
+        let path = Self::path(repo_root);
+        let raw = match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => {
+                return Err(e)
+                    .with_context(|| format!("Cannot read {}", path.display()))
+                    .error_code(error_code::JSON_READ);
+            }
+        };
+        let cp: Checkpoint = serde_json::from_str(&raw)
+            .with_context(|| {
+                format!(
+                    "Cannot parse {} — delete it manually if you want a fresh release",
+                    path.display()
+                )
+            })
+            .error_code(error_code::JSON_PARSE)?;
+        if cp.schema_version != CHECKPOINT_SCHEMA {
+            return Err(anyhow::anyhow!(
+                "checkpoint at {} has schema {} but this build expects {}; delete it to start fresh",
+                path.display(),
+                cp.schema_version,
+                CHECKPOINT_SCHEMA
+            ))
+            .error_code(error_code::JSON_PARSE);
+        }
+        Ok(Some(cp))
+    }
+
+    /// Atomic write via temp + rename so a crash mid-save leaves the
+    /// previous checkpoint intact rather than a half-written one.
+    pub fn save(&self, repo_root: &Path) -> Result<()> {
+        let final_path = Self::path(repo_root);
+        let tmp_path = final_path.with_extension("json.tmp");
+        let bytes = serde_json::to_vec_pretty(self)
+            .with_context(|| "serialize release checkpoint")
+            .error_code(error_code::JSON_WRITE)?;
+        std::fs::write(&tmp_path, bytes)
+            .with_context(|| format!("write {}", tmp_path.display()))
+            .error_code(error_code::JSON_WRITE)?;
+        std::fs::rename(&tmp_path, &final_path)
+            .with_context(|| format!("rename to {}", final_path.display()))
+            .error_code(error_code::JSON_WRITE)?;
+        Ok(())
+    }
+
+    pub fn delete(repo_root: &Path) -> Result<()> {
+        let path = Self::path(repo_root);
+        match std::fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e)
+                .with_context(|| format!("delete {}", path.display()))
+                .error_code(error_code::JSON_WRITE),
+        }
+    }
+
+    pub fn advance(&mut self, phase: Phase) {
+        if phase > self.phase {
+            self.phase = phase;
+        }
+    }
+
+    pub fn is_done(&self, phase: Phase) -> bool {
+        self.phase >= phase
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn init_test_repo() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
+        dir
+    }
+
+    #[test]
+    fn load_returns_none_when_no_file() {
+        let dir = init_test_repo();
+        assert!(Checkpoint::load(dir.path()).unwrap().is_none());
+    }
+
+    #[test]
+    fn save_then_load_roundtrip() {
+        let dir = init_test_repo();
+        let mut cp = Checkpoint::new("abc123".to_string(), vec!["v1.0.0".to_string()]);
+        cp.advance(Phase::CommitDone);
+        cp.commit_sha = Some("def456".to_string());
+        cp.save(dir.path()).unwrap();
+        let loaded = Checkpoint::load(dir.path()).unwrap().unwrap();
+        assert_eq!(loaded.head_sha, "abc123");
+        assert_eq!(loaded.phase, Phase::CommitDone);
+        assert_eq!(loaded.commit_sha.as_deref(), Some("def456"));
+        assert_eq!(loaded.tag_names, vec!["v1.0.0".to_string()]);
+    }
+
+    #[test]
+    fn delete_removes_the_file() {
+        let dir = init_test_repo();
+        let cp = Checkpoint::new("abc".into(), vec![]);
+        cp.save(dir.path()).unwrap();
+        assert!(Checkpoint::path(dir.path()).exists());
+        Checkpoint::delete(dir.path()).unwrap();
+        assert!(!Checkpoint::path(dir.path()).exists());
+    }
+
+    #[test]
+    fn delete_when_absent_is_noop() {
+        let dir = init_test_repo();
+        Checkpoint::delete(dir.path()).expect("absent delete must be Ok");
+    }
+
+    #[test]
+    fn corrupt_file_surfaces_an_error() {
+        let dir = init_test_repo();
+        std::fs::write(Checkpoint::path(dir.path()), "{ not valid json").unwrap();
+        let err = Checkpoint::load(dir.path()).expect_err("parse error expected");
+        let msg = format!("{err:?}");
+        assert!(msg.contains("parse") || msg.contains("delete it manually"));
+    }
+
+    #[test]
+    fn schema_mismatch_is_rejected() {
+        let dir = init_test_repo();
+        let payload = r#"{
+            "schema_version": 999,
+            "head_sha": "abc",
+            "started_at": 0,
+            "phase": "pending",
+            "commit_sha": null,
+            "tag_names": []
+        }"#;
+        std::fs::write(Checkpoint::path(dir.path()), payload).unwrap();
+        let err = Checkpoint::load(dir.path()).expect_err("schema mismatch expected");
+        assert!(format!("{err:?}").contains("schema"));
+    }
+
+    #[test]
+    fn advance_only_moves_forward() {
+        let mut cp = Checkpoint::new("a".into(), vec![]);
+        cp.advance(Phase::TagsCreated);
+        assert_eq!(cp.phase, Phase::TagsCreated);
+        // Trying to "advance" back to a smaller phase is a no-op.
+        cp.advance(Phase::Pending);
+        assert_eq!(cp.phase, Phase::TagsCreated);
+    }
+
+    #[test]
+    fn phases_are_strictly_ordered() {
+        assert!(Phase::Pending < Phase::CommitDone);
+        assert!(Phase::CommitDone < Phase::TagsCreated);
+        assert!(Phase::TagsCreated < Phase::Pushed);
+        assert!(Phase::Pushed < Phase::ReleasesCreated);
+        assert!(Phase::ReleasesCreated < Phase::PostPublishDone);
+    }
+
+    #[test]
+    fn is_done_threshold_check() {
+        let mut cp = Checkpoint::new("a".into(), vec![]);
+        assert!(cp.is_done(Phase::Pending));
+        assert!(!cp.is_done(Phase::CommitDone));
+        cp.advance(Phase::TagsCreated);
+        assert!(cp.is_done(Phase::CommitDone));
+        assert!(cp.is_done(Phase::TagsCreated));
+        assert!(!cp.is_done(Phase::Pushed));
+    }
+
+    #[test]
+    fn save_is_atomic_via_tmp_rename() {
+        let dir = init_test_repo();
+        let cp = Checkpoint::new("a".into(), vec![]);
+        cp.save(dir.path()).unwrap();
+        // After save, no .tmp file is left behind.
+        let tmp = Checkpoint::path(dir.path()).with_extension("json.tmp");
+        assert!(!tmp.exists(), "tmp file should be cleaned up after rename");
+    }
+}

--- a/src/monorepo/run/execute.rs
+++ b/src/monorepo/run/execute.rs
@@ -14,6 +14,7 @@ use crate::hooks::{HookContext, HookPoint, resolve_hook, resolve_on_failure, run
 use crate::telemetry;
 use crate::versioning::truncate_version;
 
+use super::checkpoint::{Checkpoint, Phase};
 use super::summary::{TagToCreate, write_github_step_summary};
 use crate::monorepo::preview::build_forge_instance;
 use crate::monorepo::util::{auto_stage_new_files, collect_dirty_files};
@@ -40,6 +41,11 @@ pub(super) struct ReleasePlan<'a> {
     pub files_per_package: &'a mut HashMap<String, Vec<String>>,
     pub pkg_outputs: &'a mut Vec<(String, Vec<String>)>,
     pub shared_outputs: &'a mut Vec<String>,
+    /// Crash-resume marker, persisted at `.git/ferrflow.checkpoint.json`
+    /// as each phase succeeds. `None` on dry-run (we never write
+    /// anything in that mode) and on resumed runs that already finished
+    /// every phase. See #549.
+    pub checkpoint: Option<&'a mut Checkpoint>,
 }
 
 /// Run the commit / branch+PR / tag / floating-tag / forge-release /
@@ -72,28 +78,69 @@ pub(super) fn execute_release(plan: &mut ReleasePlan<'_>) -> Result<()> {
 
     if !plan.dry_run {
         let file_refs: Vec<&str> = files_snapshot.iter().map(String::as_str).collect();
-        run_commit_or_pr(
-            plan,
-            mode,
-            scope,
-            &file_refs,
-            &commit_msg,
-            &release_parts,
-            skip_ci,
-        )?;
-        create_release_tags(plan)?;
-        create_and_move_floating_tags(plan, &mut floating_tag_names)?;
+        if !checkpoint_is_done(plan, Phase::CommitDone) {
+            run_commit_or_pr(
+                plan,
+                mode,
+                scope,
+                &file_refs,
+                &commit_msg,
+                &release_parts,
+                skip_ci,
+            )?;
+            // Record HEAD post-commit so the checkpoint reflects the
+            // actual release commit (not the pre-bump HEAD we started
+            // from). Useful for debug + future resume sanity checks.
+            if let (Some(cp), Some(id)) = (plan.checkpoint.as_mut(), plan.repo.head_id().ok()) {
+                cp.commit_sha = Some(id.to_string());
+            }
+            checkpoint_advance(plan, Phase::CommitDone)?;
+        } else if plan.verbose {
+            eprintln!("  ↻ Resumed: skipping commit (already done)");
+        }
+        if !checkpoint_is_done(plan, Phase::TagsCreated) {
+            create_release_tags(plan)?;
+            create_and_move_floating_tags(plan, &mut floating_tag_names)?;
+            checkpoint_advance(plan, Phase::TagsCreated)?;
+        } else if plan.verbose {
+            eprintln!("  ↻ Resumed: skipping tag creation (already done)");
+        }
     }
 
     run_pre_publish_hooks(plan)?;
 
     if !plan.dry_run {
-        push_and_publish(plan, mode, &floating_tag_names)?;
+        if !checkpoint_is_done(plan, Phase::ReleasesCreated) {
+            push_and_publish(plan, mode, &floating_tag_names)?;
+            checkpoint_advance(plan, Phase::ReleasesCreated)?;
+        } else if plan.verbose {
+            eprintln!("  ↻ Resumed: skipping push + publish (already done)");
+        }
     }
 
     emit_release_telemetry(plan);
-    run_post_publish_hooks(plan)?;
+    if !checkpoint_is_done(plan, Phase::PostPublishDone) {
+        run_post_publish_hooks(plan)?;
+        checkpoint_advance(plan, Phase::PostPublishDone)?;
+    } else if plan.verbose {
+        eprintln!("  ↻ Resumed: skipping post-publish hooks (already done)");
+    }
 
+    Ok(())
+}
+
+fn checkpoint_is_done(plan: &ReleasePlan<'_>, phase: Phase) -> bool {
+    plan.checkpoint
+        .as_ref()
+        .map(|cp| cp.is_done(phase))
+        .unwrap_or(false)
+}
+
+fn checkpoint_advance(plan: &mut ReleasePlan<'_>, phase: Phase) -> Result<()> {
+    if let Some(cp) = plan.checkpoint.as_mut() {
+        cp.advance(phase);
+        cp.save(plan.root)?;
+    }
     Ok(())
 }
 

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -24,11 +24,13 @@ use super::util::{
 };
 
 mod cascade;
+mod checkpoint;
 mod drafts;
 mod execute;
 mod forced;
 mod lock;
 mod summary;
+use checkpoint::Checkpoint;
 use drafts::publish_pending_drafts;
 use execute::{ReleasePlan, execute_release, print_dry_run_hooks};
 use forced::{Forced, forced_version_for, parse_forced_version};
@@ -574,6 +576,50 @@ pub(super) fn run_release_logic(
     }
 
     if any_bumped && !tags_to_create.is_empty() {
+        // Crash-resume checkpoint (#549). On dry-run we record nothing
+        // — the run is read-only by design. Otherwise we either load an
+        // in-progress checkpoint left behind by a previous crash, or
+        // create a new one. HEAD-mismatch is fatal: an existing
+        // checkpoint pinned to a different commit means the repo state
+        // diverged from the in-flight release, and silently retrying
+        // would replay tags onto the wrong graph.
+        let head_sha = repo
+            .head_id()
+            .ok()
+            .map(|id| id.to_string())
+            .unwrap_or_default();
+        let tag_names: Vec<String> = tags_to_create
+            .iter()
+            .map(|(t, _, _, _, _, _, _)| t.clone())
+            .collect();
+        let mut checkpoint = if dry_run {
+            None
+        } else {
+            match Checkpoint::load(root)? {
+                Some(existing) if existing.head_sha == head_sha => {
+                    if verbose {
+                        eprintln!(
+                            "  ↻ Found in-progress release checkpoint at phase {:?}; resuming",
+                            existing.phase
+                        );
+                    }
+                    Some(existing)
+                }
+                Some(existing) => {
+                    return Err(anyhow::anyhow!(
+                        "found a stale release checkpoint at .git/ferrflow.checkpoint.json \
+                         pinned to commit {} but HEAD is now {}.\n  \
+                         Either reset HEAD back to {} and rerun to resume the previous release, \
+                         or delete .git/ferrflow.checkpoint.json to start fresh.",
+                        &existing.head_sha[..8.min(existing.head_sha.len())],
+                        &head_sha[..8.min(head_sha.len())],
+                        &existing.head_sha[..8.min(existing.head_sha.len())]
+                    ));
+                }
+                None => Some(Checkpoint::new(head_sha, tag_names)),
+            }
+        };
+
         let mut plan = ReleasePlan {
             repo: &repo,
             config,
@@ -589,8 +635,15 @@ pub(super) fn run_release_logic(
             files_per_package: &mut files_per_package,
             pkg_outputs: &mut pkg_outputs,
             shared_outputs: &mut shared_outputs,
+            checkpoint: checkpoint.as_mut(),
         };
         execute_release(&mut plan)?;
+        // Release finished cleanly — drop the checkpoint so the next
+        // run starts from scratch instead of trying to resume a
+        // finished release.
+        if !dry_run {
+            Checkpoint::delete(root)?;
+        }
     } else if dry_run && any_bumped {
         let plan = ReleasePlan {
             repo: &repo,
@@ -607,6 +660,7 @@ pub(super) fn run_release_logic(
             files_per_package: &mut files_per_package,
             pkg_outputs: &mut pkg_outputs,
             shared_outputs: &mut shared_outputs,
+            checkpoint: None,
         };
         print_dry_run_hooks(&plan)?;
     }


### PR DESCRIPTION
Closes #549.

Builds on #514's concurrency lock — that PR stopped two releases from racing each other; this one lets a single release **survive a crash** and pick up where it left off on the next run.

## How

A new `Checkpoint` (`src/monorepo/run/checkpoint.rs`) is persisted at `.git/ferrflow.checkpoint.json` and advances through a coarse phase sequence:

```
Pending → CommitDone → TagsCreated → Pushed → ReleasesCreated → PostPublishDone
```

After each phase finishes, the checkpoint is rewritten atomically (temp + rename). On the next `ferrflow release` invocation, if a checkpoint exists and **HEAD still matches the recorded commit**, FerrFlow loads it and skips every phase up to and including the recorded one — backed by the fact that the existing git/forge operations (`create_tag`, `create_or_move_tag`, `forge.create_release`) are already idempotent on their targets, so a partially-completed phase still recovers cleanly.

If HEAD moved between runs, FerrFlow refuses to resume and surfaces a clear error telling the user to reset HEAD back to the recorded commit or delete the checkpoint manually. This avoids the worst failure mode — replaying old tags onto a different commit graph.

On clean completion, the checkpoint is deleted so the next release starts from scratch.

## Why coarse phases instead of per-tag state

The release pipeline already groups related side effects (all tags created together, all tags pushed together, all releases created together). Tracking per-item state means duplicating the orchestration in two places, and a mid-batch crash inside any single step is rare in practice. Phase-level rewind, plus idempotent operations underneath, gives the right cost/value ratio for a v1.

## Scope

In:
- Checkpoint module with full save/load/delete + atomic write (tmp+rename), schema-version gating, corruption handling.
- Auto-resume on matching HEAD.
- Stale-HEAD detection with actionable error.
- Cleanup on success.
- Docs (EN + FR) added to \`ci/pipeline-triggers\`.

Out (explicit, follow-up):
- A \`--resume\` / \`--no-resume\` flag — auto-resume + manual delete is enough for v1, and \`--force-unlock\` from #514 doesn't touch the checkpoint by design (lock and checkpoint serve different roles).
- Finer per-tag state.

## Tests

10 new unit tests on the module: roundtrip, atomic-rename, absent-load is \`None\`, corrupt-file errors, schema-mismatch errors, phase ordering is strict, \`advance\` only moves forward, \`is_done\` threshold check, delete-when-absent is no-op.

\`cargo test --features cli\` → 524 lib + 652 bin all green. \`cargo clippy --features cli --all-targets -- -D warnings\` → clean.