### PR TITLE
feat(config): declarative publishers + workspace registries (foundation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "5.3.5"
+version = "5.3.6"
 dependencies = [
  "anyhow",
  "cargo-husky",

--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -99,6 +99,18 @@
         "hooks": {
           "$ref": "#/$defs/hooks"
         },
+        "registries": {
+          "type": "object",
+          "description": "Named registry credentials referenced by package.publishers[]. Lets users declare 'the Kellnr token lives in CARGO_REGISTRIES_KELLNR_TOKEN' once and reuse it across every cargo / npm / docker publisher.",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "url": { "type": "string" },
+              "tokenEnv": { "type": "string", "description": "Name of the env var holding the registry token. The token value is never read from config." }
+            },
+            "additionalProperties": false
+          }
+        },
         "branches": {
           "type": "array",
           "description": "Map branches to pre-release channels. When FerrFlow runs on a branch matching a configured name/pattern, it uses the corresponding channel.",
@@ -222,6 +234,12 @@
           },
           "hooks": {
             "$ref": "#/$defs/hooks"
+          },
+          "publishers": {
+            "type": "array",
+            "description": "Declarative publish targets evaluated after the GitHub Release is created. Each entry is a self-contained intent — see $defs/publisher for the kinds.",
+            "items": { "$ref": "#/$defs/publisher" },
+            "default": []
           }
         },
         "additionalProperties": false
