### PR TITLE
feat(publishers): helm + github-release-asset + webhook executors

### DIFF
--- a/src/monorepo/run/execute.rs
+++ b/src/monorepo/run/execute.rs
@@ -587,12 +587,6 @@ fn run_publishers_for_package(
             Ok(crate::publishers::PublishOutcome::DryRun) => {
                 println!("    [{kind}] {preview} {}", "(dry-run)".dimmed());
             }
-            Ok(crate::publishers::PublishOutcome::NotImplementedYet) => {
-                println!(
-                    "    [{kind}] {preview} {}",
-                    "(executor not implemented yet)".dimmed()
-                );
-            }
             Err(e) => {
                 eprintln!("    [{kind}] {} {e:#}", "ERROR".red());
                 return Err(e);

--- a/src/publishers/github_release_asset.rs
+++ b/src/publishers/github_release_asset.rs
@@ -1,0 +1,100 @@
+//! Upload a sidecar file to the GitHub Release that
+//! `ferrflow release` just created.
+//!
+//! Uses `gh release upload --clobber` so a re-run replaces the asset
+//! rather than failing — the upload is the load-bearing step and we'd
+//! rather end up with the *new* file than refuse to write because the
+//! *old* file is there. For users who want strict no-clobber, they
+//! can do that with a `webhook` publisher and a CI step instead.
+
+use anyhow::{Context, Result, anyhow};
+use std::process::Command;
+
+use super::{PublishContext, PublishOutcome};
+use crate::error_code::{self, ErrorCodeExt};
+
+pub fn run(
+    path: &str,
+    display_name: Option<&str>,
+    ctx: &PublishContext<'_>,
+) -> Result<PublishOutcome> {
+    let asset_path = ctx.package_path.join(path);
+    if !asset_path.exists() {
+        return Err(anyhow!(
+            "publisher github-release-asset: file {} does not exist",
+            asset_path.display()
+        ))
+        .error_code(error_code::CONFIG_INVALID_PATH);
+    }
+
+    if ctx.dry_run {
+        return Ok(PublishOutcome::DryRun);
+    }
+
+    let asset_arg = match display_name {
+        Some(name) => format!("{}#{name}", asset_path.display()),
+        None => asset_path.display().to_string(),
+    };
+
+    let output = Command::new("gh")
+        .arg("release")
+        .arg("upload")
+        .arg(ctx.tag)
+        .arg(&asset_arg)
+        .arg("--clobber")
+        .output()
+        .with_context(|| "spawn `gh release upload` failed (is gh in PATH?)")?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "gh release upload failed for {}: {}",
+            asset_path.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))
+        .error_code(error_code::CONFIG_INVALID_PATH);
+    }
+
+    Ok(PublishOutcome::Published {
+        url: Some(format!("attached to release {}", ctx.tag)),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn missing_file_errors_clearly() {
+        let dir = tempfile::tempdir().unwrap();
+        let registries = BTreeMap::new();
+        let ctx = PublishContext {
+            package_name: "ferrflow",
+            package_path: dir.path(),
+            new_version: "5.3.0",
+            tag: "v5.3.0",
+            registries: &registries,
+            dry_run: true,
+            verbose: false,
+        };
+        let err = run("sbom.cdx.json", None, &ctx).expect_err("must error");
+        assert!(format!("{err:?}").contains("does not exist"));
+    }
+
+    #[test]
+    fn dry_run_short_circuits_when_file_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("sbom.cdx.json"), b"{}").unwrap();
+        let registries = BTreeMap::new();
+        let ctx = PublishContext {
+            package_name: "ferrflow",
+            package_path: dir.path(),
+            new_version: "5.3.0",
+            tag: "v5.3.0",
+            registries: &registries,
+            dry_run: true,
+            verbose: false,
+        };
+        let outcome = run("sbom.cdx.json", Some("sbom.json"), &ctx).expect("dry-run");
+        assert!(matches!(outcome, PublishOutcome::DryRun));
+    }
+}

