### PR TITLE
fix(docs): correct hook env vars, schema enum, GitLab draft warning, --recover refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Add `$schema` to get autocompletion and validation in VS Code, WebStorm, and any
       "name": "my-app",
       "path": ".",
       "changelog": "CHANGELOG.md",
-      "versioned_files": [
+      "versionedFiles": [
         { "path": "package.json", "format": "json" }
       ]
     }
@@ -174,7 +174,7 @@ Add `$schema` to get autocompletion and validation in VS Code, WebStorm, and any
       name: "my-app",
       path: ".",
       changelog: "CHANGELOG.md",
-      versioned_files: [
+      versionedFiles: [
         { path: "package.json", format: "json" },
       ],
     },
@@ -211,8 +211,8 @@ format = "toml"
       "name": "api",
       "path": "services/api",
       "changelog": "services/api/CHANGELOG.md",
-      "shared_paths": ["services/shared/"],
-      "versioned_files": [
+      "sharedPaths": ["services/shared/"],
+      "versionedFiles": [
         { "path": "services/api/Cargo.toml", "format": "toml" }
       ]
     },
@@ -220,7 +220,7 @@ format = "toml"
       "name": "frontend",
       "path": "frontend",
       "changelog": "frontend/CHANGELOG.md",
-      "versioned_files": [
+      "versionedFiles": [
         { "path": "frontend/package.json", "format": "json" }
       ]
     }

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -64,7 +64,10 @@ impl Forge for GitLabForge {
         if draft {
             eprintln!(
                 "{}",
-                "Warning: GitLab does not support draft releases, creating as published".yellow()
+                "Warning: --draft is not supported on GitLab. The release will be created as \
+                 published immediately. Use a tag-protected branch or a manual approval gate if \
+                 you need a review step before publishing."
+                    .yellow()
             );
         }
 


### PR DESCRIPTION
Batched quick-win fixes from the audit:

- **#551** — README hooks section listed `FERRFLOW_VERSION` and `FERRFLOW_PREV_VERSION`, but `hooks/runner.rs` actually exports `FERRFLOW_OLD_VERSION` and `FERRFLOW_NEW_VERSION` (plus `FERRFLOW_BUMP_TYPE`, `FERRFLOW_TAG`, `FERRFLOW_PACKAGE_PATH`, `FERRFLOW_DRY_RUN`). Fixed and linked to the full doc table.
- **#552** — JSON Schema `versionedFiles.format` enum was missing 5 of the 13 supported formats: `pubspecyaml`, `mixexs`, `chartyaml`, `gemspec`, `packageswift`. Added, then mirrored to `FerrFlow-Cloud/packages/site/public/schema/ferrflow.json` per CLAUDE.md byte-parity rule.
- **#553 (--recover ref)** — `src/git/push.rs:373-378` pointed users at `ferrflow release --recover`, a flag that doesn't exist. Replaced with a pointer to the crash-resume docs and `--force-unlock`.
- **#553 (GitLab draft)** — the silent draft-degradation warning was a one-liner. Expanded it to explain that the release is created as published immediately and what alternative gates exist.
- **#553 (README casing)** — README JSON/JSON5 examples used snake_case (`versioned_files`, `shared_paths`) which the schema rejects under `additionalProperties: false`. Normalized to camelCase. TOML examples keep snake_case (TOML convention).

No behaviour change; cargo build clean.