@@ -229,6 +247,76 @@
     }
   },
   "$defs": {
+    "publisher": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["kind"],
+          "properties": {
+            "kind": { "const": "cargo" },
+            "registry": { "type": "string" },
+            "allowDirty": { "type": "boolean", "default": false }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": ["kind"],
+          "properties": {
+            "kind": { "const": "npm" },
+            "registry": { "type": "string" },
+            "tag": { "type": "string" },
+            "access": { "type": "string", "enum": ["public", "restricted"] }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": ["kind", "image"],
+          "properties": {
+            "kind": { "const": "docker" },
+            "image": { "type": "string" },
+            "tags": { "type": "array", "items": { "type": "string" }, "default": ["{version}"] },
+            "platforms": { "type": "array", "items": { "type": "string" } },
+            "context": { "type": "string", "default": "." },
+            "dockerfile": { "type": "string", "default": "Dockerfile" },
+            "sign": { "type": "string", "enum": ["none", "sigstore"], "default": "none" }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": ["kind", "registry"],
+          "properties": {
+            "kind": { "const": "helm" },
+            "chart": { "type": "string", "default": "." },
+            "registry": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": ["kind", "path"],
+          "properties": {
+            "kind": { "const": "github-release-asset" },
+            "path": { "type": "string" },
+            "displayName": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": ["kind", "url"],
+          "properties": {
+            "kind": { "const": "webhook" },
+            "url": { "type": "string" },
+            "body": {},
+            "headers": { "type": "object", "additionalProperties": { "type": "string" } }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
     "hooks": {
       "type": "object",
       "description": "Shell commands executed at lifecycle points during release.",

--- a/src/config/format.rs
+++ b/src/config/format.rs
@@ -59,6 +59,9 @@ const CAMEL_CASE_KEYS: &[&str] = &[
     "floating_tags",
     "orphaned_tag_strategy",
     "prerelease_identifier",
+    "token_env",
+    "allow_dirty",
+    "display_name",
 ];
 
 pub(crate) fn to_camel_case_keys(value: serde_json::Value) -> serde_json::Value {

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -173,6 +173,7 @@ fn collect_package(path_default: &str, monorepo: bool) -> PackageConfig {
         tag_template: None,
         hooks: None,
         floating_tags: None,
+        publishers: vec![],
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -18,9 +18,11 @@ pub use format::{ConfigFileFormat, ConfigFormatHandler, format_handler};
 #[cfg(feature = "cli")]
 pub use init::init;
 pub use package::{FileFormat, FloatingTagLevel, PackageConfig, VersionedFile, VersioningStrategy};
+#[allow(unused_imports)]
 pub use types::{
-    BranchChannelConfig, ChannelValue, ForgeKind, HooksConfig, OnFailure, OrphanedTagStrategy,
-    PrereleaseIdentifier, ReleaseCommitMode, ReleaseCommitScope,
+    BranchChannelConfig, ChannelValue, DockerSign, ForgeKind, HooksConfig, OnFailure,
+    OrphanedTagStrategy, PrereleaseIdentifier, PublisherConfig, RegistryConfig, ReleaseCommitMode,
+    ReleaseCommitScope,
 };
 #[allow(unused_imports)]
 pub use workspace::{WorkspaceConfig, default_commit_skip_markers};
@@ -208,6 +210,7 @@ impl Config {
                     tag_template: None,
                     hooks: None,
                     floating_tags: None,
+                    publishers: vec![],
                 }]
             },
         }

--- a/src/config/package.rs
+++ b/src/config/package.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use super::types::HooksConfig;
+use super::types::{HooksConfig, PublisherConfig};
 use super::workspace::WorkspaceConfig;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -21,6 +21,12 @@ pub struct PackageConfig {
     pub floating_tags: Option<Vec<FloatingTagLevel>>,
     #[serde(default)]
     pub hooks: Option<HooksConfig>,
+    /// Declarative publish targets. Evaluated in declaration order
+    /// after the git push + GitHub Release create the new tag. v1
+    /// only emits dry-run preview lines; per-kind execution lands in
+    /// follow-up PRs.
+    #[serde(default)]
+    pub publishers: Vec<PublisherConfig>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Default)]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -160,6 +160,7 @@ fn effective_versioning_inherits_workspace() {
         tag_template: None,
         hooks: None,
         floating_tags: None,
+        publishers: vec![],
     };
     assert_eq!(
         pkg.effective_versioning(&ws, &[]),
@@ -184,6 +185,7 @@ fn effective_versioning_package_overrides() {
         tag_template: None,
         hooks: None,
         floating_tags: None,
+        publishers: vec![],
     };
     assert_eq!(
         pkg.effective_versioning(&ws, &[]),
@@ -205,6 +207,7 @@ fn effective_versioning_autodetects_from_tags_when_unset() {
         tag_template: None,
         hooks: None,
         floating_tags: None,
+        publishers: vec![],
     };
     let tags = vec!["v2024.04.18", "v2024.05.01"];
     assert_eq!(
@@ -227,6 +230,7 @@ fn effective_versioning_falls_back_to_semver_without_tags() {
         tag_template: None,
         hooks: None,
         floating_tags: None,
+        publishers: vec![],
     };
     assert_eq!(
         pkg.effective_versioning(&ws, &[]),
@@ -250,6 +254,7 @@ fn make_pkg(name: &str, tag_template: Option<&str>) -> PackageConfig {
         tag_template: tag_template.map(String::from),
         hooks: None,
         floating_tags: None,
+        publishers: vec![],
     }
 }
 
@@ -464,6 +469,7 @@ fn json_serializes_camel_case() {
             tag_template: Some("{name}@v{version}".into()),
             hooks: None,
             floating_tags: None,
+            publishers: vec![],
         }],
     };
     let serialized = handler.serialize(&config).unwrap();
@@ -510,6 +516,7 @@ fn toml_keeps_snake_case() {
             tag_template: Some("{name}@v{version}".into()),
             hooks: None,
             floating_tags: None,
+            publishers: vec![],
         }],
     };
     let serialized = handler.serialize(&config).unwrap();
@@ -1101,6 +1108,7 @@ fn tag_prefix_no_version_placeholder() {
         tag_template: Some("release-latest".to_string()),
         hooks: None,
         floating_tags: None,
+        publishers: vec![],
     };
     // When template has no {version}, prefix is the entire template
     assert_eq!(pkg.tag_prefix(&ws, false), "release-latest");
@@ -1120,6 +1128,7 @@ fn tag_for_version_replaces_placeholders() {
         tag_template: Some("{name}/v{version}".to_string()),
         hooks: None,
         floating_tags: None,
+        publishers: vec![],
     };
     assert_eq!(pkg.tag_for_version(&ws, true, "1.2.3"), "api/v1.2.3");
 }
@@ -1462,4 +1471,182 @@ fn path_to_file_url_unix_style() {
     assert!(url.starts_with("file:///"));
     assert!(url.contains("test.js"));
     assert!(!url.contains('\\'));
+}
+
+// -----------------------------------------------------------------------
+// publishers + registries (RFC v1 — parse/dry-run preview only)
+// -----------------------------------------------------------------------
+
+#[test]
+fn registries_parse_in_workspace_section() {
+    let json = r#"{
+        "workspace": {
+            "registries": {
+                "kellnr": { "url": "https://kellnr.example.com", "tokenEnv": "CARGO_REGISTRIES_KELLNR_TOKEN" },
+                "gh-packages": { "tokenEnv": "NODE_AUTH_TOKEN" }
+            }
+        },
+        "package": []
+    }"#;
+    let cfg: Config = serde_json::from_str(json).unwrap();
+    let kellnr = cfg.workspace.registries.get("kellnr").unwrap();
+    assert_eq!(kellnr.url.as_deref(), Some("https://kellnr.example.com"));
+    assert_eq!(
+        kellnr.token_env.as_deref(),
+        Some("CARGO_REGISTRIES_KELLNR_TOKEN")
+    );
+    let gh = cfg.workspace.registries.get("gh-packages").unwrap();
+    assert_eq!(gh.url, None);
+    assert_eq!(gh.token_env.as_deref(), Some("NODE_AUTH_TOKEN"));
+}
+
+#[test]
+fn publishers_cargo_kind_parses() {
+    let json = r#"{
+        "package": [{
+            "name": "auth",
+            "path": "crates/auth",
+            "publishers": [
+                { "kind": "cargo", "registry": "kellnr", "allowDirty": false }
+            ]
+        }]
+    }"#;
+    let cfg: Config = serde_json::from_str(json).unwrap();
+    let p = &cfg.packages[0].publishers[0];
+    match p {
+        PublisherConfig::Cargo {
+            registry,
+            allow_dirty,
+        } => {
+            assert_eq!(registry.as_deref(), Some("kellnr"));
+            assert!(!*allow_dirty);
+        }
+        _ => panic!("expected cargo kind"),
+    }
+}
+
+#[test]
+fn publishers_docker_kind_has_defaults() {
+    let json = r#"{
+        "package": [{
+            "name": "auth",
+            "path": "crates/auth",
+            "publishers": [
+                { "kind": "docker", "image": "ghcr.io/ferrlabs/auth" }
+            ]
+        }]
+    }"#;
+    let cfg: Config = serde_json::from_str(json).unwrap();
+    match &cfg.packages[0].publishers[0] {
+        PublisherConfig::Docker {
+            image,
+            tags,
+            platforms,
+            context,
+            dockerfile,
+            sign,
+        } => {
+            assert_eq!(image, "ghcr.io/ferrlabs/auth");
+            assert_eq!(tags, &vec!["{version}".to_string()]);
+            assert!(platforms.is_empty());
+            assert_eq!(context, ".");
+            assert_eq!(dockerfile, "Dockerfile");
+            assert_eq!(*sign, crate::config::DockerSign::None);
+        }
+        _ => panic!("expected docker kind"),
+    }
+}
+
+#[test]
+fn publishers_describe_renders_dry_run_preview() {
+    let cargo = PublisherConfig::Cargo {
+        registry: Some("kellnr".to_string()),
+        allow_dirty: false,
+    };
+    assert_eq!(
+        cargo.describe("ferrlabs-auth", "0.1.0"),
+        "cargo publish ferrlabs-auth@0.1.0 → kellnr"
+    );
+
+    let docker = PublisherConfig::Docker {
+        image: "ghcr.io/ferrlabs/auth".to_string(),
+        tags: vec!["{version}".to_string(), "latest".to_string()],
+        platforms: vec!["linux/amd64".to_string(), "linux/arm64".to_string()],
+        context: ".".to_string(),
+        dockerfile: "Dockerfile".to_string(),
+        sign: crate::config::DockerSign::Sigstore,
+    };
+    let line = docker.describe("ferrlabs-auth", "0.1.0");
+    assert!(line.contains("ghcr.io/ferrlabs/auth"));
+    assert!(line.contains("0.1.0"));
+    assert!(line.contains("latest"));
+    assert!(line.contains("linux/amd64,linux/arm64"));
+    assert!(line.contains("+sigstore"));
+
+    let webhook = PublisherConfig::Webhook {
+        url: "https://hooks.slack.com/x".to_string(),
+        body: None,
+        headers: Default::default(),
+    };
+    assert!(webhook.describe("auth", "0.1.0").contains("POST"));
+    assert!(webhook.describe("auth", "0.1.0").contains("auth@0.1.0"));
+}
+
+#[test]
+fn publishers_default_to_empty_vec_when_omitted() {
+    let json = r#"{
+        "package": [{ "name": "x", "path": "." }]
+    }"#;
+    let cfg: Config = serde_json::from_str(json).unwrap();
+    assert!(cfg.packages[0].publishers.is_empty());
+}
+
+#[test]
+fn publishers_accepts_all_six_kinds_in_one_package() {
+    let json = r#"{
+        "package": [{
+            "name": "kit",
+            "path": "crates/kit",
+            "publishers": [
+                { "kind": "cargo" },
+                { "kind": "npm", "tag": "beta", "access": "public" },
+                { "kind": "docker", "image": "ghcr.io/x/kit" },
+                { "kind": "helm", "registry": "oci://ghcr.io/x/charts" },
+                { "kind": "github-release-asset", "path": "sbom.cdx.json" },
+                { "kind": "webhook", "url": "https://example.com/x" }
+            ]
+        }]
+    }"#;
+    let cfg: Config = serde_json::from_str(json).unwrap();
+    let kinds: Vec<&str> = cfg.packages[0]
+        .publishers
+        .iter()
+        .map(PublisherConfig::kind_name)
+        .collect();
+    assert_eq!(
+        kinds,
+        vec![
+            "cargo",
+            "npm",
+            "docker",
+            "helm",
+            "github-release-asset",
+            "webhook"
+        ]
+    );
+}
+
+#[test]
+fn publishers_unknown_kind_is_rejected() {
+    let json = r#"{
+        "package": [{
+            "name": "x",
+            "path": ".",
+            "publishers": [{ "kind": "telegram", "channel": "@foo" }]
+        }]
+    }"#;
+    assert!(
+        serde_json::from_str::<Config>(json).is_err(),
+        "an unknown publisher kind must not silently parse"
+    );
 }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -92,3 +92,213 @@ pub enum ReleaseCommitScope {
     Grouped,
     PerPackage,
 }
