### PR TITLE
feat(publishers): add noVerify option to cargo publisher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "5.3.6"
+version = "5.6.0"
 dependencies = [
  "anyhow",
  "cargo-husky",

--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -255,7 +255,8 @@
           "properties": {
             "kind": { "const": "cargo" },
             "registry": { "type": "string" },
-            "allowDirty": { "type": "boolean", "default": false }
+            "allowDirty": { "type": "boolean", "default": false },
+            "noVerify": { "type": "boolean", "default": false, "description": "Pass cargo publish --no-verify. Set for multi-crate batch releases so inter-dependent crates don't fail on registry-index propagation timing." }
           },
           "additionalProperties": false
         },

--- a/src/config/format.rs
+++ b/src/config/format.rs
@@ -61,6 +61,7 @@ const CAMEL_CASE_KEYS: &[&str] = &[
     "prerelease_identifier",
     "token_env",
     "allow_dirty",
+    "no_verify",
     "display_name",
 ];
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1507,7 +1507,7 @@ fn publishers_cargo_kind_parses() {
             "name": "auth",
             "path": "crates/auth",
             "publishers": [
-                { "kind": "cargo", "registry": "kellnr", "allowDirty": false }
+                { "kind": "cargo", "registry": "kellnr", "allowDirty": false, "noVerify": true }
             ]
         }]
     }"#;
@@ -1517,10 +1517,28 @@ fn publishers_cargo_kind_parses() {
         PublisherConfig::Cargo {
             registry,
             allow_dirty,
+            no_verify,
         } => {
             assert_eq!(registry.as_deref(), Some("kellnr"));
             assert!(!*allow_dirty);
+            assert!(*no_verify);
         }
+        _ => panic!("expected cargo kind"),
+    }
+}
+
+#[test]
+fn publishers_cargo_no_verify_defaults_false() {
+    let json = r#"{
+        "package": [{
+            "name": "auth",
+            "path": "crates/auth",
+            "publishers": [{ "kind": "cargo" }]
+        }]
+    }"#;
+    let cfg: Config = serde_json::from_str(json).unwrap();
+    match &cfg.packages[0].publishers[0] {
+        PublisherConfig::Cargo { no_verify, .. } => assert!(!*no_verify),
         _ => panic!("expected cargo kind"),
     }
 }
@@ -1562,6 +1580,7 @@ fn publishers_describe_renders_dry_run_preview() {
     let cargo = PublisherConfig::Cargo {
         registry: Some("kellnr".to_string()),
         allow_dirty: false,
+        no_verify: false,
     };
     assert_eq!(
         cargo.describe("ferrlabs-auth", "0.1.0"),

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -134,6 +134,17 @@ pub enum PublisherConfig {
         /// Mirrors `cargo publish --allow-dirty`. Default false.
         #[serde(default, rename = "allowDirty")]
         allow_dirty: bool,
+        /// Mirrors `cargo publish --no-verify`. Default false.
+        ///
+        /// Set this when publishing a batch of inter-dependent
+        /// workspace crates: the verify build would otherwise require
+        /// each just-published crate to propagate to the registry
+        /// index before the next dependent crate can resolve it, which
+        /// makes a multi-crate release order- and timing-sensitive.
+        /// `--no-verify` skips that build (the workspace was already
+        /// built + tested in CI) and makes the batch publish robust.
+        #[serde(default, rename = "noVerify")]
+        no_verify: bool,
     },
     /// `npm publish` to npmjs.org, GitHub Packages, or a custom
     /// registry. `registry` references workspace registries.

--- a/src/publishers/cargo.rs
+++ b/src/publishers/cargo.rs
@@ -23,6 +23,7 @@ use crate::error_code::{self, ErrorCodeExt};
 pub fn run(
     registry: Option<&str>,
     allow_dirty: bool,
+    no_verify: bool,
     ctx: &PublishContext<'_>,
 ) -> Result<PublishOutcome> {
     let registry_label = registry.unwrap_or("crates-io");
@@ -60,6 +61,9 @@ pub fn run(
     }
     if allow_dirty {
         cmd.arg("--allow-dirty");
+    }
+    if no_verify {
+        cmd.arg("--no-verify");
     }
 
     let output = cmd.output().with_context(|| {
@@ -176,7 +180,7 @@ mod tests {
     fn missing_registry_definition_is_a_clear_error() {
         let registries = BTreeMap::new();
         let (c, _) = ctx(&registries, true);
-        let err = run(Some("kellnr"), false, &c).expect_err("must error");
+        let err = run(Some("kellnr"), false, false, &c).expect_err("must error");
         let msg = format!("{err:?}");
         assert!(
             msg.contains("not declared under `workspace.registries`"),
@@ -195,7 +199,7 @@ mod tests {
             },
         );
         let (c, _) = ctx(&registries, false);
-        let err = run(Some("kellnr"), false, &c).expect_err("must error");
+        let err = run(Some("kellnr"), false, false, &c).expect_err("must error");
         let msg = format!("{err:?}");
         assert!(
             msg.contains("is not set"),
@@ -207,7 +211,7 @@ mod tests {
     fn dry_run_short_circuits_after_validation() {
         let registries = BTreeMap::new();
         let (c, _) = ctx(&registries, true);
-        let outcome = run(None, false, &c).expect("public registry dry-run");
+        let outcome = run(None, false, false, &c).expect("public registry dry-run");
         assert!(matches!(outcome, PublishOutcome::DryRun));
     }
 
@@ -222,7 +226,7 @@ mod tests {
             },
         );
         let (c, _) = ctx(&registries, true);
-        let outcome = run(Some("kellnr"), false, &c).expect("dry-run with env");
+        let outcome = run(Some("kellnr"), false, false, &c).expect("dry-run with env");
         assert!(matches!(outcome, PublishOutcome::DryRun));
     }
 

--- a/src/publishers/mod.rs
+++ b/src/publishers/mod.rs
@@ -67,7 +67,8 @@ pub fn run(p: &PublisherConfig, ctx: &PublishContext<'_>) -> Result<PublishOutco
         PublisherConfig::Cargo {
             registry,
             allow_dirty,
-        } => cargo::run(registry.as_deref(), *allow_dirty, ctx),
+            no_verify,
+        } => cargo::run(registry.as_deref(), *allow_dirty, *no_verify, ctx),
         PublisherConfig::Npm {
             registry,
             tag,


### PR DESCRIPTION
Adds `noVerify` to the cargo publisher (mirrors `cargo publish --no-verify`). Needed for dogfooding Kit, whose 10 inter-dependent crates publish to Kellnr: the verify build would otherwise require each just-published crate to propagate to the registry index before the next dependent crate resolves, making a multi-crate release order/timing-sensitive. `--no-verify` makes the batch robust (the workspace is already built+tested in CI). Defaults false. Schema + tests updated; 39 publisher tests pass, clippy clean.