### PR TITLE
perf(ci): cache npm globals for the bench job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,6 +458,23 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
+      # Cache ~/.npm so the competitor npm-global installs that
+      # `Benchmarks/scripts/run.sh` does (`npm install -g
+      # @changesets/cli`, `commit-and-tag-version`, `standard-version`,
+      # `semantic-release@23`, the `npx --yes release-please` size
+      # measurement) reuse downloaded tarballs across runs instead of
+      # re-fetching them every time. Key on the file that pins the
+      # competitor set + their versions, with a wide fallback so a
+      # version change still benefits from the previous cache shape.
+      - name: Cache competitor npm globals
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.npm
+            ~/.cache/npx
+          key: bench-npm-cache-${{ hashFiles('.github/workflows/ci.yml', 'benchmarks/fixtures/definitions/*.json') }}
+          restore-keys: |
+            bench-npm-cache-
       - uses: FerrLabs/Benchmarks@v5
         with:
           type: full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,7 +467,7 @@ jobs:
       # competitor set + their versions, with a wide fallback so a
       # version change still benefits from the previous cache shape.
       - name: Cache competitor npm globals
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             ~/.npm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "5.3.2"
+version = "5.3.5"
 dependencies = [
  "anyhow",
  "cargo-husky",


### PR DESCRIPTION
The benchmark job (`Benchmark` in `ci.yml`) dominates the CI wall-time at ~14 min, and a large slice of that is just `run.sh` re-installing the competitor Node packages from scratch every run: `@changesets/cli`, `commit-and-tag-version`, `standard-version`, `semantic-release@23`, plus the `release-please` size measurement via `npx --yes`.

Adding `actions/cache@v4` over `~/.npm` and `~/.cache/npx` lets the existing `npm install -g` and `npx --yes` calls in `Benchmarks/scripts/run.sh` reuse already-downloaded tarballs across runs. Cache key is hashed on this workflow + the fixture definitions, with a wide `bench-npm-cache-` fallback so a single bench-config tweak doesn't blow the whole cache away.

Expected impact: 1–3 minutes off the bench job on cache hit, no change on first/cold run. The hyperfine timings themselves are unaffected — only the per-tool setup phase benefits.