+
+/// Declarative registry-credential map shared across every publisher
+/// kind. Lets users say "the Kellnr registry's token is in
+/// CARGO_REGISTRIES_KELLNR_TOKEN" once at the workspace level instead
+/// of restating it on every package's publisher entry.
+///
+/// `tokenEnv` is the env-var name (not the value) — the actual token
+/// stays in the runner's secret store. `url` is informational and used
+/// for the dry-run preview message + future idempotency probes.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Default)]
+pub struct RegistryConfig {
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(alias = "tokenEnv")]
+    pub token_env: Option<String>,
+}
+
+/// Declarative replacement for the shell-soup that currently lives in
+/// `postPublish` hooks across every FerrLabs cloud repo. Each
+/// publisher is a self-contained intent ("push this package to that
+/// registry"), evaluated in declaration order after the release
+/// commit + tag + GitHub Release have been created. v1 ships parsing
+/// and dry-run preview only — actual publish execution lands in
+/// follow-up PRs (one publisher kind per PR) so the schema can be
+/// reviewed before any side-effecting code does.
+///
+/// The kind is the externally-tagged discriminator (`{"kind":
+/// "cargo", ...}`) — keeps the JSON Schema readable and lets us add
+/// kinds without overloading existing fields.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum PublisherConfig {
+    /// `cargo publish` to crates.io or a custom registry (Kellnr,
+    /// Cloudsmith, …). `registry` references the
+    /// `workspace.registries.<name>` map; the default `crates-io` is
+    /// implicit.
+    Cargo {
+        #[serde(default)]
+        registry: Option<String>,
+        /// Mirrors `cargo publish --allow-dirty`. Default false.
+        #[serde(default, rename = "allowDirty")]
+        allow_dirty: bool,
+    },
+    /// `npm publish` to npmjs.org, GitHub Packages, or a custom
+    /// registry. `registry` references workspace registries.
+    Npm {
+        #[serde(default)]
+        registry: Option<String>,
+        /// Distribution tag passed to `npm publish --tag`. Defaults to
+        /// `"latest"` for stable, `"<channel>"` for prereleases — the
+        /// publisher fills in at execution time.
+        #[serde(default)]
+        tag: Option<String>,
+        /// `--access public|restricted` for scoped packages.
+        #[serde(default)]
+        access: Option<String>,
+    },
+    /// Docker `buildx` push with optional Sigstore signing.
+    Docker {
+        /// Fully-qualified image base, without the tag (e.g.
+        /// `ghcr.io/ferrlabs/auth`).
+        image: String,
+        /// Tag templates. `{version}`, `{major}`, `{minor}`, `latest`
+        /// are recognized.
+        #[serde(default = "default_docker_tags")]
+        tags: Vec<String>,
+        /// Target platforms for buildx multi-arch. Defaults to
+        /// `linux/amd64` (single-arch) when omitted.
+        #[serde(default)]
+        platforms: Vec<String>,
+        /// Build context (relative to the package path). Defaults to
+        /// `"."` (the package root).
+        #[serde(default = "default_docker_context")]
+        context: String,
+        /// `Dockerfile` location relative to `context`. Defaults to
+        /// `"Dockerfile"`.
+        #[serde(default = "default_dockerfile")]
+        dockerfile: String,
+        /// Sigstore keyless signing. `sigstore` = cosign keyless,
+        /// `none` = no signature.
+        #[serde(default)]
+        sign: DockerSign,
+    },
+    /// OCI helm chart push.
+    Helm {
+        /// Chart directory relative to the package path.
+        #[serde(default = "default_helm_chart_path")]
+        chart: String,
+        /// Target OCI registry, e.g. `oci://ghcr.io/ferrlabs/charts`.
+        registry: String,
+    },
+    /// Attach an extra file to the GitHub Release that
+    /// `ferrflow release` just created. Useful for SBOMs, signed
+    /// blobs, install scripts, etc.
+    GithubReleaseAsset {
+        /// Path to the file to upload, relative to the package path.
+        path: String,
+        /// Override the asset's filename on GitHub. Defaults to the
+        /// path's basename.
+        #[serde(default, rename = "displayName")]
+        display_name: Option<String>,
+    },
+    /// Generic POST notifier — Slack incoming webhook, Discord,
+    /// custom internal services. The JSON body has access to
+    /// `{name}`, `{version}`, `{tag}`, `{url}` placeholders.
+    Webhook {
+        url: String,
+        /// JSON body template. If omitted, FerrFlow sends a default
+        /// payload `{"package": "...", "version": "..."}`.
+        #[serde(default)]
+        body: Option<serde_json::Value>,
+        /// Header map. Values support `{env:NAME}` interpolation for
+        /// secrets, evaluated at publish time.
+        #[serde(default)]
+        headers: std::collections::BTreeMap<String, String>,
+    },
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum DockerSign {
+    #[default]
+    None,
+    Sigstore,
+}
+
+fn default_docker_tags() -> Vec<String> {
+    vec!["{version}".to_string()]
+}
+
+fn default_docker_context() -> String {
+    ".".to_string()
+}
+
+fn default_dockerfile() -> String {
+    "Dockerfile".to_string()
+}
+
+fn default_helm_chart_path() -> String {
+    ".".to_string()
+}
+
+impl PublisherConfig {
+    /// Short human-friendly name (`"cargo"`, `"docker"`, …) for log
+    /// lines, dry-run output, and step summaries. Stable enough to be
+    /// pattern-matched in CI scripts.
+    pub fn kind_name(&self) -> &'static str {
+        match self {
+            PublisherConfig::Cargo { .. } => "cargo",
+            PublisherConfig::Npm { .. } => "npm",
+            PublisherConfig::Docker { .. } => "docker",
+            PublisherConfig::Helm { .. } => "helm",
+            PublisherConfig::GithubReleaseAsset { .. } => "github-release-asset",
+            PublisherConfig::Webhook { .. } => "webhook",
+        }
+    }
+
+    /// One-line description for the dry-run preview ("would publish
+    /// X to Y"). Resolves placeholders that only depend on per-call
+    /// inputs (name + new version); registry-level fields stay
+    /// unresolved at this stage.
+    pub fn describe(&self, package_name: &str, new_version: &str) -> String {
+        match self {
+            PublisherConfig::Cargo { registry, .. } => {
+                let reg = registry.as_deref().unwrap_or("crates-io");
+                format!("cargo publish {package_name}@{new_version} → {reg}")
+            }
+            PublisherConfig::Npm { registry, tag, .. } => {
+                let reg = registry.as_deref().unwrap_or("npmjs.org");
+                let tag = tag.as_deref().unwrap_or("latest");
+                format!("npm publish {package_name}@{new_version} → {reg} (tag={tag})")
+            }
+            PublisherConfig::Docker {
+                image,
+                tags,
+                platforms,
+                sign,
+                ..
+            } => {
+                let resolved: Vec<String> = tags
+                    .iter()
+                    .map(|t| t.replace("{version}", new_version))
+                    .collect();
+                let platforms_s = if platforms.is_empty() {
+                    "linux/amd64".to_string()
+                } else {
+                    platforms.join(",")
+                };
+                let sign_s = match sign {
+                    DockerSign::None => "",
+                    DockerSign::Sigstore => " +sigstore",
+                };
+                format!(
+                    "docker push {image}:[{}] platforms={platforms_s}{sign_s}",
+                    resolved.join(", ")
+                )
+            }
+            PublisherConfig::Helm { chart, registry } => {
+                format!("helm push {chart} {new_version} → {registry}")
+            }
+            PublisherConfig::GithubReleaseAsset { path, display_name } => {
+                let shown = display_name.as_deref().unwrap_or(path);
+                format!("upload {shown} → GitHub Release {new_version}")
+            }
+            PublisherConfig::Webhook { url, .. } => {
+                format!("POST {url} ({package_name}@{new_version})")
+            }
+        }
+    }
+}

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -2,9 +2,10 @@ use serde::{Deserialize, Serialize};
 
 use super::package::{FloatingTagLevel, VersioningStrategy};
 use super::types::{
-    BranchChannelConfig, ForgeKind, HooksConfig, OrphanedTagStrategy, ReleaseCommitMode,
-    ReleaseCommitScope,
+    BranchChannelConfig, ForgeKind, HooksConfig, OrphanedTagStrategy, RegistryConfig,
+    ReleaseCommitMode, ReleaseCommitScope,
 };