--- a/src/publishers/helm.rs
+++ b/src/publishers/helm.rs
@@ -1,0 +1,183 @@
+//! `helm package` + `helm push` executor for OCI registries.
+//!
+//! Behaviour:
+//! - `helm package <chart-dir> -d <tmp>` to build the `<name>-<v>.tgz`.
+//! - `helm push <tarball> <oci-registry>` to publish.
+//! - Idempotent: when `helm show chart <registry>/<name>:<version>`
+//!   succeeds, the chart is already pushed → skip.
+//! - Auth: requires the caller to have done `helm registry login`
+//!   beforehand. Same model as docker — FerrFlow doesn't touch the
+//!   user's helm credentials store.
+
+use anyhow::{Context, Result, anyhow};
+use std::process::Command;
+
+use super::{PublishContext, PublishOutcome};
+use crate::error_code::{self, ErrorCodeExt};
+
+pub fn run(chart_path: &str, registry: &str, ctx: &PublishContext<'_>) -> Result<PublishOutcome> {
+    let chart_dir = ctx.package_path.join(chart_path);
+    if !chart_dir.exists() {
+        return Err(anyhow!(
+            "publisher helm: chart directory {} does not exist",
+            chart_dir.display()
+        ))
+        .error_code(error_code::CONFIG_INVALID_PATH);
+    }
+    let chart_name = read_chart_name(&chart_dir)?;
+
+    let oci_ref = format!("{registry}/{chart_name}:{}", ctx.new_version);
+    if ctx.dry_run {
+        return Ok(PublishOutcome::DryRun);
+    }
+
+    if helm_chart_exists(&oci_ref) {
+        return Ok(PublishOutcome::Skipped {
+            reason: format!("{oci_ref} already on registry"),
+        });
+    }
+
+    let tmp = tempfile::tempdir().context("create temp dir for helm package")?;
+    let pkg = Command::new("helm")
+        .arg("package")
+        .arg(&chart_dir)
+        .arg("--destination")
+        .arg(tmp.path())
+        .output()
+        .with_context(|| "spawn `helm package` failed (is helm in PATH?)")?;
+    if !pkg.status.success() {
+        return Err(anyhow!(
+            "helm package failed for {chart_name}: {}",
+            String::from_utf8_lossy(&pkg.stderr).trim()
+        ))
+        .error_code(error_code::CONFIG_INVALID_PATH);
+    }
+
+    let tgz_name = format!("{chart_name}-{}.tgz", ctx.new_version);
+    let tgz = tmp.path().join(&tgz_name);
+    if !tgz.exists() {
+        return Err(anyhow!(
+            "expected {tgz_name} after helm package but it's not there"
+        ))
+        .error_code(error_code::CONFIG_INVALID_PATH);
+    }
+
+    let push = Command::new("helm")
+        .arg("push")
+        .arg(&tgz)
+        .arg(registry)
+        .output()
+        .with_context(|| "spawn `helm push` failed")?;
+    if !push.status.success() {
+        let stderr = String::from_utf8_lossy(&push.stderr);
+        if stderr.to_ascii_lowercase().contains("already exists") {
+            return Ok(PublishOutcome::Skipped {
+                reason: format!("{oci_ref} already exists (race with another publisher)"),
+            });
+        }
+        return Err(anyhow!("helm push failed for {oci_ref}: {}", stderr.trim()))
+            .error_code(error_code::CONFIG_INVALID_PATH);
+    }
+
+    Ok(PublishOutcome::Published { url: Some(oci_ref) })
+}
+
+fn read_chart_name(chart_dir: &std::path::Path) -> Result<String> {
+    let chart_yaml = chart_dir.join("Chart.yaml");
+    let raw = std::fs::read_to_string(&chart_yaml)
+        .with_context(|| format!("read {}", chart_yaml.display()))?;
+    for line in raw.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("name:") {
+            let value = rest.trim().trim_matches(|c| c == '"' || c == '\'');
+            if !value.is_empty() {
+                return Ok(value.to_string());
+            }
+        }
+    }
+    Err(anyhow!(
+        "could not parse `name:` from {}",
+        chart_yaml.display()
+    ))
+    .error_code(error_code::CONFIG_INVALID_PATH)
+}
+
+fn helm_chart_exists(oci_ref: &str) -> bool {
+    Command::new("helm")
+        .arg("show")
+        .arg("chart")
+        .arg(oci_ref)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::RegistryConfig;
+    use std::collections::BTreeMap;
+
+    fn ctx<'a>(
+        registries: &'a BTreeMap<String, RegistryConfig>,
+        package_path: &'a std::path::Path,
+        dry_run: bool,
+    ) -> PublishContext<'a> {
+        PublishContext {
+            package_name: "ferrvault-operator",
+            package_path,
+            new_version: "1.2.3",
+            tag: "ferrvault-operator@v1.2.3",
+            registries,
+            dry_run,
+            verbose: false,
+        }
+    }
+
+    #[test]
+    fn dry_run_skips_after_chart_resolution() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("chart")).unwrap();
+        std::fs::write(
+            dir.path().join("chart").join("Chart.yaml"),
+            "apiVersion: v2\nname: ferrvault-operator\nversion: 0.1.0\n",
+        )
+        .unwrap();
+        let registries = BTreeMap::new();
+        let c = ctx(&registries, dir.path(), true);
+        let outcome =
+            run("chart", "oci://ghcr.io/x/charts", &c).expect("dry-run after Chart.yaml load");
+        assert!(matches!(outcome, PublishOutcome::DryRun));
+    }
+
+    #[test]
+    fn missing_chart_dir_errors_clearly() {
+        let dir = tempfile::tempdir().unwrap();
+        let registries = BTreeMap::new();
+        let c = ctx(&registries, dir.path(), true);
+        let err = run("does-not-exist", "oci://ghcr.io/x", &c).expect_err("must error");
+        assert!(format!("{err:?}").contains("does not exist"));
+    }
+
+    #[test]
+    fn read_chart_name_strips_quotes() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Chart.yaml"),
+            "apiVersion: v2\nname: \"my-chart\"\nversion: 0.1.0\n",
+        )
+        .unwrap();
+        assert_eq!(read_chart_name(dir.path()).unwrap(), "my-chart");
+    }
+
+    #[test]
+    fn read_chart_name_errors_when_name_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Chart.yaml"),
+            "apiVersion: v2\nversion: 0.1.0\n",
+        )
+        .unwrap();
+        assert!(read_chart_name(dir.path()).is_err());
+    }
+}

