### PR TITLE
fix: add the 5 missing file formats to the JSON schema format enum

### DIFF
--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -164,7 +164,21 @@
                 "format": {
                   "type": "string",
                   "description": "File format used to locate and update the version field.",
-                  "enum": ["csproj", "toml", "json", "xml", "gradle", "gomod", "helm", "txt"]
+                  "enum": [
+                    "csproj",
+                    "toml",
+                    "json",
+                    "xml",
+                    "gradle",
+                    "gomod",
+                    "helm",
+                    "chartyaml",
+                    "pubspecyaml",
+                    "mixexs",
+                    "gemspec",
+                    "packageswift",
+                    "txt"
+                  ]
                 },
                 "selector": {
                   "type": "string",


### PR DESCRIPTION
Closes #552.

The versionedFiles `format` enum listed only 8 of the 13 formats the CLI supports — it omitted `chartyaml`, `pubspecyaml`, `mixexs`, `gemspec`, and `packageswift`. Since users are told to reference `https://ferrflow.com/schema/ferrflow.json` for editor validation, anyone configuring a Ruby gem, Dart, Elixir, Helm Chart.yaml, or Swift package got a false red-squiggle even though the CLI accepts the value.

Added the 5 missing values; verified they match the `FileFormat` serde names in `src/config/package.rs` exactly (all 13 now present).

Note: the served copy at `FerrFlow-Cloud/packages/site/public/schema/ferrflow.json` must stay byte-identical — a follow-up PR there syncs it (separate repo, separate PR).