+use std::collections::BTreeMap;
 
 #[derive(Debug, Deserialize, Serialize, Default)]
 pub struct WorkspaceConfig {
@@ -40,6 +41,13 @@ pub struct WorkspaceConfig {
     pub hooks: Option<HooksConfig>,
     #[serde(default)]
     pub branches: Option<Vec<BranchChannelConfig>>,
+    /// Named registry credentials shared by `package.publishers[]`.
+    /// Keyed by a short identifier (e.g. `"kellnr"`, `"gh-packages"`)
+    /// that publishers reference by name. Lets users declare auth
+    /// once and reuse it across every cargo / npm / docker entry. See
+    /// the publisher RFC.
+    #[serde(default)]
+    pub registries: BTreeMap<String, RegistryConfig>,
 }
 
 impl WorkspaceConfig {

--- a/src/monorepo/run/execute.rs
+++ b/src/monorepo/run/execute.rs
@@ -536,6 +536,13 @@ fn run_post_publish_hooks(plan: &mut ReleasePlan<'_>) -> Result<()> {
                 plan.root,
             )?;
         }
+        // Declarative publishers preview. v1 ships the plan only —
+        // each kind's actual execution lands in a follow-up PR, so
+        // even on a live release we currently just print what FerrFlow
+        // *will* run once the executors exist. Until then users keep
+        // their existing postPublish shell hooks alongside; the
+        // preview lets them iterate on the publishers block safely.
+        print_dry_run_publishers(pkg, &ctx.package, &ctx.new_version);
     }
     Ok(())
 }