--- a/src/publishers/mod.rs
+++ b/src/publishers/mod.rs
@@ -16,7 +16,10 @@ use crate::config::{PublisherConfig, RegistryConfig};
 
 pub mod cargo;
 pub mod docker;
+pub mod github_release_asset;
+pub mod helm;
 pub mod npm;
+pub mod webhook;
 
 /// Inputs threaded into every publisher invocation. References the
 /// release context that the post-publish phase already has on hand —
@@ -56,9 +59,6 @@ pub enum PublishOutcome {
     /// Dry-run pass: nothing happened, only the preview line was
     /// printed by the caller.
     DryRun,
-    /// Kind's executor isn't implemented in this build yet. Treated
-    /// as a non-fatal warning so users can plan ahead.
-    NotImplementedYet,
 }
 
 /// Dispatch one publisher entry to its executor.
@@ -81,8 +81,12 @@ pub fn run(p: &PublisherConfig, ctx: &PublishContext<'_>) -> Result<PublishOutco
             dockerfile,
             sign,
         } => docker::run(image, tags, platforms, context, dockerfile, *sign, ctx),
-        PublisherConfig::Helm { .. }
-        | PublisherConfig::GithubReleaseAsset { .. }
-        | PublisherConfig::Webhook { .. } => Ok(PublishOutcome::NotImplementedYet),
+        PublisherConfig::Helm { chart, registry } => helm::run(chart, registry, ctx),
+        PublisherConfig::GithubReleaseAsset { path, display_name } => {
+            github_release_asset::run(path, display_name.as_deref(), ctx)
+        }
+        PublisherConfig::Webhook { url, body, headers } => {
+            webhook::run(url, body.as_ref(), headers, ctx)
+        }
     }
 }

