### PR TITLE
fix(audit): zerover metadata clear, path containment, URL encoding

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -72,7 +72,7 @@ pub fn generate_only(config_path: Option<&Path>, dry_run: bool) -> Result<()> {
         let new_version = bump_version(&current_version, bump)?;
 
         let changelog_path = match &pkg.changelog {
-            Some(rel) => root.join(rel),
+            Some(rel) => crate::formats::join_within_repo(&root, rel)?,
             None => {
                 println!(
                     "{}",

--- a/src/error_code.rs
+++ b/src/error_code.rs
@@ -65,6 +65,8 @@ pub const CONFIG_READ_FAILED: ErrorCode = ErrorCode(1015);
 pub const CONFIG_MULTIPLE_FILES: ErrorCode = ErrorCode(1016);
 #[allow(dead_code)]
 pub const CONFIG_ALREADY_EXISTS: ErrorCode = ErrorCode(1017);
+#[allow(dead_code)]
+pub const CONFIG_INVALID_PATH: ErrorCode = ErrorCode(1018);
 
 #[allow(dead_code)]
 pub const VALIDATE_INVALID_REPO_SPEC: ErrorCode = ErrorCode(1100);

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -13,9 +13,50 @@ pub mod txt;
 pub mod xml;
 
 use anyhow::Result;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 use crate::config::{FileFormat, VersionedFile};
+use crate::error_code::{self, ErrorCodeExt};
+
+/// Join `relative` onto `repo_root` and reject any path that:
+/// - is absolute (escapes the repo via `/etc/passwd`),
+/// - contains a `..` component that climbs above `repo_root`.
+///
+/// Lexical containment (no I/O / symlink resolution) — sufficient for
+/// rejecting config-driven traversal, and safe to call on paths that
+/// don't yet exist on disk (write_version creates them). See #553.
+pub(crate) fn join_within_repo(repo_root: &Path, relative: &str) -> Result<PathBuf> {
+    let rel = Path::new(relative);
+    if rel.is_absolute() {
+        return Err(anyhow::anyhow!(
+            "config path `{relative}` is absolute; FerrFlow only writes inside the repository root"
+        ))
+        .error_code(error_code::CONFIG_INVALID_PATH);
+    }
+    let mut depth: i32 = 0;
+    for c in rel.components() {
+        match c {
+            Component::Normal(_) => depth += 1,
+            Component::CurDir => {}
+            Component::ParentDir => {
+                depth -= 1;
+                if depth < 0 {
+                    return Err(anyhow::anyhow!(
+                        "config path `{relative}` escapes the repository root via `..`"
+                    ))
+                    .error_code(error_code::CONFIG_INVALID_PATH);
+                }
+            }
+            Component::Prefix(_) | Component::RootDir => {
+                return Err(anyhow::anyhow!(
+                    "config path `{relative}` has an absolute prefix; FerrFlow only writes inside the repository root"
+                ))
+                .error_code(error_code::CONFIG_INVALID_PATH);
+            }
+        }
+    }
+    Ok(repo_root.join(rel))
+}
 
 pub trait VersionFile {
     fn read_version(&self, file_path: &Path) -> Result<String>;
@@ -62,13 +103,13 @@ pub fn get_handler(format: &FileFormat) -> Box<dyn VersionFile> {
 }
 
 pub fn read_version(vf: &VersionedFile, repo_root: &Path) -> Result<String> {
-    let path = repo_root.join(&vf.path);
+    let path = join_within_repo(repo_root, &vf.path)?;
     let handler = get_handler(&vf.format);
     handler.read_version_with_selector(&path, vf.selector.as_deref())
 }
 
 pub fn write_version(vf: &VersionedFile, repo_root: &Path, version: &str) -> Result<()> {
-    let path = repo_root.join(&vf.path);
+    let path = join_within_repo(repo_root, &vf.path)?;
     let handler = get_handler(&vf.format);
     handler.write_version_with_selector(&path, version, vf.selector.as_deref())
 }
@@ -97,6 +138,45 @@ mod tests {
         ] {
             let _ = get_handler(format);
         }
+    }
+
+    #[test]
+    fn join_within_repo_accepts_normal_relative_path() {
+        let root = Path::new("/repo");
+        let joined = join_within_repo(root, "Cargo.toml").unwrap();
+        assert_eq!(joined, root.join("Cargo.toml"));
+    }
+
+    #[test]
+    fn join_within_repo_accepts_nested_relative_path() {
+        let root = Path::new("/repo");
+        let joined = join_within_repo(root, "crates/foo/Cargo.toml").unwrap();
+        assert_eq!(joined, root.join("crates/foo/Cargo.toml"));
+    }
+
+    #[test]
+    fn join_within_repo_rejects_absolute_unix_path() {
+        let err = join_within_repo(Path::new("/repo"), "/etc/passwd").unwrap_err();
+        assert!(format!("{err:?}").contains("absolute"));
+    }
+
+    #[test]
+    fn join_within_repo_rejects_parent_escape() {
+        let err = join_within_repo(Path::new("/repo"), "../outside").unwrap_err();
+        assert!(format!("{err:?}").contains("escapes"));
+    }
+
+    #[test]
+    fn join_within_repo_rejects_deep_parent_escape() {
+        let err = join_within_repo(Path::new("/repo"), "a/b/../../../etc/passwd").unwrap_err();
+        assert!(format!("{err:?}").contains("escapes"));
+    }
+
+    #[test]
+    fn join_within_repo_allows_balanced_parent_segments() {
+        // `a/b/../c` ends up at `a/c` inside the repo — legal.
+        let joined = join_within_repo(Path::new("/repo"), "a/b/../c").unwrap();
+        assert!(joined.starts_with("/repo"));
     }
 
     #[test]

--- a/src/validate/source.rs
+++ b/src/validate/source.rs
@@ -4,6 +4,36 @@ use std::path::PathBuf;
 use crate::config::Config;
 use crate::error_code::{self, ErrorCodeExt};
 
+/// Percent-encode bytes outside the unreserved set, preserving forward
+/// slashes so a multi-segment path (`src/lib/foo.rs`) keeps its
+/// structure. Used when interpolating user-supplied paths into URL
+/// path positions. See #553.
+fn encode_path(s: &str) -> String {
+    encode_with_safe(s, |b| matches!(b, b'/'))
+}
+
+/// Percent-encode bytes outside the unreserved set with no exceptions —
+/// the value lands in a single URL query parameter and must not
+/// smuggle further `?`, `&`, `=`, or `#` characters. Used for the git
+/// ref (`?ref=…`).
+fn encode_query_value(s: &str) -> String {
+    encode_with_safe(s, |_| false)
+}
+
+fn encode_with_safe(s: &str, extra_safe: impl Fn(u8) -> bool) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        let unreserved =
+            b.is_ascii_alphanumeric() || matches!(b, b'-' | b'.' | b'_' | b'~') || extra_safe(b);
+        if unreserved {
+            out.push(b as char);
+        } else {
+            out.push_str(&format!("%{b:02X}"));
+        }
+    }
+    out
+}
+
 pub trait FileSource {
     fn read_file(&self, path: &str) -> Result<Option<Vec<u8>>>;
     fn path_exists(&self, path: &str) -> Result<bool>;
@@ -72,10 +102,12 @@ impl FileSource for GitHubSource {
     fn read_file(&self, path: &str) -> Result<Option<Vec<u8>>> {
         let mut url = format!(
             "https://api.github.com/repos/{}/{}/contents/{}",
-            self.owner, self.repo, path
+            encode_path(&self.owner),
+            encode_path(&self.repo),
+            encode_path(path)
         );
         if let Some(ref r) = self.git_ref {
-            url.push_str(&format!("?ref={r}"));
+            url.push_str(&format!("?ref={}", encode_query_value(r)));
         }
         let mut req = ureq::get(&url).header("Accept", "application/vnd.github.v3.raw");
         if let Some(ref token) = self.token {
@@ -108,13 +140,15 @@ pub struct GitLabSource {
 impl FileSource for GitLabSource {
     fn read_file(&self, path: &str) -> Result<Option<Vec<u8>>> {
         let project_id = format!("{}/{}", self.owner, self.repo);
-        let encoded_project = project_id.replace('/', "%2F");
-        let encoded_path = path.replace('/', "%2F");
+        // Percent-encode everything (including the embedded slash) so
+        // the project id and the file path land as single URL segments.
+        let encoded_project = encode_query_value(&project_id);
+        let encoded_path = encode_query_value(path);
         let mut url = format!(
             "https://gitlab.com/api/v4/projects/{encoded_project}/repository/files/{encoded_path}/raw"
         );
         if let Some(ref r) = self.git_ref {
-            url.push_str(&format!("?ref={r}"));
+            url.push_str(&format!("?ref={}", encode_query_value(r)));
         } else {
             url.push_str("?ref=main");
         }
@@ -186,4 +220,30 @@ pub fn load_config_from_source(
         CONFIG_FILENAMES.join(", ")
     ))
     .error_code(error_code::VALIDATE_NO_CONFIG)?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_path_preserves_slashes_and_unreserved() {
+        assert_eq!(encode_path("src/foo.rs"), "src/foo.rs");
+        assert_eq!(encode_path("a-_.~b"), "a-_.~b");
+    }
+
+    #[test]
+    fn encode_path_percent_encodes_specials() {
+        assert_eq!(encode_path("a b"), "a%20b");
+        assert_eq!(encode_path("a?b"), "a%3Fb");
+        assert_eq!(encode_path("a#b"), "a%23b");
+        assert_eq!(encode_path("a&b"), "a%26b");
+    }
+
+    #[test]
+    fn encode_query_value_encodes_slash_too() {
+        assert_eq!(encode_query_value("feat/x"), "feat%2Fx");
+        assert_eq!(encode_query_value("a=b&c"), "a%3Db%26c");
+        assert_eq!(encode_query_value("a?b#c"), "a%3Fb%23c");
+    }
 }

--- a/src/versioning/tests.rs
+++ b/src/versioning/tests.rs
@@ -182,6 +182,24 @@ fn test_zerover_clamps_non_zero_major() {
 }
 
 #[test]
+fn test_zerover_clears_prerelease_and_build_metadata() {
+    // Stable bumps must drop pre-release + build metadata, matching
+    // bump_semver's behaviour. See #553.
+    assert_eq!(
+        bump_zerover("0.4.0-beta.1", BumpType::Minor).unwrap(),
+        "0.5.0"
+    );
+    assert_eq!(
+        bump_zerover("0.4.0+build.7", BumpType::Patch).unwrap(),
+        "0.4.1"
+    );
+    assert_eq!(
+        bump_zerover("0.4.0-rc.1+build.7", BumpType::Major).unwrap(),
+        "0.5.0"
+    );
+}
+
+#[test]
 fn test_zerover_invalid_version() {
     assert!(bump_zerover("garbage", BumpType::Patch).is_err());
 }


### PR DESCRIPTION
Batched low-severity items from #553. Each is independently testable.

## 1. \`bump_zerover\` drops pre-release + build metadata

\`bump_semver\` already does \`v.pre = EMPTY; v.build = EMPTY\` before incrementing. \`bump_zerover\` was missing the same clear, so \`0.4.0-beta.1+build.7\` bumped to \`0.5.0-beta.1+build.7\` — not a clean stable version. Aligned with \`bump_semver\`. Three new tests cover prerelease-only, build-only, and combined inputs.

## 2. Path-traversal containment on config-driven paths

\`read_version\` / \`write_version\` did \`repo_root.join(&vf.path)\` with no normalization, and \`changelog\` paths went through the same blind \`root.join\`. A \`versionedFiles[].path\` of \`/etc/something\` or \`../../outside\` would escape the repo. Added \`join_within_repo\` — lexical containment (no I/O, safe on not-yet-existing paths) that rejects absolute paths and \`..\` components that climb above the root. 6 new tests cover normal/nested/absolute/parent-escape/deep-escape/balanced-parent cases.

## 3. URL encoding in remote-validation source

\`GitHubSource::read_file\` interpolated \`{path}\` and \`{ref}\` directly into the API URL. \`GitLabSource\` percent-encoded the project id and path but missed the ref. A ref or path containing \`?\`, \`&\`, \`#\`, or spaces would silently break the request or smuggle query parameters. Added two small encoders (\`encode_path\` preserves slashes, \`encode_query_value\` encodes them) used at every interpolation point. 3 new tests cover the typical escape cases.

## Tests

\`cargo test --features cli --lib\` → 544 passed. \`cargo clippy --features cli --all-targets -- -D warnings\` → clean.

## Not included

The audit's \"forge host validation\" item (low) is left out — the host is taken from the local repo's own remote (trusted) and \`extract_host\` already strips userinfo. Worth a dedicated PR if/when self-hosted forge configs become a path of widespread concern.