### PR TITLE
feat(cli): add ferrflow publish to run publishers without releasing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "5.6.0"
+version = "5.7.0"
 dependencies = [
  "anyhow",
  "cargo-husky",

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
     default: 'latest'
   mode:
-    description: 'Action mode: "release" runs the full release pipeline. "preview" posts a PR comment with version bump preview.'
+    description: 'Action mode: "release" runs the full release pipeline. "preview" posts a PR comment with version bump preview. "publish" runs the configured publishers for the currently-released version (no bump/tag) — for a separate job that has the build toolchain + registry auth the publishers need.'
     required: false
     default: 'release'
   dry_run:
@@ -110,3 +110,8 @@ runs:
         FERRFLOW_BOT_ENDPOINT: ${{ inputs.bot_endpoint }}
         FERRFLOW_BOT_AUDIENCE: ${{ inputs.bot_audience }}
       run: ferrflow ${{ inputs.dry_run == 'true' && '--dry-run' || '' }} release ${{ inputs.force_version != '' && format('--force-version {0}', inputs.force_version) || '' }}
+
+    - name: Run FerrFlow publishers
+      if: inputs.mode == 'publish'
+      shell: bash
+      run: ferrflow ${{ inputs.dry_run == 'true' && '--dry-run' || '' }} publish

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,6 +64,16 @@ pub enum Commands {
         #[arg(long)]
         force_unlock: bool,
     },
+    /// Run the configured publishers for the currently-released version
+    /// of each package, without bumping or tagging. Use after `release`
+    /// has cut the version — typically in a separate CI job that has the
+    /// build toolchain and registry auth the publishers need (docker
+    /// buildx, helm, npm, …).
+    Publish {
+        /// Package to publish (required in monorepos to target one;
+        /// omit to run publishers for every package)
+        package: Option<String>,
+    },
     /// Generate/update CHANGELOG.md only
     Changelog,
     /// Scaffold a ferrflow configuration file
@@ -118,6 +128,7 @@ impl Commands {
         match self {
             Commands::Check { .. } => "check",
             Commands::Release { .. } => "release",
+            Commands::Publish { .. } => "publish",
             Commands::Changelog => "changelog",
             Commands::Init { .. } => "init",
             Commands::Status { .. } => "status",
@@ -158,6 +169,12 @@ impl Cli {
                 channel.as_deref(),
                 draft,
                 force_unlock,
+            ),
+            Commands::Publish { package } => crate::publish::run(
+                self.config.as_deref(),
+                package.as_deref(),
+                self.dry_run,
+                self.verbose,
             ),
             Commands::Changelog => {
                 crate::changelog::generate_only(self.config.as_deref(), self.dry_run)
@@ -309,6 +326,22 @@ mod tests {
     fn parse_status_default() {
         let cli = parse(&["ferrflow", "status"]);
         assert!(matches!(cli.command, Commands::Status { .. }));
+    }
+
+    #[test]
+    fn parse_publish_no_package() {
+        let cli = parse(&["ferrflow", "publish"]);
+        assert!(matches!(cli.command, Commands::Publish { package: None }));
+    }
+
+    #[test]
+    fn parse_publish_with_package_and_dry_run() {
+        let cli = parse(&["ferrflow", "--dry-run", "publish", "my-pkg"]);
+        assert!(cli.dry_run);
+        match cli.command {
+            Commands::Publish { package } => assert_eq!(package.as_deref(), Some("my-pkg")),
+            _ => panic!("expected Publish"),
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod git;
 mod hooks;
 mod monorepo;
 mod prerelease;
+mod publish;
 mod publishers;
 mod query;
 mod status;

--- a/src/monorepo/run/execute.rs
+++ b/src/monorepo/run/execute.rs
@@ -555,14 +555,6 @@ fn run_publishers_for_package(
     new_version: &str,
     tag: &str,
 ) -> Result<()> {
-    if pkg.publishers.is_empty() {
-        return Ok(());
-    }
-    println!(
-        "  {} {} publishers:",
-        "→".cyan(),
-        pkg.publishers.len().to_string().cyan()
-    );
     let package_path = plan.root.join(&pkg.path);
     let pub_ctx = crate::publishers::PublishContext {
         package_name,
@@ -573,27 +565,7 @@ fn run_publishers_for_package(
         dry_run: plan.dry_run,
         verbose: plan.verbose,
     };
-    for p in &pkg.publishers {
-        let kind = p.kind_name();
-        let preview = p.describe(package_name, new_version);
-        match crate::publishers::run(p, &pub_ctx) {
-            Ok(crate::publishers::PublishOutcome::Published { url }) => {
-                let suffix = url.as_deref().unwrap_or("");
-                println!("    [{kind}] {preview} → {} {suffix}", "published".green());
-            }
-            Ok(crate::publishers::PublishOutcome::Skipped { reason }) => {
-                println!("    [{kind}] {preview} → {} ({reason})", "skipped".yellow());
-            }
-            Ok(crate::publishers::PublishOutcome::DryRun) => {
-                println!("    [{kind}] {preview} {}", "(dry-run)".dimmed());
-            }
-            Err(e) => {
-                eprintln!("    [{kind}] {} {e:#}", "ERROR".red());
-                return Err(e);
-            }
-        }
-    }
-    Ok(())
+    crate::publishers::run_all(&pkg.publishers, &pub_ctx)
 }
 
 /// Dry-run hook trace: when nothing will actually fire (no commit, no

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -1,0 +1,211 @@
+use anyhow::Result;
+use colored::Colorize;
+use std::path::Path;
+
+use crate::config::{Config, PackageConfig};
+use crate::error_code::{self, ErrorCodeExt};
+use crate::formats::read_version;
+use crate::git::{Repository, find_highest_semver_tag_with_cache, get_repo_root, open_repo};
+use crate::publishers::{self, PublishContext};
+
+pub fn run(
+    config_path: Option<&Path>,
+    package: Option<&str>,
+    dry_run: bool,
+    verbose: bool,
+) -> Result<()> {
+    let repo = open_repo(&std::env::current_dir()?)?;
+    let root = get_repo_root(&repo)?;
+    let config = Config::load(&root, config_path)?;
+
+    if config.packages.is_empty() {
+        Err(anyhow::anyhow!(
+            "No packages configured. Run `ferrflow init` to create a config."
+        ))
+        .error_code(error_code::QUERY_NO_PACKAGES)?;
+    }
+
+    let targets: Vec<&PackageConfig> = match package {
+        Some(name) => vec![
+            config
+                .packages
+                .iter()
+                .find(|p| p.name == name)
+                .ok_or_else(|| anyhow::anyhow!("package '{name}' not found"))
+                .error_code(error_code::QUERY_PACKAGE_NOT_FOUND)?,
+        ],
+        None => config.packages.iter().collect(),
+    };
+
+    let mut ran = 0usize;
+    for pkg in targets {
+        if pkg.publishers.is_empty() {
+            continue;
+        }
+        let version = current_version(&repo, pkg, &config, &root)?;
+        let tag = pkg.tag_for_version(&config.workspace, config.is_monorepo(), &version);
+        let package_path = root.join(&pkg.path);
+
+        println!(
+            "{} {} @ {}",
+            "publish".bold(),
+            pkg.name.cyan(),
+            version.cyan()
+        );
+        let ctx = PublishContext {
+            package_name: &pkg.name,
+            package_path: &package_path,
+            new_version: &version,
+            tag: &tag,
+            registries: &config.workspace.registries,
+            dry_run,
+            verbose,
+        };
+        publishers::run_all(&pkg.publishers, &ctx)?;
+        ran += 1;
+    }
+
+    if ran == 0 {
+        println!(
+            "{}",
+            "No publishers configured on any package — nothing to publish.".yellow()
+        );
+    }
+
+    Ok(())
+}
+
+/// Resolve the version currently on disk for `pkg` — the last released
+/// version, since `publish` runs after `release` has written and tagged
+/// it. Falls back to the highest matching tag for tag-only packages
+/// (#531) that carry no `versionedFiles`.
+fn current_version(
+    repo: &Repository,
+    pkg: &PackageConfig,
+    config: &Config,
+    root: &Path,
+) -> Result<String> {
+    if let Some(vf) = pkg.versioned_files.first() {
+        return read_version(vf, root);
+    }
+    let prefix = pkg.tag_prefix(&config.workspace, config.is_monorepo());
+    find_highest_semver_tag_with_cache(repo, &prefix, config.workspace.orphaned_tag_strategy, None)?
+        .map(|(_, version)| version)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "package '{}' has no versionedFiles and no matching release tag; \
+                 run `ferrflow release` before `ferrflow publish`",
+                pkg.name
+            )
+        })
+        .error_code(error_code::QUERY_PACKAGE_NOT_FOUND)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{commit_file, git, init_repo, with_cwd};
+    use std::fs;
+
+    fn write_config(dir: &Path, body: &str) -> std::path::PathBuf {
+        let path = dir.join(".ferrflow");
+        fs::write(&path, body).unwrap();
+        path
+    }
+
+    #[test]
+    fn no_packages_errors() {
+        let (dir, repo) = init_repo();
+        let cfg = write_config(dir.path(), r#"{"package": []}"#);
+        commit_file(dir.path(), "init.txt", "x", "chore: init", 1_800_000_001);
+        let _ = &repo;
+        let err = with_cwd(dir.path(), || run(Some(&cfg), None, true, false)).unwrap_err();
+        assert!(format!("{err:?}").contains("No packages"));
+    }
+
+    #[test]
+    fn unknown_package_errors() {
+        let (dir, _repo) = init_repo();
+        let cfg = write_config(
+            dir.path(),
+            r#"{"package": [{"name": "a", "path": ".", "versionedFiles": [{"path": "Cargo.toml", "format": "toml"}]}]}"#,
+        );
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"a\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        commit_file(dir.path(), "init.txt", "x", "chore: init", 1_800_000_002);
+        let err = with_cwd(dir.path(), || run(Some(&cfg), Some("nope"), true, false)).unwrap_err();
+        assert!(format!("{err:?}").contains("not found"));
+    }
+
+    #[test]
+    fn package_without_publishers_is_a_noop() {
+        let (dir, _repo) = init_repo();
+        let cfg = write_config(
+            dir.path(),
+            r#"{"package": [{"name": "a", "path": ".", "versionedFiles": [{"path": "Cargo.toml", "format": "toml"}]}]}"#,
+        );
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"a\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        commit_file(dir.path(), "init.txt", "x", "chore: init", 1_800_000_003);
+        // No publishers → nothing runs, no error.
+        with_cwd(dir.path(), || run(Some(&cfg), None, true, false)).unwrap();
+    }
+
+    #[test]
+    fn dry_run_dispatches_publisher_against_current_version() {
+        let (dir, _repo) = init_repo();
+        // cargo publisher with no registry targets crates.io, so it skips
+        // token validation and short-circuits to DryRun without spawning
+        // cargo — exercising the read-version → dispatch path end to end.
+        let cfg = write_config(
+            dir.path(),
+            r#"{"package": [{"name": "a", "path": ".", "versionedFiles": [{"path": "Cargo.toml", "format": "toml"}], "publishers": [{"kind": "cargo"}]}]}"#,
+        );
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"a\"\nversion = \"2.3.4\"\n",
+        )
+        .unwrap();
+        commit_file(dir.path(), "init.txt", "x", "chore: init", 1_800_000_004);
+        with_cwd(dir.path(), || run(Some(&cfg), Some("a"), true, false)).unwrap();
+    }
+
+    #[test]
+    fn current_version_reads_from_versioned_file() {
+        let (dir, repo) = init_repo();
+        write_config(
+            dir.path(),
+            r#"{"package": [{"name": "a", "path": ".", "versionedFiles": [{"path": "Cargo.toml", "format": "toml"}]}]}"#,
+        );
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"a\"\nversion = \"9.9.9\"\n",
+        )
+        .unwrap();
+        commit_file(dir.path(), "init.txt", "x", "chore: init", 1_800_000_005);
+        let config = Config::load(dir.path(), None).unwrap();
+        let v = current_version(&repo, &config.packages[0], &config, dir.path()).unwrap();
+        assert_eq!(v, "9.9.9");
+    }
+
+    #[test]
+    fn current_version_falls_back_to_tag_for_tag_only_package() {
+        let (dir, repo) = init_repo();
+        write_config(
+            dir.path(),
+            r#"{"package": [{"name": "img", "path": ".", "changelog": "CHANGELOG.md"}]}"#,
+        );
+        commit_file(dir.path(), "init.txt", "x", "chore: init", 1_800_000_006);
+        // Single-package repo → default tag template is `v{version}`.
+        git(dir.path(), &["tag", "v1.4.0"]);
+        let config = Config::load(dir.path(), None).unwrap();
+        let v = current_version(&repo, &config.packages[0], &config, dir.path()).unwrap();
+        assert_eq!(v, "1.4.0");
+    }
+}

--- a/src/publishers/mod.rs
+++ b/src/publishers/mod.rs
@@ -9,6 +9,7 @@
 //! helm/asset/webhook land in follow-up PRs.
 
 use anyhow::Result;
+use colored::Colorize;
 use std::collections::BTreeMap;
 use std::path::Path;
 
@@ -59,6 +60,43 @@ pub enum PublishOutcome {
     /// Dry-run pass: nothing happened, only the preview line was
     /// printed by the caller.
     DryRun,
+}
+
+/// Run every publisher declared for a package against `ctx`, rendering
+/// a uniform `[kind] action … → status` line per entry. Shared by the
+/// `ferrflow release` post-publish phase and the standalone `ferrflow
+/// publish` command so both surface publishers identically. Returns the
+/// first executor error, after which remaining publishers are skipped.
+pub fn run_all(publishers: &[PublisherConfig], ctx: &PublishContext<'_>) -> Result<()> {
+    if publishers.is_empty() {
+        return Ok(());
+    }
+    println!(
+        "  {} {} publishers:",
+        "→".cyan(),
+        publishers.len().to_string().cyan()
+    );
+    for p in publishers {
+        let kind = p.kind_name();
+        let preview = p.describe(ctx.package_name, ctx.new_version);
+        match run(p, ctx) {
+            Ok(PublishOutcome::Published { url }) => {
+                let suffix = url.as_deref().unwrap_or("");
+                println!("    [{kind}] {preview} → {} {suffix}", "published".green());
+            }
+            Ok(PublishOutcome::Skipped { reason }) => {
+                println!("    [{kind}] {preview} → {} ({reason})", "skipped".yellow());
+            }
+            Ok(PublishOutcome::DryRun) => {
+                println!("    [{kind}] {preview} {}", "(dry-run)".dimmed());
+            }
+            Err(e) => {
+                eprintln!("    [{kind}] {} {e:#}", "ERROR".red());
+                return Err(e);
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Dispatch one publisher entry to its executor.


### PR DESCRIPTION
@
## What

Adds a standalone **`ferrflow publish [PACKAGE]`** command that runs the configured publishers for each packages currently-released version — without bumping, committing, or tagging. Also exposes it through the GitHub Action as **`mode: publish`**.

## Why

Publishers from #571 otherwise only run inside `ferrflow release`s job, which is often minimal (checkout + binary). Publishers that need a build toolchain or registry auth — docker buildx, helm, a built npm `dist/` — cant run there. `ferrflow publish` lets a separate tag-triggered CI job, with buildx/helm/login already set up, run the publishers. This unblocks dogfooding the docker/helm/npm publishers (FerrVault operator, UI).

## How it works

- Reads each packages current version from `versionedFiles` (or the latest matching tag for tag-only packages, #531), derives the tag, builds a `PublishContext`, and runs the publishers.
- Idempotent: anything already on the registry is skipped, so a re-run is safe. Honors global `--dry-run`.
- Extracts the publisher run/print loop into `publishers::run_all`, now shared by the release post-publish phase and the new command (no duplicated dispatch).

## Verification

- 6 unit tests on the command (version resolution from files + tag fallback, unknown-package error, no-packages error, no-publishers no-op, dry-run dispatch) + 2 CLI parse tests. Full suite: 736 bin + 600 lib green, clippy clean.
- Ran locally against Kits config: `ferrflow --dry-run publish` reads all 10 crates versions and previews each cargo publisher.

Docs (CLI reference) ship in a FerrFlow-Cloud PR.

Closes #580
@