@@ -559,6 +566,33 @@ pub(super) fn print_dry_run_hooks(plan: &ReleasePlan<'_>) -> Result<()> {
                 run_hook(point, &cmd, ctx, on_failure, true, plan.verbose, plan.root)?;
             }
         }
+        print_dry_run_publishers(pkg, &ctx.package, &ctx.new_version);
     }
     Ok(())
+}
+
+/// Render the declarative `publishers[]` plan as one line per entry.
+/// The v1 scope is preview-only — execution lands per-kind in
+/// follow-up PRs — so this is how users see what FerrFlow *would*
+/// publish without any side effect.
+pub(super) fn print_dry_run_publishers(
+    pkg: &crate::config::PackageConfig,
+    package_name: &str,
+    new_version: &str,
+) {
+    if pkg.publishers.is_empty() {
+        return;
+    }
+    println!(
+        "  {} {} publishers:",
+        "→".cyan(),
+        pkg.publishers.len().to_string().cyan()
+    );
+    for p in &pkg.publishers {
+        println!(
+            "    [{}] {}",
+            p.kind_name(),
+            p.describe(package_name, new_version)
+        );
+    }
 }

--- a/src/monorepo/tests.rs
+++ b/src/monorepo/tests.rs
@@ -43,6 +43,7 @@ fn make_pkg(name: &str, path: &str, shared: &[&str]) -> PackageConfig {
         tag_template: None,
         hooks: None,
         floating_tags: None,
+        publishers: vec![],
     }
 }
 

--- a/src/validate/tests.rs
+++ b/src/validate/tests.rs
@@ -23,6 +23,7 @@ fn make_package(name: &str, path: &str) -> PackageConfig {
         versioning: None,
         tag_template: None,
         floating_tags: None,
+        publishers: vec![],
         hooks: None,
     }
 }


### PR DESCRIPTION
Part 1 of #571. Adds schema, types, parsing and dry-run preview for the new workspace.registries + package.publishers[] blocks. No execution code yet — actual cargo/npm/docker publishers ship in follow-up PRs (one per kind). Users adding a publishers block today see a preview line in release output without any side effect. Tests: 566 lib tests passing, clippy clean.