### PR TITLE
feat(publishers): add args escape-hatch to command publishers

### DIFF
--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -256,7 +256,8 @@
             "kind": { "const": "cargo" },
             "registry": { "type": "string" },
             "allowDirty": { "type": "boolean", "default": false },
-            "noVerify": { "type": "boolean", "default": false, "description": "Pass cargo publish --no-verify. Set for multi-crate batch releases so inter-dependent crates don't fail on registry-index propagation timing." }
+            "noVerify": { "type": "boolean", "default": false, "description": "Pass cargo publish --no-verify. Set for multi-crate batch releases so inter-dependent crates don't fail on registry-index propagation timing." },
+            "args": { "type": "array", "items": { "type": "string" }, "description": "Extra flags appended verbatim to the underlying cargo publish invocation. Escape hatch for options FerrFlow doesn't model natively.", "default": [] }
           },
           "additionalProperties": false
         },
@@ -267,7 +268,8 @@
             "kind": { "const": "npm" },
             "registry": { "type": "string" },
             "tag": { "type": "string" },
-            "access": { "type": "string", "enum": ["public", "restricted"] }
+            "access": { "type": "string", "enum": ["public", "restricted"] },
+            "args": { "type": "array", "items": { "type": "string" }, "description": "Extra flags appended verbatim to the underlying npm publish invocation. Escape hatch for options FerrFlow doesn't model natively.", "default": [] }
           },
           "additionalProperties": false
         },
@@ -281,7 +283,8 @@
             "platforms": { "type": "array", "items": { "type": "string" } },
             "context": { "type": "string", "default": "." },
             "dockerfile": { "type": "string", "default": "Dockerfile" },
-            "sign": { "type": "string", "enum": ["none", "sigstore"], "default": "none" }
+            "sign": { "type": "string", "enum": ["none", "sigstore"], "default": "none" },
+            "args": { "type": "array", "items": { "type": "string" }, "description": "Extra flags appended verbatim to the underlying docker buildx build invocation (before the build-context positional). Escape hatch for options FerrFlow doesn't model natively.", "default": [] }
           },
           "additionalProperties": false
         },
@@ -291,7 +294,8 @@
           "properties": {
             "kind": { "const": "helm" },
             "chart": { "type": "string", "default": "." },
-            "registry": { "type": "string" }
+            "registry": { "type": "string" },
+            "args": { "type": "array", "items": { "type": "string" }, "description": "Extra flags appended verbatim to the underlying helm push invocation. Escape hatch for options FerrFlow doesn't model natively.", "default": [] }
           },
           "additionalProperties": false
         },
