### PR TITLE
feat(cli): add --timing flag for per-stage breakdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "5.9.0"
+version = "5.10.0"
 dependencies = [
  "anyhow",
  "cargo-husky",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,7 @@ use clap_complete::Shell;
 
 use crate::config::ConfigFileFormat;
 use crate::status::OutputFormat;
+use crate::timing::Timing;
 
 #[derive(Parser)]
 #[command(name = "ferrflow")]
@@ -23,6 +24,10 @@ pub struct Cli {
     /// Path to config file (overrides auto-detection, env: FERRFLOW_CONFIG)
     #[arg(long, global = true, env = "FERRFLOW_CONFIG")]
     pub config: Option<PathBuf>,
+
+    /// Print a per-stage timing breakdown to stderr after the command finishes
+    #[arg(long, global = true)]
+    pub timing: bool,
 
     #[command(subcommand)]
     pub command: Commands,
@@ -142,6 +147,13 @@ impl Commands {
 
 impl Cli {
     pub fn run(self) -> Result<()> {
+        let mut timing = Timing::new(self.timing);
+        let result = self.dispatch(&mut timing);
+        timing.report();
+        result
+    }
+
+    fn dispatch(self, timing: &mut Timing) -> Result<()> {
         match self.command {
             Commands::Check {
                 json,
@@ -153,6 +165,7 @@ impl Cli {
                 json,
                 channel.as_deref(),
                 comment,
+                timing,
             ),
             Commands::Release {
                 force,
@@ -169,6 +182,7 @@ impl Cli {
                 channel.as_deref(),
                 draft,
                 force_unlock,
+                timing,
             ),
             Commands::Publish { package } => crate::publish::run(
                 self.config.as_deref(),
@@ -180,12 +194,14 @@ impl Cli {
                 crate::changelog::generate_only(self.config.as_deref(), self.dry_run)
             }
             Commands::Init { format } => crate::config::init(format),
-            Commands::Status { output } => crate::status::run(self.config.as_deref(), &output),
+            Commands::Status { output } => {
+                crate::status::run(self.config.as_deref(), &output, timing)
+            }
             Commands::Version { package, json } => {
                 crate::query::version(self.config.as_deref(), package.as_deref(), json)
             }
             Commands::Tag { package, json } => {
-                crate::query::tag(self.config.as_deref(), package.as_deref(), json)
+                crate::query::tag(self.config.as_deref(), package.as_deref(), json, timing)
             }
             Commands::Validate {
                 json,
@@ -464,6 +480,25 @@ mod tests {
     fn global_config_path() {
         let cli = parse(&["ferrflow", "--config", "/tmp/ferrflow.json", "check"]);
         assert_eq!(cli.config, Some(PathBuf::from("/tmp/ferrflow.json")));
+    }
+
+    #[test]
+    fn global_timing_default_off() {
+        let cli = parse(&["ferrflow", "check"]);
+        assert!(!cli.timing);
+    }
+
+    #[test]
+    fn global_timing() {
+        let cli = parse(&["ferrflow", "--timing", "check"]);
+        assert!(cli.timing);
+    }
+
+    #[test]
+    fn global_timing_after_subcommand() {
+        let cli = parse(&["ferrflow", "release", "--timing", "--dry-run"]);
+        assert!(cli.timing);
+        assert!(cli.dry_run);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod publishers;
 mod query;
 mod status;
 mod telemetry;
+mod timing;
 mod validate;
 mod versioning;
 

--- a/src/monorepo/check.rs
+++ b/src/monorepo/check.rs
@@ -5,21 +5,24 @@ use std::path::Path;
 use crate::config::Config;
 use crate::git::{get_repo_root, open_repo};
 use crate::telemetry;
+use crate::timing::Timing;
 
 use super::preview::post_preview_comment;
 use super::run::run_release_logic;
 
+#[allow(clippy::too_many_arguments)]
 pub fn check(
     config_path: Option<&Path>,
     verbose: bool,
     json: bool,
     channel: Option<&str>,
     comment: bool,
+    timing: &mut Timing,
 ) -> Result<()> {
     crate::bot_token::ensure_bot_token()?;
-    let repo = open_repo(&std::env::current_dir()?)?;
+    let repo = timing.stage("open_repo", || open_repo(&std::env::current_dir()?))?;
     let root = get_repo_root(&repo)?;
-    let config = Config::load(&root, config_path)?;
+    let config = timing.stage("load config", || Config::load(&root, config_path))?;
 
     if !json {
         println!("{}", "FerrFlow — Check (dry run)".bold().blue());
@@ -27,7 +30,7 @@ pub fn check(
     }
 
     let result = run_release_logic(
-        &root, &config, true, verbose, json, false, None, channel, false, false,
+        &root, &config, true, verbose, json, false, None, channel, false, false, timing,
     );
 
     if comment {

--- a/src/monorepo/release.rs
+++ b/src/monorepo/release.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 use crate::config::Config;
 use crate::git::{get_repo_root, open_repo};
+use crate::timing::Timing;
 
 use super::run::run_release_logic;
 
@@ -19,11 +20,12 @@ pub fn release(
     channel: Option<&str>,
     draft: bool,
     force_unlock: bool,
+    timing: &mut Timing,
 ) -> Result<()> {
     crate::bot_token::ensure_bot_token()?;
-    let repo = open_repo(&std::env::current_dir()?)?;
+    let repo = timing.stage("open_repo", || open_repo(&std::env::current_dir()?))?;
     let root = get_repo_root(&repo)?;
-    let config = Config::load(&root, config_path)?;
+    let config = timing.stage("load config", || Config::load(&root, config_path))?;
     drop(repo);
 
     if dry_run {
@@ -51,6 +53,7 @@ pub fn release(
             channel,
             draft,
             force_unlock,
+            timing,
         );
     }
 
@@ -72,6 +75,7 @@ pub fn release(
             channel,
             draft,
             force_unlock,
+            timing,
         );
 
         match result {

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -15,6 +15,7 @@ use crate::git::{
 use crate::hooks::{HookContext, HookPoint, resolve_hook, resolve_on_failure, run_hook};
 use crate::prerelease::PrereleaseContext;
 use crate::telemetry;
+use crate::timing::Timing;
 use crate::versioning::{compute_next_version, truncate_version};
 
 use super::types::{CheckCommit, CheckPackage, CheckResult};
@@ -48,6 +49,7 @@ pub(super) fn run_release_logic(
     channel: Option<&str>,
     draft: bool,
     force_unlock: bool,
+    timing: &mut Timing,
 ) -> Result<()> {
     if config.packages.is_empty() {
         if json {
@@ -66,6 +68,10 @@ pub(super) fn run_release_logic(
 
     let repo = open_repo(root)?;
 
+    if dry_run {
+        timing.skip("fetch_tags", "dry-run");
+    }
+
     // Acquire the release lock before any mutating step. Dropped at the
     // end of run_release_logic via RAII. Skipped on dry-run (no writes).
     // The lockfile lives at .git/ferrflow.lock; concurrent invocations
@@ -78,11 +84,15 @@ pub(super) fn run_release_logic(
         Some(lock::ReleaseLock::acquire(root)?)
     };
 
-    if !dry_run
-        && let Err(e) = fetch_tags(&repo, &config.workspace.remote)
-        && verbose
-    {
-        eprintln!("Warning: could not fetch remote tags: {e}");
+    if !dry_run {
+        let start = std::time::Instant::now();
+        let fetch = fetch_tags(&repo, &config.workspace.remote);
+        timing.record("fetch_tags", start.elapsed());
+        if let Err(e) = fetch
+            && verbose
+        {
+            eprintln!("Warning: could not fetch remote tags: {e}");
+        }
     }
 
     let current_branch = crate::git::resolve_current_branch(&repo, &config.workspace.branch);
@@ -111,7 +121,7 @@ pub(super) fn run_release_logic(
     // each repeat that scan. Coupled with the ancestor set, the per-pkg
     // lookups collapse from O(tags) callbacks + O(commits) walk to O(1)
     // hash hits.
-    let tag_index = crate::git::TagIndex::build(&repo).ok();
+    let tag_index = timing.stage("build TagIndex", || crate::git::TagIndex::build(&repo).ok());
 
     let target_branch = if prerelease_ctx.is_prerelease() {
         current_branch.clone()
@@ -142,6 +152,7 @@ pub(super) fn run_release_logic(
 
     let forced: Option<Forced<'_>> = parse_forced_version(force_version, config.is_monorepo())?;
 
+    let compute_start = std::time::Instant::now();
     for (pkg_idx, pkg) in config.packages.iter().enumerate() {
         let tag_search_prefix = pkg.tag_prefix(&config.workspace, config.is_monorepo());
 
@@ -571,6 +582,8 @@ pub(super) fn run_release_logic(
         )?;
     }
 
+    timing.record("per-package compute", compute_start.elapsed());
+
     if json {
         println!(
             "{}",
@@ -643,7 +656,10 @@ pub(super) fn run_release_logic(
             shared_outputs: &mut shared_outputs,
             checkpoint: checkpoint.as_mut(),
         };
-        execute_release(&mut plan)?;
+        let release_start = std::time::Instant::now();
+        let release_result = execute_release(&mut plan);
+        timing.record("release commit phase", release_start.elapsed());
+        release_result?;
         // Release finished cleanly — drop the checkpoint so the next
         // run starts from scratch instead of trying to resume a
         // finished release.
@@ -669,6 +685,7 @@ pub(super) fn run_release_logic(
             checkpoint: None,
         };
         print_dry_run_hooks(&plan)?;
+        timing.skip("release commit phase", "dry-run");
     }
 
     if !any_bumped && !draft && !dry_run {

--- a/src/query.rs
+++ b/src/query.rs
@@ -5,6 +5,7 @@ use crate::git::{
     Repository, TagIndex, find_highest_semver_tag_with_cache, find_last_tag_name,
     find_last_tag_name_with_cache, get_repo_root, open_repo,
 };
+use crate::timing::Timing;
 use anyhow::Result;
 use serde::Serialize;
 
@@ -135,10 +136,15 @@ pub fn version(
     Ok(())
 }
 
-pub fn tag(config_path: Option<&std::path::Path>, package: Option<&str>, json: bool) -> Result<()> {
-    let repo = open_repo(&std::env::current_dir()?)?;
+pub fn tag(
+    config_path: Option<&std::path::Path>,
+    package: Option<&str>,
+    json: bool,
+    timing: &mut Timing,
+) -> Result<()> {
+    let repo = timing.stage("open_repo", || open_repo(&std::env::current_dir()?))?;
     let root = get_repo_root(&repo)?;
-    let config = Config::load(&root, config_path)?;
+    let config = timing.stage("load config", || Config::load(&root, config_path))?;
 
     if config.packages.is_empty() {
         Err(anyhow::anyhow!(
@@ -196,7 +202,8 @@ pub fn tag(config_path: Option<&std::path::Path>, package: Option<&str>, json: b
         // The index pre-resolves both, leaving per-package work as a
         // linear scan over already-resolved entries.
         let strategy = config.workspace.orphaned_tag_strategy;
-        let index = TagIndex::build(&repo).ok();
+        let index = timing.stage("build TagIndex", || TagIndex::build(&repo).ok());
+        let resolve_start = std::time::Instant::now();
         let entries: Vec<TagEntry> = config
             .packages
             .iter()
@@ -228,6 +235,7 @@ pub fn tag(config_path: Option<&std::path::Path>, package: Option<&str>, json: b
                 }
             })
             .collect();
+        timing.record("per-package tag lookup", resolve_start.elapsed());
 
         if json {
             println!("{}", serde_json::to_string(&entries)?);
@@ -386,7 +394,10 @@ mod tests {
         setup_single_package(dir.path());
         create_commit(&repo, dir.path(), "init.txt", "initial");
         let config_path = dir.path().join(".ferrflow");
-        with_cwd(dir.path(), || tag(Some(&config_path), None, false)).unwrap();
+        with_cwd(dir.path(), || {
+            tag(Some(&config_path), None, false, &mut Timing::new(false))
+        })
+        .unwrap();
     }
 
     #[test]
@@ -396,7 +407,10 @@ mod tests {
         create_commit(&repo, dir.path(), "init.txt", "initial");
         create_tag(&repo, "v1.2.3");
         let config_path = dir.path().join(".ferrflow");
-        with_cwd(dir.path(), || tag(Some(&config_path), None, false)).unwrap();
+        with_cwd(dir.path(), || {
+            tag(Some(&config_path), None, false, &mut Timing::new(false))
+        })
+        .unwrap();
     }
 
     #[test]
@@ -406,7 +420,10 @@ mod tests {
         create_commit(&repo, dir.path(), "init.txt", "initial");
         create_tag(&repo, "v1.2.3");
         let config_path = dir.path().join(".ferrflow");
-        with_cwd(dir.path(), || tag(Some(&config_path), None, true)).unwrap();
+        with_cwd(dir.path(), || {
+            tag(Some(&config_path), None, true, &mut Timing::new(false))
+        })
+        .unwrap();
     }
 
     // Issue #531: a package without `versionedFiles` must still resolve a
@@ -448,7 +465,10 @@ mod tests {
         create_commit(&repo, dir.path(), "init.txt", "initial");
         create_tag(&repo, "img@v1.0.0");
         let config_path = dir.path().join(".ferrflow");
-        with_cwd(dir.path(), || tag(Some(&config_path), None, true)).unwrap();
+        with_cwd(dir.path(), || {
+            tag(Some(&config_path), None, true, &mut Timing::new(false))
+        })
+        .unwrap();
     }
 
     #[test]
@@ -458,7 +478,12 @@ mod tests {
         create_commit(&repo, dir.path(), "init.txt", "initial");
         let config_path = dir.path().join(".ferrflow");
         let result = with_cwd(dir.path(), || {
-            tag(Some(&config_path), Some("nonexistent"), false)
+            tag(
+                Some(&config_path),
+                Some("nonexistent"),
+                false,
+                &mut Timing::new(false),
+            )
         });
         assert!(result.is_err());
     }
@@ -469,7 +494,10 @@ mod tests {
         setup_monorepo(dir.path());
         create_commit(&repo, dir.path(), "init.txt", "initial");
         let config_path = dir.path().join(".ferrflow");
-        with_cwd(dir.path(), || tag(Some(&config_path), None, false)).unwrap();
+        with_cwd(dir.path(), || {
+            tag(Some(&config_path), None, false, &mut Timing::new(false))
+        })
+        .unwrap();
     }
 
     #[test]
@@ -478,7 +506,9 @@ mod tests {
         fs::write(dir.path().join(".ferrflow"), r#"{"package": []}"#).unwrap();
         create_commit(&repo, dir.path(), "init.txt", "initial");
         let config_path = dir.path().join(".ferrflow");
-        let result = with_cwd(dir.path(), || tag(Some(&config_path), None, false));
+        let result = with_cwd(dir.path(), || {
+            tag(Some(&config_path), None, false, &mut Timing::new(false))
+        });
         assert!(result.is_err());
     }
 }

--- a/src/status.rs
+++ b/src/status.rs
@@ -2,6 +2,7 @@ use crate::config::Config;
 use crate::conventional_commits::{BumpType, determine_bump};
 use crate::formats::read_version;
 use crate::git::{find_last_tag_name, get_commits_since_last_tag, get_repo_root, open_repo};
+use crate::timing::Timing;
 use anyhow::Result;
 use colored::Colorize;
 use serde::Serialize;
@@ -20,10 +21,14 @@ struct PackageStatus {
     has_changes: bool,
 }
 
-pub fn run(config_path: Option<&std::path::Path>, output: &OutputFormat) -> Result<()> {
-    let repo = open_repo(&std::env::current_dir()?)?;
+pub fn run(
+    config_path: Option<&std::path::Path>,
+    output: &OutputFormat,
+    timing: &mut Timing,
+) -> Result<()> {
+    let repo = timing.stage("open_repo", || open_repo(&std::env::current_dir()?))?;
     let root = get_repo_root(&repo)?;
-    let config = Config::load(&root, config_path)?;
+    let config = timing.stage("load config", || Config::load(&root, config_path))?;
 
     if config.packages.is_empty() {
         println!(
@@ -35,6 +40,7 @@ pub fn run(config_path: Option<&std::path::Path>, output: &OutputFormat) -> Resu
 
     let mut statuses: Vec<PackageStatus> = Vec::new();
 
+    let compute_start = std::time::Instant::now();
     for pkg in &config.packages {
         let tag_search_prefix = pkg.tag_prefix(&config.workspace, config.is_monorepo());
         let last_tag = find_last_tag_name(
@@ -68,6 +74,7 @@ pub fn run(config_path: Option<&std::path::Path>, output: &OutputFormat) -> Resu
             has_changes,
         });
     }
+    timing.record("per-package compute", compute_start.elapsed());
 
     match output {
         OutputFormat::Text => print_text(&statuses),
@@ -151,7 +158,14 @@ mod tests {
         setup_single_package(dir.path());
         create_commit(&repo, dir.path(), "init.txt", "initial");
         let config_path = dir.path().join(".ferrflow");
-        with_cwd(dir.path(), || run(Some(&config_path), &OutputFormat::Text)).unwrap();
+        with_cwd(dir.path(), || {
+            run(
+                Some(&config_path),
+                &OutputFormat::Text,
+                &mut Timing::new(false),
+            )
+        })
+        .unwrap();
     }
 
     #[test]
@@ -160,7 +174,14 @@ mod tests {
         setup_single_package(dir.path());
         create_commit(&repo, dir.path(), "init.txt", "initial");
         let config_path = dir.path().join(".ferrflow");
-        with_cwd(dir.path(), || run(Some(&config_path), &OutputFormat::Json)).unwrap();
+        with_cwd(dir.path(), || {
+            run(
+                Some(&config_path),
+                &OutputFormat::Json,
+                &mut Timing::new(false),
+            )
+        })
+        .unwrap();
     }
 
     #[test]
@@ -169,7 +190,14 @@ mod tests {
         fs::write(dir.path().join(".ferrflow"), r#"{"package": []}"#).unwrap();
         create_commit(&repo, dir.path(), "init.txt", "initial");
         let config_path = dir.path().join(".ferrflow");
-        with_cwd(dir.path(), || run(Some(&config_path), &OutputFormat::Text)).unwrap();
+        with_cwd(dir.path(), || {
+            run(
+                Some(&config_path),
+                &OutputFormat::Text,
+                &mut Timing::new(false),
+            )
+        })
+        .unwrap();
     }
 
     #[test]
@@ -179,7 +207,14 @@ mod tests {
         create_commit(&repo, dir.path(), "init.txt", "chore: initial");
         create_tag(&repo, "v1.0.0");
         let config_path = dir.path().join(".ferrflow");
-        with_cwd(dir.path(), || run(Some(&config_path), &OutputFormat::Text)).unwrap();
+        with_cwd(dir.path(), || {
+            run(
+                Some(&config_path),
+                &OutputFormat::Text,
+                &mut Timing::new(false),
+            )
+        })
+        .unwrap();
     }
 
     #[test]
@@ -190,7 +225,14 @@ mod tests {
         create_tag(&repo, "v1.0.0");
         create_commit(&repo, dir.path(), "new.txt", "feat: new feature");
         let config_path = dir.path().join(".ferrflow");
-        with_cwd(dir.path(), || run(Some(&config_path), &OutputFormat::Text)).unwrap();
+        with_cwd(dir.path(), || {
+            run(
+                Some(&config_path),
+                &OutputFormat::Text,
+                &mut Timing::new(false),
+            )
+        })
+        .unwrap();
     }
 
     #[test]
@@ -201,6 +243,13 @@ mod tests {
         create_tag(&repo, "v1.0.0");
         create_commit(&repo, dir.path(), "feature.txt", "feat: add feature");
         let config_path = dir.path().join(".ferrflow");
-        with_cwd(dir.path(), || run(Some(&config_path), &OutputFormat::Json)).unwrap();
+        with_cwd(dir.path(), || {
+            run(
+                Some(&config_path),
+                &OutputFormat::Json,
+                &mut Timing::new(false),
+            )
+        })
+        .unwrap();
     }
 }

--- a/src/timing.rs
+++ b/src/timing.rs
@@ -1,0 +1,123 @@
+use std::time::{Duration, Instant};
+
+pub struct Timing {
+    enabled: bool,
+    stages: Vec<Stage>,
+}
+
+enum Stage {
+    Measured(&'static str, Duration),
+    Skipped(&'static str, &'static str),
+}
+
+impl Timing {
+    pub fn new(enabled: bool) -> Self {
+        Self {
+            enabled,
+            stages: Vec::new(),
+        }
+    }
+
+    pub fn stage<T>(&mut self, name: &'static str, f: impl FnOnce() -> T) -> T {
+        if !self.enabled {
+            return f();
+        }
+        let start = Instant::now();
+        let out = f();
+        self.stages.push(Stage::Measured(name, start.elapsed()));
+        out
+    }
+
+    pub fn record(&mut self, name: &'static str, elapsed: Duration) {
+        if self.enabled {
+            self.stages.push(Stage::Measured(name, elapsed));
+        }
+    }
+
+    pub fn skip(&mut self, name: &'static str, reason: &'static str) {
+        if self.enabled {
+            self.stages.push(Stage::Skipped(name, reason));
+        }
+    }
+
+    pub fn total(&self) -> Duration {
+        self.stages
+            .iter()
+            .filter_map(|s| match s {
+                Stage::Measured(_, d) => Some(*d),
+                Stage::Skipped(..) => None,
+            })
+            .sum()
+    }
+
+    pub fn report(&self) {
+        if !self.enabled || self.stages.is_empty() {
+            return;
+        }
+
+        let label_width = self
+            .stages
+            .iter()
+            .map(|s| match s {
+                Stage::Measured(name, _) | Stage::Skipped(name, _) => name.len(),
+            })
+            .chain(std::iter::once("total".len()))
+            .max()
+            .unwrap_or(0);
+
+        eprintln!();
+        eprintln!("Timing breakdown:");
+        for stage in &self.stages {
+            match stage {
+                Stage::Measured(name, d) => {
+                    eprintln!("  {name:<label_width$}  {:>6} ms", d.as_millis());
+                }
+                Stage::Skipped(name, reason) => {
+                    eprintln!("  {name:<label_width$}  — ({reason})");
+                }
+            }
+        }
+        let rule = "─".repeat(label_width + 12);
+        eprintln!("  {rule}");
+        eprintln!(
+            "  {:<label_width$}  {:>6} ms",
+            "total",
+            self.total().as_millis()
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_records_nothing() {
+        let mut t = Timing::new(false);
+        let out = t.stage("noop", || 42);
+        t.record("manual", Duration::from_millis(5));
+        t.skip("phase", "dry-run");
+        assert_eq!(out, 42);
+        assert!(t.stages.is_empty());
+        assert_eq!(t.total(), Duration::ZERO);
+    }
+
+    #[test]
+    fn enabled_accumulates_measured_stages() {
+        let mut t = Timing::new(true);
+        t.record("a", Duration::from_millis(10));
+        t.record("b", Duration::from_millis(20));
+        t.skip("c", "dry-run");
+        assert_eq!(t.total(), Duration::from_millis(30));
+        assert_eq!(t.stages.len(), 3);
+    }
+
+    #[test]
+    fn stage_returns_value_and_records_when_enabled() {
+        let mut t = Timing::new(true);
+        let out = t.stage("compute", || 7 * 6);
+        assert_eq!(out, 42);
+        assert_eq!(t.stages.len(), 1);
+        assert!(t.total() < Duration::from_secs(1));
+    }
+}


### PR DESCRIPTION
## What

Adds a global `--timing` CLI flag that prints a per-stage timing breakdown to stderr after a command finishes:

```
$ ferrflow --timing check
FerrFlow — Check (dry run)

● demo  1.0.0 → 1.1.0  (minor)

Timing breakdown:
  open_repo                 22 ms
  load config                0 ms
  fetch_tags            — (dry-run)
  build TagIndex             0 ms
  per-package compute        4 ms
  release commit phase  — (dry-run)
  ────────────────────────────────
  total                     27 ms
```

When `--timing` is not set there is zero behaviour change and no extra output.

## Why

After #466 + #474 (HEAD ancestor cache + TagIndex) shaved `tag` mono-large from 1815 ms to ~800 ms, the remaining cost was unaccounted for. Users hitting perf issues had no in-tool way to localize a slowdown. `--timing` gives an instant per-stage attribution.

## Design

- New `src/timing.rs`: a lightweight `Timing` accumulator (`Vec` of measured/skipped stages, no global state). `stage(name, closure)` times a section, `record(name, dur)` logs a manually-timed span, `skip(name, reason)` marks a phase that didn't run.
- Zero-cost when off: when the flag is unset, `stage` just calls the closure and `record`/`skip` are no-ops — no `Vec` pushes, no formatting, no printing. The only added work on the hot path is the `Instant::now()` pairs, which are nanosecond.
- Threaded through `Cli::run` → the instrumented commands; the breakdown is printed once at the end on stderr so it never pollutes stdout / `--json` output.

## Stages instrumented

- `monorepo::check` / `monorepo::release` (via `run_release_logic`): `open_repo`, `load config`, `fetch_tags` (skipped on dry-run), `build TagIndex`, `per-package compute` (incl. dependency cascade), `release commit phase` (skipped on dry-run).
- `query::tag`: `open_repo`, `load config`, plus `build TagIndex` + `per-package tag lookup` on the multi-package path.
- `status::run`: `open_repo`, `load config`, `per-package compute`.

## Tests

- Unit tests for `Timing` (disabled records nothing; enabled accumulates measured stages and sums total; `stage` returns the closure value).
- CLI parse tests for `--timing` (default off, set before and after the subcommand).
- Full suite green (744 passed), clippy clean with `-D warnings`.

Closes #478