### PR TITLE
perf(ci): install cargo-tarpaulin prebuilt instead of compiling from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,9 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-tarpaulin
       - name: Generate coverage
         run: cargo tarpaulin --out xml --skip-clean
         env:


### PR DESCRIPTION
The Coverage job ran `cargo install cargo-tarpaulin`, which compiles tarpaulin (and its dependency tree) from source on every CI run — several minutes, uncached, on every push and PR. Every other tool in this workflow already uses `taiki-e/install-action` for prebuilt binaries (cargo-nextest in Test, cargo-audit/deny/machete in Security).

Switched coverage to `taiki-e/install-action@v2 with: tool: cargo-tarpaulin` — a prebuilt download (seconds) instead of a from-source build. No behaviour change to the coverage run itself (`cargo tarpaulin --out xml --skip-clean` unchanged).