### PR TITLE
fix(changelog): align categorization with bump parser, keep refactor section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,7 +622,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "5.3.0"
+version = "5.3.2"
 dependencies = [
  "anyhow",
  "cargo-husky",

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "cli")]
 use crate::conventional_commits::determine_bump;
-use crate::conventional_commits::{BumpType, CommitClass, classify, parse_subject};
+use crate::conventional_commits::{BumpType, CommitCategory, classify_commit, parse_subject};
 use anyhow::Result;
 use chrono::Local;
 use std::path::Path;
@@ -101,18 +101,24 @@ pub fn generate_only(config_path: Option<&Path>, dry_run: bool) -> Result<()> {
 
 pub fn build_section(new_version: &str, commits: &[GitLog]) -> String {
     let date = Local::now().format("%Y-%m-%d").to_string();
+    let mut breaking = Vec::new();
     let mut features = Vec::new();
     let mut fixes = Vec::new();
-    let mut breaking = Vec::new();
+    let mut refactors = Vec::new();
 
+    // Reuse the same classifier that drives `determine_bump` so the
+    // changelog can never label a release "Breaking Changes" while the
+    // bump engine computed a minor — and so `refactor:` commits, which
+    // are Patch in the bump engine, no longer disappear from the
+    // rendered section. See #525.
     for commit in commits {
         let subject = parse_subject(&commit.message);
-
-        match classify(&commit.message) {
-            CommitClass::Breaking => breaking.push(format!("- {subject}")),
-            CommitClass::Feature => features.push(format!("- {subject}")),
-            CommitClass::Fix => fixes.push(format!("- {subject}")),
-            CommitClass::Other => {}
+        match classify_commit(&commit.message) {
+            CommitCategory::Breaking => breaking.push(format!("- {subject}")),
+            CommitCategory::Feature => features.push(format!("- {subject}")),
+            CommitCategory::Fix => fixes.push(format!("- {subject}")),
+            CommitCategory::Refactor => refactors.push(format!("- {subject}")),
+            CommitCategory::Other => {}
         }
     }
 
@@ -131,6 +137,11 @@ pub fn build_section(new_version: &str, commits: &[GitLog]) -> String {
     if !fixes.is_empty() {
         section.push_str("\n### Bug Fixes\n\n");
         section.push_str(&fixes.join("\n"));
+        section.push('\n');
+    }
+    if !refactors.is_empty() {
+        section.push_str("\n### Refactoring\n\n");
+        section.push_str(&refactors.join("\n"));
         section.push('\n');
     }
 
@@ -315,7 +326,11 @@ mod tests {
     }
 
     #[test]
-    fn build_section_refactor_chore_excluded() {
+    fn build_section_chore_docs_excluded_refactor_kept() {
+        // chore/docs/ci/style/test/build don't bump and don't appear in
+        // the user-facing changelog. refactor: DOES bump (patch) and
+        // must appear, otherwise a release shows up with an empty
+        // changelog section. See #525.
         let commits = make_commits(&[
             "refactor: clean up",
             "chore: update deps",
@@ -329,6 +344,29 @@ mod tests {
         assert!(!section.contains("### Features"));
         assert!(!section.contains("### Bug Fixes"));
         assert!(!section.contains("### Breaking Changes"));
+        assert!(
+            section.contains("### Refactoring"),
+            "refactor: must render its own section, not be silently dropped"
+        );
+        assert!(section.contains("- refactor: clean up"));
+        assert!(!section.contains("chore: update deps"));
+        assert!(!section.contains("docs: update readme"));
+        assert!(!section.contains("ci: fix pipeline"));
+        assert!(!section.contains("style: format code"));
+        assert!(!section.contains("test: add tests"));
+        assert!(!section.contains("build: update config"));
+    }
+
+    #[test]
+    fn build_section_does_not_misclassify_feature_word() {
+        // `feature:` (no colon-delimited type) and `feat add` (no colon)
+        // are not the conventional `feat:` type and must not appear as
+        // features.
+        let commits = make_commits(&["feature: misnamed type", "feat add no colon"]);
+        let section = build_section("1.0.1", &commits);
+        assert!(!section.contains("### Features"));
+        assert!(!section.contains("misnamed type"));
+        assert!(!section.contains("no colon"));
     }
 
     #[test]

--- a/src/conventional_commits.rs
+++ b/src/conventional_commits.rs
@@ -22,7 +22,6 @@ impl std::fmt::Display for BumpType {
 
 static BREAKING_RE: OnceLock<Regex> = OnceLock::new();
 static FEAT_RE: OnceLock<Regex> = OnceLock::new();
-static PATCH_RE: OnceLock<Regex> = OnceLock::new();
 
 fn breaking_header_re() -> &'static Regex {
     BREAKING_RE.get_or_init(|| {
@@ -34,58 +33,70 @@ fn feat_header_re() -> &'static Regex {
     FEAT_RE.get_or_init(|| Regex::new(r"^feat(\(.+\))?:").unwrap())
 }
 
-fn patch_header_re() -> &'static Regex {
-    PATCH_RE.get_or_init(|| Regex::new(r"^(fix|perf|refactor)(\(.+\))?:").unwrap())
-}
-
 static BREAKING_FOOTER_RE: OnceLock<Regex> = OnceLock::new();
 
 fn breaking_footer_re() -> &'static Regex {
     BREAKING_FOOTER_RE.get_or_init(|| Regex::new(r"(?m)^BREAKING[ -]CHANGE:").unwrap())
 }
 
-static FIX_RE: OnceLock<Regex> = OnceLock::new();
-
-fn fix_header_re() -> &'static Regex {
-    FIX_RE.get_or_init(|| Regex::new(r"^(fix|perf)(\(.+\))?:").unwrap())
+pub fn determine_bump(message: &str) -> BumpType {
+    match classify_commit(message) {
+        CommitCategory::Breaking => BumpType::Major,
+        CommitCategory::Feature => BumpType::Minor,
+        CommitCategory::Fix | CommitCategory::Refactor => BumpType::Patch,
+        CommitCategory::Other => BumpType::None,
+    }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum CommitClass {
+/// Author-facing categorization of a single commit. Drives both the
+/// version bump (via [`determine_bump`]) and changelog section grouping,
+/// so the two can't disagree the way they used to. See #525.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommitCategory {
+    /// `feat!:`, `fix(scope)!:`, etc. or a `BREAKING CHANGE:` footer.
     Breaking,
+    /// `feat:` or `feat(scope):` (and not breaking).
     Feature,
+    /// `fix:` / `perf:` — patch-bumping bug or performance changes.
     Fix,
+    /// `refactor:` — patch-bumping internal restructuring. Distinct
+    /// from `Fix` so the changelog can render it as its own section
+    /// (the prior code dropped refactor commits entirely from the
+    /// changelog while still letting them trigger a release).
+    Refactor,
+    /// `chore:` / `docs:` / `ci:` / `style:` / `test:` / `build:` or any
+    /// non-conventional message. Doesn't bump and shouldn't appear in
+    /// the user-facing changelog.
     Other,
 }
 
-pub fn classify(message: &str) -> CommitClass {
+pub fn classify_commit(message: &str) -> CommitCategory {
     let header = parse_subject(message);
 
     if breaking_header_re().is_match(header) || breaking_footer_re().is_match(message) {
-        return CommitClass::Breaking;
+        return CommitCategory::Breaking;
     }
     if feat_header_re().is_match(header) {
-        return CommitClass::Feature;
+        return CommitCategory::Feature;
     }
-    if fix_header_re().is_match(header) {
-        return CommitClass::Fix;
+    if fix_perf_header_re().is_match(header) {
+        return CommitCategory::Fix;
     }
-    CommitClass::Other
+    if refactor_header_re().is_match(header) {
+        return CommitCategory::Refactor;
+    }
+    CommitCategory::Other
 }
 
-pub fn determine_bump(message: &str) -> BumpType {
-    let header = parse_subject(message);
+static FIX_PERF_RE: OnceLock<Regex> = OnceLock::new();
+static REFACTOR_RE: OnceLock<Regex> = OnceLock::new();
 
-    if breaking_header_re().is_match(header) || breaking_footer_re().is_match(message) {
-        return BumpType::Major;
-    }
-    if feat_header_re().is_match(header) {
-        return BumpType::Minor;
-    }
-    if patch_header_re().is_match(header) {
-        return BumpType::Patch;
-    }
-    BumpType::None
+fn fix_perf_header_re() -> &'static Regex {
+    FIX_PERF_RE.get_or_init(|| Regex::new(r"^(fix|perf)(\(.+\))?:").unwrap())
+}
+
+fn refactor_header_re() -> &'static Regex {
+    REFACTOR_RE.get_or_init(|| Regex::new(r"^refactor(\(.+\))?:").unwrap())
 }
 
 pub fn parse_subject(message: &str) -> &str {


### PR DESCRIPTION
Closes #525. Also closes the matching item in #553 (changelog naive substring matching).

## What was wrong

\`build_section\` used ad-hoc string checks (\`message.contains(\"BREAKING CHANGE\")\`, \`first_line.starts_with(\"feat\")\`) that disagreed with the authoritative parser in \`determine_bump\`:

1. **\`refactor:\` was silently dropped.** \`determine_bump\` treats \`refactor\` as a patch bump, but \`build_section\` had no branch for it — so a release triggered by a lone refactor commit produced a real version bump with an **empty changelog section** (just the header, no entries).
2. **Categorization could disagree with the bump engine.** Body prose containing \"BREAKING CHANGE\" anywhere → \"Breaking Changes\" header. \`first_line.starts_with(\"feat\")\` matched \`feature: …\` and \`feat add\` (no colon) as features.

## Fix

Introduced \`CommitCategory\` + \`classify_commit\` in \`conventional_commits.rs\`. \`determine_bump\` and \`build_section\` now share that single classifier — they can't drift apart again.

- New category \`Refactor\` → renders as its own \"### Refactoring\" section.
- \`Fix\` covers \`fix:\` / \`perf:\` (already in changelog as \"Bug Fixes\").
- \`Feature\` is strictly the anchored \`^feat(\(.+\))?:\` regex, so \`feature:\` / \`feat add\` no longer leak in.

The bump engine is unchanged for any commit type that already had a category — refactor still yields patch, breaking still yields major, etc. Only the changelog rendering grew the missing branch.

## Tests

- Refactor commit produces a \"### Refactoring\" section (was previously empty).
- chore/docs/ci/style/test/build still don't render.
- \`feature: …\` / \`feat add …\` not categorized as features.
- Existing breaking-change and mixed-commits tests still pass.

`cargo test --features cli --lib changelog` → 18/18. `cargo clippy --features cli --all-targets -- -D warnings` → clean.

## Note vs #550

The prose-mention bug (\"BREAKING CHANGES are coming\" wrongly bumping major) is fixed in #558 (the regex tightening). The two PRs are orthogonal — this PR uses whatever \`breaking_footer_re\` returns; #558 fixes the regex itself.