@@ -301,7 +305,8 @@
           "properties": {
             "kind": { "const": "github-release-asset" },
             "path": { "type": "string" },
-            "displayName": { "type": "string" }
+            "displayName": { "type": "string" },
+            "args": { "type": "array", "items": { "type": "string" }, "description": "Extra flags appended verbatim to the underlying gh release upload invocation. Escape hatch for options FerrFlow doesn't model natively.", "default": [] }
           },
           "additionalProperties": false
         },

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1518,6 +1518,7 @@ fn publishers_cargo_kind_parses() {
             registry,
             allow_dirty,
             no_verify,
+            ..
         } => {
             assert_eq!(registry.as_deref(), Some("kellnr"));
             assert!(!*allow_dirty);
@@ -1544,6 +1545,31 @@ fn publishers_cargo_no_verify_defaults_false() {
 }
 
 #[test]
+fn publishers_args_parses_and_defaults_empty() {
+    let json = r#"{
+        "package": [{
+            "name": "auth",
+            "path": "crates/auth",
+            "publishers": [
+                { "kind": "cargo", "args": ["--locked", "--jobs", "2"] },
+                { "kind": "npm" }
+            ]
+        }]
+    }"#;
+    let cfg: Config = serde_json::from_str(json).unwrap();
+    match &cfg.packages[0].publishers[0] {
+        PublisherConfig::Cargo { args, .. } => {
+            assert_eq!(args, &vec!["--locked", "--jobs", "2"]);
+        }
+        _ => panic!("expected cargo kind"),
+    }
+    match &cfg.packages[0].publishers[1] {
+        PublisherConfig::Npm { args, .. } => assert!(args.is_empty()),
+        _ => panic!("expected npm kind"),
+    }
+}
+
+#[test]
 fn publishers_docker_kind_has_defaults() {
     let json = r#"{
         "package": [{
@@ -1563,6 +1589,7 @@ fn publishers_docker_kind_has_defaults() {
             context,
             dockerfile,
             sign,
+            ..
         } => {
             assert_eq!(image, "ghcr.io/ferrlabs/auth");
             assert_eq!(tags, &vec!["{version}".to_string()]);
@@ -1581,6 +1608,7 @@ fn publishers_describe_renders_dry_run_preview() {
         registry: Some("kellnr".to_string()),
         allow_dirty: false,
         no_verify: false,
+        args: vec![],
     };
     assert_eq!(
         cargo.describe("ferrlabs-auth", "0.1.0"),
@@ -1594,6 +1622,7 @@ fn publishers_describe_renders_dry_run_preview() {
         context: ".".to_string(),
         dockerfile: "Dockerfile".to_string(),
         sign: crate::config::DockerSign::Sigstore,
+        args: vec![],
     };
     let line = docker.describe("ferrlabs-auth", "0.1.0");
     assert!(line.contains("ghcr.io/ferrlabs/auth"));

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -145,6 +145,11 @@ pub enum PublisherConfig {
         /// built + tested in CI) and makes the batch publish robust.
         #[serde(default, rename = "noVerify")]
         no_verify: bool,
+        /// Extra raw arguments appended to the `cargo publish`
+        /// invocation. Escape hatch for flags FerrFlow doesn't model
+        /// (e.g. `--features`, `--target`). Passed verbatim.
+        #[serde(default)]
+        args: Vec<String>,
     },
     /// `npm publish` to npmjs.org, GitHub Packages, or a custom
     /// registry. `registry` references workspace registries.
@@ -159,6 +164,10 @@ pub enum PublisherConfig {
         /// `--access public|restricted` for scoped packages.
         #[serde(default)]
         access: Option<String>,
+        /// Extra raw arguments appended to `npm publish` (e.g.
+        /// `--provenance`, `--dry-run`). Passed verbatim.
+        #[serde(default)]
+        args: Vec<String>,
     },
     /// Docker `buildx` push with optional Sigstore signing.
     Docker {
@@ -185,6 +194,11 @@ pub enum PublisherConfig {
         /// `none` = no signature.
         #[serde(default)]
         sign: DockerSign,
+        /// Extra raw arguments passed to `docker buildx build`,
+        /// inserted before the build context positional (e.g.
+        /// `--build-arg`, `--cache-from`, `--provenance=false`).
+        #[serde(default)]
+        args: Vec<String>,
     },
     /// OCI helm chart push.
     Helm {
@@ -193,6 +207,10 @@ pub enum PublisherConfig {
         chart: String,
         /// Target OCI registry, e.g. `oci://ghcr.io/ferrlabs/charts`.
         registry: String,
+        /// Extra raw arguments appended to `helm push` (e.g.
+        /// `--insecure-skip-tls-verify`). Passed verbatim.
+        #[serde(default)]
+        args: Vec<String>,
     },
     /// Attach an extra file to the GitHub Release that
     /// `ferrflow release` just created. Useful for SBOMs, signed
@@ -204,6 +222,10 @@ pub enum PublisherConfig {
         /// path's basename.
         #[serde(default, rename = "displayName")]
         display_name: Option<String>,
+        /// Extra raw arguments appended to `gh release upload` (e.g.
+        /// `--repo`). Passed verbatim.
+        #[serde(default)]
+        args: Vec<String>,
     },
     /// Generic POST notifier — Slack incoming webhook, Discord,
     /// custom internal services. The JSON body has access to
@@ -300,10 +322,14 @@ impl PublisherConfig {
                     resolved.join(", ")
                 )
             }
-            PublisherConfig::Helm { chart, registry } => {
+            PublisherConfig::Helm {
+                chart, registry, ..
+            } => {
                 format!("helm push {chart} {new_version} → {registry}")
             }
-            PublisherConfig::GithubReleaseAsset { path, display_name } => {
+            PublisherConfig::GithubReleaseAsset {
+                path, display_name, ..
+            } => {
                 let shown = display_name.as_deref().unwrap_or(path);
                 format!("upload {shown} → GitHub Release {new_version}")
             }

--- a/src/publishers/cargo.rs
+++ b/src/publishers/cargo.rs
@@ -24,6 +24,7 @@ pub fn run(
     registry: Option<&str>,
     allow_dirty: bool,
     no_verify: bool,
+    extra_args: &[String],
     ctx: &PublishContext<'_>,
 ) -> Result<PublishOutcome> {
     let registry_label = registry.unwrap_or("crates-io");
@@ -65,6 +66,7 @@ pub fn run(
     if no_verify {
         cmd.arg("--no-verify");
     }
+    cmd.args(extra_args);
 
     let output = cmd.output().with_context(|| {
         format!(
@@ -180,7 +182,7 @@ mod tests {
     fn missing_registry_definition_is_a_clear_error() {
         let registries = BTreeMap::new();
         let (c, _) = ctx(&registries, true);
-        let err = run(Some("kellnr"), false, false, &c).expect_err("must error");
+        let err = run(Some("kellnr"), false, false, &[], &c).expect_err("must error");
         let msg = format!("{err:?}");
         assert!(
             msg.contains("not declared under `workspace.registries`"),
@@ -199,7 +201,7 @@ mod tests {
             },
         );
         let (c, _) = ctx(&registries, false);
-        let err = run(Some("kellnr"), false, false, &c).expect_err("must error");
+        let err = run(Some("kellnr"), false, false, &[], &c).expect_err("must error");
         let msg = format!("{err:?}");
         assert!(
             msg.contains("is not set"),
@@ -211,7 +213,7 @@ mod tests {
     fn dry_run_short_circuits_after_validation() {
         let registries = BTreeMap::new();
         let (c, _) = ctx(&registries, true);
-        let outcome = run(None, false, false, &c).expect("public registry dry-run");
+        let outcome = run(None, false, false, &[], &c).expect("public registry dry-run");
         assert!(matches!(outcome, PublishOutcome::DryRun));
     }
 
@@ -226,7 +228,7 @@ mod tests {
             },
         );
         let (c, _) = ctx(&registries, true);
-        let outcome = run(Some("kellnr"), false, false, &c).expect("dry-run with env");
+        let outcome = run(Some("kellnr"), false, false, &[], &c).expect("dry-run with env");
         assert!(matches!(outcome, PublishOutcome::DryRun));
     }
 

--- a/src/publishers/docker.rs
+++ b/src/publishers/docker.rs
@@ -40,6 +40,7 @@ pub fn run(
     context_subdir: &str,
     dockerfile: &str,
     sign: DockerSign,
+    extra_args: &[String],
     ctx: &PublishContext<'_>,
 ) -> Result<PublishOutcome> {
     let resolved_tags = expand_tags(tags, ctx.new_version);
@@ -87,6 +88,9 @@ pub fn run(
     }
     cmd.arg("--metadata-file")
         .arg(metadata_path(ctx.package_path));
+    // User-supplied flags go BEFORE the build-context positional —
+    // buildx rejects flags that follow the context argument.
+    cmd.args(extra_args);
     cmd.arg(&context_path);
 
     let output = cmd.output().with_context(|| {
@@ -248,6 +252,7 @@ mod tests {
             ".",
             "Dockerfile",
             DockerSign::None,
+            &[],
             &ctx(&registries, true),
         )
         .expect("dry-run");

--- a/src/publishers/github_release_asset.rs
+++ b/src/publishers/github_release_asset.rs
@@ -16,6 +16,7 @@ use crate::error_code::{self, ErrorCodeExt};
 pub fn run(
     path: &str,
     display_name: Option<&str>,
+    extra_args: &[String],
     ctx: &PublishContext<'_>,
 ) -> Result<PublishOutcome> {
     let asset_path = ctx.package_path.join(path);
@@ -42,6 +43,7 @@ pub fn run(
         .arg(ctx.tag)
         .arg(&asset_arg)
         .arg("--clobber")
+        .args(extra_args)
         .output()
         .with_context(|| "spawn `gh release upload` failed (is gh in PATH?)")?;
     if !output.status.success() {
@@ -76,7 +78,7 @@ mod tests {
             dry_run: true,
             verbose: false,
         };
-        let err = run("sbom.cdx.json", None, &ctx).expect_err("must error");
+        let err = run("sbom.cdx.json", None, &[], &ctx).expect_err("must error");
         assert!(format!("{err:?}").contains("does not exist"));
     }
 
@@ -94,7 +96,7 @@ mod tests {
             dry_run: true,
             verbose: false,
         };
-        let outcome = run("sbom.cdx.json", Some("sbom.json"), &ctx).expect("dry-run");
+        let outcome = run("sbom.cdx.json", Some("sbom.json"), &[], &ctx).expect("dry-run");
         assert!(matches!(outcome, PublishOutcome::DryRun));
     }
 }

--- a/src/publishers/helm.rs
+++ b/src/publishers/helm.rs
@@ -15,7 +15,12 @@ use std::process::Command;
 use super::{PublishContext, PublishOutcome};
 use crate::error_code::{self, ErrorCodeExt};
 
-pub fn run(chart_path: &str, registry: &str, ctx: &PublishContext<'_>) -> Result<PublishOutcome> {
+pub fn run(
+    chart_path: &str,
+    registry: &str,
+    extra_args: &[String],
+    ctx: &PublishContext<'_>,
+) -> Result<PublishOutcome> {
     let chart_dir = ctx.package_path.join(chart_path);
     if !chart_dir.exists() {
         return Err(anyhow!(
@@ -66,6 +71,7 @@ pub fn run(chart_path: &str, registry: &str, ctx: &PublishContext<'_>) -> Result
         .arg("push")
         .arg(&tgz)
         .arg(registry)
+        .args(extra_args)
         .output()
         .with_context(|| "spawn `helm push` failed")?;
     if !push.status.success() {
@@ -146,7 +152,7 @@ mod tests {
         let registries = BTreeMap::new();
         let c = ctx(&registries, dir.path(), true);
         let outcome =
-            run("chart", "oci://ghcr.io/x/charts", &c).expect("dry-run after Chart.yaml load");
+            run("chart", "oci://ghcr.io/x/charts", &[], &c).expect("dry-run after Chart.yaml load");
         assert!(matches!(outcome, PublishOutcome::DryRun));
     }
 
@@ -155,7 +161,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let registries = BTreeMap::new();
         let c = ctx(&registries, dir.path(), true);
-        let err = run("does-not-exist", "oci://ghcr.io/x", &c).expect_err("must error");
+        let err = run("does-not-exist", "oci://ghcr.io/x", &[], &c).expect_err("must error");
         assert!(format!("{err:?}").contains("does not exist"));
     }
 

--- a/src/publishers/mod.rs
+++ b/src/publishers/mod.rs
@@ -68,12 +68,20 @@ pub fn run(p: &PublisherConfig, ctx: &PublishContext<'_>) -> Result<PublishOutco
             registry,
             allow_dirty,
             no_verify,
-        } => cargo::run(registry.as_deref(), *allow_dirty, *no_verify, ctx),
+            args,
+        } => cargo::run(registry.as_deref(), *allow_dirty, *no_verify, args, ctx),
         PublisherConfig::Npm {
             registry,
             tag,
             access,
-        } => npm::run(registry.as_deref(), tag.as_deref(), access.as_deref(), ctx),
+            args,
+        } => npm::run(
+            registry.as_deref(),
+            tag.as_deref(),
+            access.as_deref(),
+            args,
+            ctx,
+        ),
         PublisherConfig::Docker {
             image,
             tags,
@@ -81,11 +89,20 @@ pub fn run(p: &PublisherConfig, ctx: &PublishContext<'_>) -> Result<PublishOutco
             context,
             dockerfile,
             sign,
-        } => docker::run(image, tags, platforms, context, dockerfile, *sign, ctx),
-        PublisherConfig::Helm { chart, registry } => helm::run(chart, registry, ctx),
-        PublisherConfig::GithubReleaseAsset { path, display_name } => {
-            github_release_asset::run(path, display_name.as_deref(), ctx)
-        }
+            args,
+        } => docker::run(
+            image, tags, platforms, context, dockerfile, *sign, args, ctx,
+        ),
+        PublisherConfig::Helm {
+            chart,
+            registry,
+            args,
+        } => helm::run(chart, registry, args, ctx),
+        PublisherConfig::GithubReleaseAsset {
+            path,
+            display_name,
+            args,
+        } => github_release_asset::run(path, display_name.as_deref(), args, ctx),
         PublisherConfig::Webhook { url, body, headers } => {
             webhook::run(url, body.as_ref(), headers, ctx)
         }

--- a/src/publishers/npm.rs
+++ b/src/publishers/npm.rs
@@ -26,6 +26,7 @@ pub fn run(
     registry: Option<&str>,
     tag: Option<&str>,
     access: Option<&str>,
+    extra_args: &[String],
     ctx: &PublishContext<'_>,
 ) -> Result<PublishOutcome> {
     let registry_label = registry.unwrap_or("npmjs.org");
@@ -81,6 +82,7 @@ pub fn run(
     if let Some(a) = access {
         cmd.arg(format!("--access={a}"));
     }
+    cmd.args(extra_args);
 
     let output = cmd.output().with_context(|| {
         format!(
@@ -230,8 +232,14 @@ mod tests {
     #[test]
     fn missing_registry_definition_is_a_clear_error() {
         let registries = BTreeMap::new();
-        let err =
-            run(Some("gh-packages"), None, None, &ctx(&registries, true)).expect_err("must error");
+        let err = run(
+            Some("gh-packages"),
+            None,
+            None,
+            &[],
+            &ctx(&registries, true),
+        )
+        .expect_err("must error");
         assert!(format!("{err:?}").contains("not declared under `workspace.registries`"));
     }
 
@@ -245,15 +253,21 @@ mod tests {
                 token_env: Some("__FERRFLOW_NPM_TOKEN_NEVER_SET".into()),
             },
         );
-        let err =
-            run(Some("gh-packages"), None, None, &ctx(&registries, false)).expect_err("must error");
+        let err = run(
+            Some("gh-packages"),
+            None,
+            None,
+            &[],
+            &ctx(&registries, false),
+        )
+        .expect_err("must error");
         assert!(format!("{err:?}").contains("is not set"));
     }
 
     #[test]
     fn dry_run_short_circuits_for_public_npm() {
         let registries = BTreeMap::new();
-        let outcome = run(None, None, None, &ctx(&registries, true)).expect("dry-run");
+        let outcome = run(None, None, None, &[], &ctx(&registries, true)).expect("dry-run");
         assert!(matches!(outcome, PublishOutcome::DryRun));
     }
 


### PR DESCRIPTION
@
## What

Adds an `args: string[]` field to every command-based publisher — `cargo`, `npm`, `docker`, `helm`, `github-release-asset`. The strings are appended verbatim to the underlying tool invocation, so users can pass options FerrFlow doesnt model natively without waiting for a new typed field.

```json
{
  "publishers": [
    { "kind": "cargo", "registry": "kellnr", "args": ["--locked"] },
    { "kind": "npm", "args": ["--provenance"] },
    { "kind": "docker", "image": "ghcr.io/ferrlabs/api", "args": ["--build-arg", "PROFILE=release"] }
  ]
}
```

## Why

The typed fields cover the common flags, but there will always be a tool option we dont model (`cargo publish --locked`, `npm publish --provenance`, `docker buildx --build-arg`, …). The escape hatch keeps publishers usable without a config-schema change per flag.

## Notes

- `webhook` is excluded — it isnt a shelled-out command.
- For docker, `args` are inserted **before** the build-context positional (buildx rejects flags that follow the context argument).
- `args` defaults to `[]`, so existing configs are unaffected.
- Schema updated (mirrored to FerrFlow-Cloud in a separate PR alongside the docs).

Closes #578
@