### PR TITLE
fix: require colon delimiter in BREAKING CHANGE footer to stop spurious major bumps

### DIFF
--- a/src/conventional_commits.rs
+++ b/src/conventional_commits.rs
@@ -41,7 +41,7 @@ fn patch_header_re() -> &'static Regex {
 static BREAKING_FOOTER_RE: OnceLock<Regex> = OnceLock::new();
 
 fn breaking_footer_re() -> &'static Regex {
-    BREAKING_FOOTER_RE.get_or_init(|| Regex::new(r"(?m)^BREAKING CHANGE").unwrap())
+    BREAKING_FOOTER_RE.get_or_init(|| Regex::new(r"(?m)^BREAKING[ -]CHANGE:").unwrap())
 }
 
 pub fn determine_bump(message: &str) -> BumpType {
@@ -122,6 +122,24 @@ mod tests {
     fn test_breaking_change_in_body() {
         let msg = "feat: something\n\nBREAKING CHANGE: removed old API";
         assert_eq!(determine_bump(msg), BumpType::Major);
+    }
+
+    #[test]
+    fn test_breaking_change_hyphen_footer() {
+        let msg = "feat: something\n\nBREAKING-CHANGE: removed old API";
+        assert_eq!(determine_bump(msg), BumpType::Major);
+    }
+
+    #[test]
+    fn test_breaking_change_prose_is_not_major() {
+        assert_eq!(
+            determine_bump("docs: note that BREAKING CHANGES are coming in v2"),
+            BumpType::None
+        );
+        let body = "feat: add flag\n\nBREAKING CHANGE will be handled later, not yet";
+        assert_eq!(determine_bump(body), BumpType::Minor);
+        let plural = "chore: cleanup\n\nBREAKING CHANGES: none in this one";
+        assert_eq!(determine_bump(plural), BumpType::None);
     }
 
     #[test]


### PR DESCRIPTION
Closes #550.

`breaking_footer_re()` was `(?m)^BREAKING CHANGE` — it matched any line merely *starting* with the words "BREAKING CHANGE", with no required colon, so prose like `BREAKING CHANGES are coming in v2` or `BREAKING CHANGE will be handled later` forced a spurious **major** bump (`determine_bump` ORs the footer match across the whole message).

Tightened to `(?m)^BREAKING[ -]CHANGE:` — requires the spec delimiter colon and also accepts the `BREAKING-CHANGE:` hyphen synonym mandated by the Conventional Commits spec, which the old regex missed entirely.

Tests added: hyphen footer still bumps major; `BREAKING CHANGES are coming`, `BREAKING CHANGE will be handled later` (no colon), and `BREAKING CHANGES:` (plural) no longer bump major. Full suite green locally.