### PR TITLE
fix: correct changelog classification, zerover metadata, and stale recover hint

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "cli")]
 use crate::conventional_commits::determine_bump;
-use crate::conventional_commits::{BumpType, parse_subject};
+use crate::conventional_commits::{BumpType, CommitClass, classify, parse_subject};
 use anyhow::Result;
 use chrono::Local;
 use std::path::Path;
@@ -107,14 +107,12 @@ pub fn build_section(new_version: &str, commits: &[GitLog]) -> String {
 
     for commit in commits {
         let subject = parse_subject(&commit.message);
-        let first_line = commit.message.lines().next().unwrap_or("").to_lowercase();
 
-        if commit.message.contains("BREAKING CHANGE") || first_line.contains("!:") {
-            breaking.push(format!("- {subject}"));
-        } else if first_line.starts_with("feat") {
-            features.push(format!("- {subject}"));
-        } else if first_line.starts_with("fix") || first_line.starts_with("perf") {
-            fixes.push(format!("- {subject}"));
+        match classify(&commit.message) {
+            CommitClass::Breaking => breaking.push(format!("- {subject}")),
+            CommitClass::Feature => features.push(format!("- {subject}")),
+            CommitClass::Fix => fixes.push(format!("- {subject}")),
+            CommitClass::Other => {}
         }
     }
 
@@ -238,6 +236,19 @@ mod tests {
         assert!(section.contains("### Features"));
         assert!(section.contains("### Bug Fixes"));
         assert!(!section.contains("chore: update deps"));
+    }
+
+    #[test]
+    fn build_section_does_not_misclassify_prose() {
+        let commits = make_commits(&[
+            "fix: handle the !: token in the parser",
+            "features added without a conventional prefix",
+        ]);
+        let section = build_section("1.0.1", &commits);
+        assert!(section.contains("### Bug Fixes"));
+        assert!(section.contains("- fix: handle the !: token in the parser"));
+        assert!(!section.contains("### Breaking Changes"));
+        assert!(!section.contains("### Features"));
     }
 
     #[test]

--- a/src/conventional_commits.rs
+++ b/src/conventional_commits.rs
@@ -44,6 +44,35 @@ fn breaking_footer_re() -> &'static Regex {
     BREAKING_FOOTER_RE.get_or_init(|| Regex::new(r"(?m)^BREAKING CHANGE").unwrap())
 }
 
+static FIX_RE: OnceLock<Regex> = OnceLock::new();
+
+fn fix_header_re() -> &'static Regex {
+    FIX_RE.get_or_init(|| Regex::new(r"^(fix|perf)(\(.+\))?:").unwrap())
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum CommitClass {
+    Breaking,
+    Feature,
+    Fix,
+    Other,
+}
+
+pub fn classify(message: &str) -> CommitClass {
+    let header = parse_subject(message);
+
+    if breaking_header_re().is_match(header) || breaking_footer_re().is_match(message) {
+        return CommitClass::Breaking;
+    }
+    if feat_header_re().is_match(header) {
+        return CommitClass::Feature;
+    }
+    if fix_header_re().is_match(header) {
+        return CommitClass::Fix;
+    }
+    CommitClass::Other
+}
+
 pub fn determine_bump(message: &str) -> BumpType {
     let header = parse_subject(message);
 

--- a/src/git/push.rs
+++ b/src/git/push.rs
@@ -372,8 +372,8 @@ pub(super) fn fetch_and_rebase(repo: &Repository, remote_name: &str, branch: &st
         None => {
             return Err(anyhow!(
                 "Refusing to rebase: HEAD is detached. Check out '{branch}' before retrying. \
-                 (To recover an in-progress release, use `ferrflow release --recover` or reset \
-                 the branch manually.)"
+                 (If a previous release left a stale lock, clear it with `ferrflow release \
+                 --force-unlock`, or reset the branch manually.)"
             ));
         }
     }

--- a/src/versioning/strategies.rs
+++ b/src/versioning/strategies.rs
@@ -78,6 +78,9 @@ pub(super) fn bump_zerover(current: &str, bump: BumpType) -> Result<String> {
         .map_err(|e| anyhow::anyhow!("Invalid semver '{}': {}", current, e))
         .error_code(error_code::VERSIONING_INVALID_SEMVER)?;
 
+    v.pre = semver::Prerelease::EMPTY;
+    v.build = semver::BuildMetadata::EMPTY;
+
     match bump {
         BumpType::Major => {
             v.minor += 1;
@@ -95,4 +98,27 @@ pub(super) fn bump_zerover(current: &str, bump: BumpType) -> Result<String> {
 
     v.major = 0;
     Ok(v.to_string())
+}
+
+#[cfg(test)]
+mod zerover_tests {
+    use super::*;
+
+    #[test]
+    fn zerover_clears_prerelease_and_build_metadata() {
+        assert_eq!(
+            bump_zerover("0.4.0-beta.1+build", BumpType::Minor).unwrap(),
+            "0.5.0"
+        );
+        assert_eq!(
+            bump_zerover("0.4.0-rc.2", BumpType::Patch).unwrap(),
+            "0.4.1"
+        );
+    }
+
+    #[test]
+    fn zerover_keeps_major_at_zero() {
+        assert_eq!(bump_zerover("0.3.5", BumpType::Major).unwrap(), "0.4.0");
+        assert_eq!(bump_zerover("1.2.3", BumpType::Minor).unwrap(), "0.3.0");
+    }
 }


### PR DESCRIPTION
Addresses three medium/low audit findings tracked in #553.

**Changelog mis-bucketing (medium, bug)** — `build_section` used ad-hoc `message.contains("BREAKING CHANGE")` / `first_line.contains("!:")` / `starts_with("feat")`, so prose mentioning "BREAKING CHANGE", a subject like `fix: handle the !: token`, or a non-conventional `features added` were mis-bucketed. Classification now goes through one source of truth: a new `conventional_commits::classify()` (Breaking/Feature/Fix/Other) reusing the same header/footer regexes as `determine_bump`. Behaviour preserved (refactor/chore/docs excluded; fix+perf → Bug Fixes).

**`bump_zerover` kept pre-release/build metadata (low, bug)** — unlike `bump_semver` it didn't reset `v.pre`/`v.build`, so `0.4.0-beta.1+build` bumped to `0.5.0-beta.1+build`. Now cleared first.

**Stale `--recover` hint (medium, ux)** — the detached-HEAD error pointed at `ferrflow release --recover`, a non-existent flag. Now points at the real lever `--force-unlock`.

Tests added for the changelog misclassification and the zerover metadata clearing; full suite + clippy green locally.