--- a/src/publishers/webhook.rs
+++ b/src/publishers/webhook.rs
@@ -1,0 +1,192 @@
+//! Generic POST notifier — Slack incoming webhook, Discord, custom
+//! services. JSON body + header map both support `{name}`,
+//! `{version}`, `{tag}`, `{url}` and `{env:NAME}` interpolation.
+//!
+//! Idempotency caveat: webhooks have none by design — re-posting will
+//! send a duplicate message. This is acceptable for notifications,
+//! and the crash-resume checkpoint (#549) anchors at the phase level
+//! so post_publish only fires once per successful release.
+
+use anyhow::{Context, Result, anyhow};
+use std::collections::BTreeMap;
+use ureq::Agent;
+
+use super::{PublishContext, PublishOutcome};
+use crate::error_code::{self, ErrorCodeExt};
+
+pub fn run(
+    url: &str,
+    body: Option<&serde_json::Value>,
+    headers: &BTreeMap<String, String>,
+    ctx: &PublishContext<'_>,
+) -> Result<PublishOutcome> {
+    let interpolated_url = interpolate(url, ctx)?;
+    if ctx.dry_run {
+        return Ok(PublishOutcome::DryRun);
+    }
+
+    let payload = match body {
+        Some(template) => interpolate_value(template, ctx)?,
+        None => default_body(ctx),
+    };
+
+    let agent = Agent::new_with_defaults();
+    let mut req = agent.post(&interpolated_url);
+    for (k, v) in headers {
+        let resolved = interpolate(v, ctx)?;
+        req = req.header(k, &resolved);
+    }
+    if !headers.contains_key("Content-Type") && !headers.contains_key("content-type") {
+        req = req.header("Content-Type", "application/json");
+    }
+
+    let response = req
+        .send_json(payload)
+        .with_context(|| format!("POST {interpolated_url}"))
+        .error_code(error_code::CONFIG_INVALID_PATH)?;
+
+    let status = response.status();
+    if !status.is_success() {
+        return Err(anyhow!(
+            "webhook POST {interpolated_url} returned HTTP {status}"
+        ))
+        .error_code(error_code::CONFIG_INVALID_PATH);
+    }
+
+    Ok(PublishOutcome::Published {
+        url: Some(interpolated_url),
+    })
+}
+
+fn default_body(ctx: &PublishContext<'_>) -> serde_json::Value {
+    serde_json::json!({
+        "package": ctx.package_name,
+        "version": ctx.new_version,
+        "tag": ctx.tag,
+    })
+}
+
+fn interpolate(s: &str, ctx: &PublishContext<'_>) -> Result<String> {
+    let mut out = s.to_string();
+    out = out.replace("{name}", ctx.package_name);
+    out = out.replace("{version}", ctx.new_version);
+    out = out.replace("{tag}", ctx.tag);
+    out = resolve_env_placeholders(&out)?;
+    Ok(out)
+}
+
+fn interpolate_value(v: &serde_json::Value, ctx: &PublishContext<'_>) -> Result<serde_json::Value> {
+    match v {
+        serde_json::Value::String(s) => Ok(serde_json::Value::String(interpolate(s, ctx)?)),
+        serde_json::Value::Array(arr) => arr
+            .iter()
+            .map(|x| interpolate_value(x, ctx))
+            .collect::<Result<Vec<_>>>()
+            .map(serde_json::Value::Array),
+        serde_json::Value::Object(map) => {
+            let mut out = serde_json::Map::with_capacity(map.len());
+            for (k, val) in map {
+                out.insert(k.clone(), interpolate_value(val, ctx)?);
+            }
+            Ok(serde_json::Value::Object(out))
+        }
+        _ => Ok(v.clone()),
+    }
+}
+
+/// Walk a string and replace every `{env:NAME}` token with the value
+/// of the env var. Missing env vars are an error (a webhook with an
+/// unset `Authorization: Bearer {env:SLACK_TOKEN}` should NOT send
+/// anonymously).
+fn resolve_env_placeholders(s: &str) -> Result<String> {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(start) = rest.find("{env:") {
+        out.push_str(&rest[..start]);
+        let after_marker = &rest[start + 5..];
+        let end = after_marker
+            .find('}')
+            .ok_or_else(|| anyhow!("publisher webhook: unterminated `{{env:...}}` in template"))?;
+        let var_name = &after_marker[..end];
+        let value = std::env::var(var_name).map_err(|_| {
+            anyhow!("publisher webhook: env var `{var_name}` referenced via {{env:...}} is not set")
+        })?;
+        out.push_str(&value);
+        rest = &after_marker[end + 1..];
+    }
+    out.push_str(rest);
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::RegistryConfig;
+
+    fn make_ctx<'a>(registries: &'a BTreeMap<String, RegistryConfig>) -> PublishContext<'a> {
+        let pkg_path = std::path::PathBuf::from(".");
+        PublishContext {
+            package_name: "ferrflow",
+            package_path: Box::leak(Box::new(pkg_path)),
+            new_version: "5.3.0",
+            tag: "v5.3.0",
+            registries,
+            dry_run: true,
+            verbose: false,
+        }
+    }
+
+    #[test]
+    fn interpolate_replaces_all_placeholders() {
+        let registries = BTreeMap::new();
+        let ctx = make_ctx(&registries);
+        assert_eq!(
+            interpolate("released {name}@{version} ({tag})", &ctx).unwrap(),
+            "released ferrflow@5.3.0 (v5.3.0)"
+        );
+    }
+
+    #[test]
+    fn env_placeholder_resolves_when_set() {
+        // SAFETY: This is a test-only var name that's never used elsewhere; the
+        // process-wide write happens once and tests run sequentially within the same
+        // process so this can't race with anything reading the same key.
+        unsafe {
+            std::env::set_var("FERRFLOW_TEST_WEBHOOK_TOKEN", "secret-123");
+        }
+        let s = resolve_env_placeholders("Bearer {env:FERRFLOW_TEST_WEBHOOK_TOKEN}").unwrap();
+        assert_eq!(s, "Bearer secret-123");
+    }
+
+    #[test]
+    fn env_placeholder_missing_is_an_error() {
+        let err = resolve_env_placeholders("Bearer {env:__FERRFLOW_NEVER_SET_TOKEN}")
+            .expect_err("must error");
+        assert!(format!("{err:?}").contains("is not set"));
+    }
+
+    #[test]
+    fn env_placeholder_unterminated_is_an_error() {
+        let err = resolve_env_placeholders("{env:FOO").expect_err("must error");
+        assert!(format!("{err:?}").contains("unterminated"));
+    }
+
+    #[test]
+    fn default_body_has_package_version_tag() {
+        let registries = BTreeMap::new();
+        let ctx = make_ctx(&registries);
+        let body = default_body(&ctx);
+        assert_eq!(body["package"], "ferrflow");
+        assert_eq!(body["version"], "5.3.0");
+        assert_eq!(body["tag"], "v5.3.0");
+    }
+
+    #[test]
+    fn dry_run_short_circuits() {
+        let registries = BTreeMap::new();
+        let ctx = make_ctx(&registries);
+        let outcome =
+            run("https://example.com/hook", None, &BTreeMap::new(), &ctx).expect("dry-run");
+        assert!(matches!(outcome, PublishOutcome::DryRun));
+    }
+}


### PR DESCRIPTION
Part 5 of #571. Final 3 publisher executors — completes the 6-kind set. Helm: package + push to OCI, idempotent via helm show chart probe. GitHub release asset: gh release upload --clobber on the new release. Webhook: ureq POST with {name}/{version}/{tag}/{env:NAME} interpolation in URL/body/headers. NotImplementedYet variant removed since every kind is now implemented. 598 lib tests passing, clippy clean.