### PR TITLE
feat(config): add workspace.deferPublish to skip publishers on release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "5.7.0"
+version = "5.9.0"
 dependencies = [
  "anyhow",
  "cargo-husky",

--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -99,6 +99,11 @@
         "hooks": {
           "$ref": "#/$defs/hooks"
         },
+        "deferPublish": {
+          "type": "boolean",
+          "description": "When true, `ferrflow release` does not run the configured publishers inline — it defers them to a separate `ferrflow publish` invocation (e.g. a CI job that carries the docker/helm/npm build toolchain the release job lacks). `ferrflow publish` always runs the publishers regardless of this flag.",
+          "default": false
+        },
         "registries": {
           "type": "object",
           "description": "Named registry credentials referenced by package.publishers[]. Lets users declare 'the Kellnr token lives in CARGO_REGISTRIES_KELLNR_TOKEN' once and reuse it across every cargo / npm / docker publisher.",

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -943,6 +943,20 @@ fn release_commit_scope_camel_case_alias() {
     );
 }
 
+#[test]
+fn defer_publish_defaults_false() {
+    let json = r#"{ "workspace": {}, "package": [] }"#;
+    let config: Config = serde_json::from_str(json).unwrap();
+    assert!(!config.workspace.defer_publish);
+}
+
+#[test]
+fn defer_publish_parses_camel_case_alias() {
+    let json = r#"{ "workspace": { "deferPublish": true }, "package": [] }"#;
+    let config: Config = serde_json::from_str(json).unwrap();
+    assert!(config.workspace.defer_publish);
+}
+
 // -----------------------------------------------------------------------
 // load_explicit with json5
 // -----------------------------------------------------------------------

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -48,6 +48,15 @@ pub struct WorkspaceConfig {
     /// the publisher RFC.
     #[serde(default)]
     pub registries: BTreeMap<String, RegistryConfig>,
+    /// When `true`, `ferrflow release` does NOT run the configured
+    /// `publishers` inline — it defers them to a separate `ferrflow
+    /// publish` invocation. Default `false` (publishers run at the end
+    /// of `release`, as usual). Set `true` when the release job is
+    /// minimal but publishing needs a build toolchain (docker buildx,
+    /// helm, a built npm dist) that lives in another CI job. `ferrflow
+    /// publish` always runs the publishers regardless of this flag.
+    #[serde(default, alias = "deferPublish")]
+    pub defer_publish: bool,
 }
 
 impl WorkspaceConfig {

--- a/src/monorepo/run/execute.rs
+++ b/src/monorepo/run/execute.rs
@@ -555,6 +555,12 @@ fn run_publishers_for_package(
     new_version: &str,
     tag: &str,
 ) -> Result<()> {
+    // `deferPublish` hands publishing off to a separate `ferrflow
+    // publish` run (typically a CI job that carries the build toolchain
+    // the release job lacks). Skip the inline run here.
+    if plan.config.workspace.defer_publish {
+        return Ok(());
+    }
     let package_path = plan.root.join(&pkg.path);
     let pub_ctx = crate::publishers::PublishContext {
         package_name,


### PR DESCRIPTION
@
## What

Adds `workspace.deferPublish` (bool, default `false`). When `true`, `ferrflow release` **skips** the inline publisher phase; `ferrflow publish` still runs the publishers regardless.

## Why

Publishers run at the end of `ferrflow release`, inside whatever job runs the release. When that job is minimal (no docker buildx / helm / built npm `dist/`), repos had to keep a **separate config file** for `ferrflow publish` so the release run wouldn't try to publish and fail. That two-file split is awkward. With `deferPublish: true`, a repo keeps **one** `.ferrflow` (publishers + the flag): `release` versions/tags, and a separate `ferrflow publish` job (with the toolchain) publishes.

## Notes

- Default `false` → existing behaviour unchanged (publishers run on release, as Kit relies on).
- Flag is read from config by the binary — **no action / reusable-workflow changes needed**.
- Implemented as a guard in the release post-publish phase; `ferrflow publish` ignores the flag.

## Verification

Unit tests (parse + default). Functional check in a temp repo: `ferrflow --dry-run release` with `deferPublish: true` shows no publisher output, while `ferrflow --dry-run publish` runs them. Full suite + clippy green; schema mirrored to FerrFlow-Cloud.

Closes #582
@