### PR TITLE
perf(cache): cross-run cache for per-package walk

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,350 @@
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::config::Config;
+use crate::git::Repository;
+
+const CACHE_DIR_NAME: &str = "ferrflow-cache";
+const MAX_AGE: Duration = Duration::from_secs(5 * 60);
+const PRUNE_MAX_AGE: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+const PRUNE_MAX_ENTRIES: usize = 50;
+
+#[derive(Serialize, Deserialize)]
+pub struct CachedRun {
+    pub json: Option<String>,
+    pub text_lines: Vec<String>,
+}
+
+pub struct CacheKey {
+    head: String,
+    tags_hash: String,
+    config_hash: String,
+    variant: &'static str,
+}
+
+impl CacheKey {
+    fn filename(&self) -> String {
+        format!(
+            "{}-{}-{}-{}.json",
+            self.head, self.tags_hash, self.config_hash, self.variant
+        )
+    }
+}
+
+pub fn cache_dir(repo: &Repository) -> PathBuf {
+    repo.git_dir().join(CACHE_DIR_NAME)
+}
+
+pub fn compute_key(
+    repo: &Repository,
+    root: &Path,
+    explicit_config: Option<&Path>,
+    variant: &'static str,
+) -> Option<CacheKey> {
+    let head = repo.head_id().ok()?.to_string();
+    let tags_hash = hash_tag_refs(repo);
+    let config_hash = hash_config(root, explicit_config);
+    Some(CacheKey {
+        head,
+        tags_hash,
+        config_hash,
+        variant,
+    })
+}
+
+fn hash_tag_refs(repo: &Repository) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    if let Ok(references) = repo.references()
+        && let Ok(tags) = references.tags()
+    {
+        for reference in tags.flatten() {
+            let name = String::from_utf8_lossy(reference.name().as_bstr()).into_owned();
+            let oid = reference.id().detach().to_string();
+            lines.push(format!("{name}={oid}"));
+        }
+    }
+    lines.sort();
+    sha256_hex(lines.join("\n").as_bytes())
+}
+
+fn hash_config(root: &Path, explicit_config: Option<&Path>) -> String {
+    match Config::source_path(root, explicit_config) {
+        Some(path) => match std::fs::read(&path) {
+            Ok(bytes) => sha256_hex(&bytes),
+            Err(_) => sha256_hex(b""),
+        },
+        None => sha256_hex(b""),
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
+
+pub fn read(dir: &Path, key: &CacheKey) -> Option<CachedRun> {
+    let path = dir.join(key.filename());
+    let metadata = std::fs::metadata(&path).ok()?;
+    let modified = metadata.modified().ok()?;
+    if !is_fresh(modified, SystemTime::now()) {
+        return None;
+    }
+    let bytes = std::fs::read(&path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn is_fresh(modified: SystemTime, now: SystemTime) -> bool {
+    now.duration_since(modified)
+        .map(|age| age <= MAX_AGE)
+        .unwrap_or(true)
+}
+
+pub fn write(dir: &Path, key: &CacheKey, run: &CachedRun) {
+    if std::fs::create_dir_all(dir).is_err() {
+        return;
+    }
+    let Ok(serialized) = serde_json::to_vec(run) else {
+        return;
+    };
+    let final_path = dir.join(key.filename());
+    let tmp_path = dir.join(format!("{}.{}.tmp", key.filename(), std::process::id()));
+    if std::fs::write(&tmp_path, &serialized).is_err() {
+        let _ = std::fs::remove_file(&tmp_path);
+        return;
+    }
+    if std::fs::rename(&tmp_path, &final_path).is_err() {
+        let _ = std::fs::remove_file(&tmp_path);
+        return;
+    }
+    prune(dir);
+}
+
+pub fn clear(repo: &Repository) -> Result<()> {
+    let dir = cache_dir(repo);
+    if dir.exists() {
+        std::fs::remove_dir_all(&dir)?;
+    }
+    Ok(())
+}
+
+pub fn clear_cwd() -> Result<()> {
+    let repo = crate::git::open_repo(&std::env::current_dir()?)?;
+    let dir = cache_dir(&repo);
+    clear(&repo)?;
+    println!("Cleared FerrFlow cache at {}", dir.display());
+    Ok(())
+}
+
+fn prune(dir: &Path) {
+    prune_at(dir, SystemTime::now());
+}
+
+fn prune_at(dir: &Path, now: SystemTime) {
+    let Ok(read_dir) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut entries: Vec<(PathBuf, SystemTime)> = Vec::new();
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        let modified = metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+        let too_old = now
+            .duration_since(modified)
+            .map(|age| age > PRUNE_MAX_AGE)
+            .unwrap_or(false);
+        if too_old {
+            let _ = std::fs::remove_file(&path);
+            continue;
+        }
+        entries.push((path, modified));
+    }
+
+    if entries.len() > PRUNE_MAX_ENTRIES {
+        entries.sort_by_key(|(_, modified)| *modified);
+        let excess = entries.len() - PRUNE_MAX_ENTRIES;
+        for (path, _) in entries.into_iter().take(excess) {
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(head: &str, tags: &str, config: &str) -> CacheKey {
+        CacheKey {
+            head: head.to_string(),
+            tags_hash: tags.to_string(),
+            config_hash: config.to_string(),
+            variant: "text",
+        }
+    }
+
+    fn sample() -> CachedRun {
+        CachedRun {
+            json: Some("{\"packages\":[]}".to_string()),
+            text_lines: vec!["● api  1.0.0 → 1.1.0  (minor)".to_string()],
+        }
+    }
+
+    #[test]
+    fn round_trips_through_write_and_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let k = key("head", "tags", "config");
+        write(dir.path(), &k, &sample());
+        let got = read(dir.path(), &k).expect("cache hit");
+        assert_eq!(got.json.as_deref(), Some("{\"packages\":[]}"));
+        assert_eq!(got.text_lines, sample().text_lines);
+    }
+
+    #[test]
+    fn miss_when_file_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(read(dir.path(), &key("nope", "nope", "nope")).is_none());
+    }
+
+    #[test]
+    fn tampered_file_falls_back_to_miss() {
+        let dir = tempfile::tempdir().unwrap();
+        let k = key("head", "tags", "config");
+        std::fs::create_dir_all(dir.path()).unwrap();
+        std::fs::write(dir.path().join(k.filename()), b"{ this is not json").unwrap();
+        assert!(read(dir.path(), &k).is_none());
+    }
+
+    #[test]
+    fn is_fresh_window() {
+        let now = SystemTime::now();
+        assert!(is_fresh(now, now));
+        assert!(is_fresh(now - Duration::from_secs(60), now));
+        assert!(!is_fresh(now - (MAX_AGE + Duration::from_secs(1)), now));
+    }
+
+    #[test]
+    fn write_to_readonly_parent_is_noop_not_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing_parent = dir.path().join("does-not-exist");
+        std::fs::write(&missing_parent, b"i am a file, not a dir").unwrap();
+        let cache_dir = missing_parent.join("cache");
+        let k = key("head", "tags", "config");
+        write(&cache_dir, &k, &sample());
+        assert!(read(&cache_dir, &k).is_none());
+    }
+
+    #[test]
+    fn filename_changes_with_each_key_component() {
+        let base = key("h", "t", "c").filename();
+        assert_ne!(base, key("h2", "t", "c").filename());
+        assert_ne!(base, key("h", "t2", "c").filename());
+        assert_ne!(base, key("h", "t", "c2").filename());
+        let json_variant = CacheKey {
+            head: "h".into(),
+            tags_hash: "t".into(),
+            config_hash: "c".into(),
+            variant: "json",
+        };
+        assert_ne!(base, json_variant.filename());
+    }
+
+    #[test]
+    fn prune_caps_total_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path()).unwrap();
+        for i in 0..(PRUNE_MAX_ENTRIES + 5) {
+            std::fs::write(dir.path().join(format!("entry-{i}.json")), b"{}").unwrap();
+        }
+        prune(dir.path());
+        let remaining = std::fs::read_dir(dir.path()).unwrap().count();
+        assert_eq!(remaining, PRUNE_MAX_ENTRIES);
+    }
+
+    #[test]
+    fn prune_drops_entries_older_than_seven_days() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path()).unwrap();
+        std::fs::write(dir.path().join("a.json"), b"{}").unwrap();
+        std::fs::write(dir.path().join("b.json"), b"{}").unwrap();
+        let far_future = SystemTime::now() + PRUNE_MAX_AGE + Duration::from_secs(60);
+        prune_at(dir.path(), far_future);
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
+    }
+
+    mod key {
+        use super::super::*;
+        use crate::test_utils::{commit_file, git, init_repo};
+
+        fn write_config(dir: &std::path::Path, body: &str) {
+            std::fs::write(dir.join(".ferrflow"), body).unwrap();
+        }
+
+        fn filename(repo: &Repository, root: &std::path::Path) -> String {
+            compute_key(repo, root, None, "text")
+                .expect("key")
+                .filename()
+        }
+
+        #[test]
+        fn key_is_stable_for_unchanged_inputs() {
+            let (dir, repo) = init_repo();
+            write_config(dir.path(), r#"{"package":[{"name":"a","path":"."}]}"#);
+            commit_file(dir.path(), "f.txt", "x", "feat: a", 1_900_000_000);
+            assert_eq!(filename(&repo, dir.path()), filename(&repo, dir.path()));
+        }
+
+        #[test]
+        fn key_busts_on_new_head() {
+            let (dir, repo) = init_repo();
+            write_config(dir.path(), r#"{"package":[{"name":"a","path":"."}]}"#);
+            commit_file(dir.path(), "f.txt", "x", "feat: a", 1_900_000_000);
+            let before = filename(&repo, dir.path());
+            commit_file(dir.path(), "g.txt", "y", "feat: b", 1_900_000_001);
+            assert_ne!(before, filename(&repo, dir.path()));
+        }
+
+        #[test]
+        fn key_busts_on_new_tag() {
+            let (dir, repo) = init_repo();
+            write_config(dir.path(), r#"{"package":[{"name":"a","path":"."}]}"#);
+            commit_file(dir.path(), "f.txt", "x", "feat: a", 1_900_000_000);
+            let before = filename(&repo, dir.path());
+            git(dir.path(), &["tag", "v1.0.0"]);
+            assert_ne!(before, filename(&repo, dir.path()));
+        }
+
+        #[test]
+        fn key_busts_on_config_edit() {
+            let (dir, repo) = init_repo();
+            write_config(dir.path(), r#"{"package":[{"name":"a","path":"."}]}"#);
+            commit_file(dir.path(), "f.txt", "x", "feat: a", 1_900_000_000);
+            let before = filename(&repo, dir.path());
+            write_config(
+                dir.path(),
+                r#"{"package":[{"name":"a","path":".","versioning":"calver"}]}"#,
+            );
+            assert_ne!(before, filename(&repo, dir.path()));
+        }
+    }
+
+    #[test]
+    fn prune_keeps_only_json_and_ignores_temp() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path()).unwrap();
+        std::fs::write(dir.path().join("keep.json"), b"{}").unwrap();
+        std::fs::write(dir.path().join("scratch.tmp"), b"{}").unwrap();
+        let far_future = SystemTime::now() + PRUNE_MAX_AGE + Duration::from_secs(60);
+        prune_at(dir.path(), far_future);
+        assert!(!dir.path().join("keep.json").exists());
+        assert!(dir.path().join("scratch.tmp").exists());
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -126,6 +126,17 @@ pub enum Commands {
         /// Shell to generate completions for
         shell: Shell,
     },
+    /// Manage the cross-run cache under .git/ferrflow-cache/
+    Cache {
+        #[command(subcommand)]
+        command: CacheCommand,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum CacheCommand {
+    /// Delete the cross-run cache directory
+    Clear,
 }
 
 impl Commands {
@@ -141,6 +152,7 @@ impl Commands {
             Commands::Tag { .. } => "tag",
             Commands::Validate { .. } => "validate",
             Commands::Completions { .. } => "completions",
+            Commands::Cache { .. } => "cache",
         }
     }
 }
@@ -222,6 +234,9 @@ impl Cli {
                 );
                 Ok(())
             }
+            Commands::Cache { command } => match command {
+                CacheCommand::Clear => crate::cache::clear_cwd(),
+            },
         }
     }
 }
@@ -462,6 +477,23 @@ mod tests {
     fn parse_changelog() {
         let cli = parse(&["ferrflow", "changelog"]);
         assert!(matches!(cli.command, Commands::Changelog));
+    }
+
+    #[test]
+    fn parse_cache_clear() {
+        let cli = parse(&["ferrflow", "cache", "clear"]);
+        assert!(matches!(
+            cli.command,
+            Commands::Cache {
+                command: CacheCommand::Clear
+            }
+        ));
+        assert_eq!(cli.command.name(), "cache");
+    }
+
+    #[test]
+    fn cache_requires_subcommand() {
+        assert!(Cli::try_parse_from(["ferrflow", "cache"]).is_err());
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -50,24 +50,7 @@ impl Config {
             return Self::load_explicit(&resolved_path);
         }
 
-        // Build ordered search list: json > json5 > toml > ts > js > .ferrflow
-        let mut search: Vec<&str> = CONFIG_FORMATS.iter().map(|h| h.filename()).collect();
-
-        #[cfg(feature = "cli")]
-        {
-            // Insert ts/js before .ferrflow (last element)
-            let dotfile_pos = search.len() - 1;
-            search.insert(dotfile_pos, TS_CONFIG_FILENAME);
-            search.insert(dotfile_pos + 1, JS_CONFIG_FILENAME);
-        }
-
-        let mut found: Vec<PathBuf> = Vec::new();
-        for filename in &search {
-            let path = repo_root.join(filename);
-            if path.exists() {
-                found.push(path);
-            }
-        }
+        let found = Self::discover(repo_root);
 
         if found.is_empty() {
             return Ok(Self::auto_detect(repo_root));
@@ -86,6 +69,39 @@ impl Config {
         }
 
         Self::load_from_path(&found[0])
+    }
+
+    fn discover(repo_root: &Path) -> Vec<PathBuf> {
+        // Ordered search list: json > json5 > toml > ts > js > .ferrflow
+        #[cfg_attr(not(feature = "cli"), allow(unused_mut))]
+        let mut search: Vec<&str> = CONFIG_FORMATS.iter().map(|h| h.filename()).collect();
+
+        #[cfg(feature = "cli")]
+        {
+            // Insert ts/js before .ferrflow (last element)
+            let dotfile_pos = search.len() - 1;
+            search.insert(dotfile_pos, TS_CONFIG_FILENAME);
+            search.insert(dotfile_pos + 1, JS_CONFIG_FILENAME);
+        }
+
+        search
+            .iter()
+            .map(|filename| repo_root.join(filename))
+            .filter(|path| path.exists())
+            .collect()
+    }
+
+    pub fn source_path(repo_root: &Path, explicit_path: Option<&Path>) -> Option<PathBuf> {
+        if let Some(path) = explicit_path {
+            let resolved = if path.is_relative() {
+                repo_root.join(path)
+            } else {
+                path.to_path_buf()
+            };
+            return resolved.exists().then_some(resolved);
+        }
+        let found = Self::discover(repo_root);
+        (found.len() == 1).then(|| found.into_iter().next().unwrap())
     }
 
     fn load_from_path(path: &Path) -> Result<Self> {
@@ -218,6 +234,14 @@ impl Config {
 
     pub fn is_monorepo(&self) -> bool {
         self.packages.len() > 1
+    }
+
+    pub fn has_release_side_effects(&self) -> bool {
+        self.workspace.hooks.is_some()
+            || self
+                .packages
+                .iter()
+                .any(|pkg| pkg.hooks.is_some() || !pkg.publishers.is_empty())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ pub mod prerelease;
 pub mod versioning;
 
 #[cfg(feature = "cli")]
+pub mod cache;
+#[cfg(feature = "cli")]
 pub mod forge;
 #[cfg(feature = "cli")]
 pub mod git;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod bot_token;
+mod cache;
 mod changelog;
 mod cli;
 mod config;

--- a/src/monorepo/check.rs
+++ b/src/monorepo/check.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use colored::Colorize;
 use std::path::Path;
 
+use crate::cache::{self, CachedRun};
 use crate::config::Config;
 use crate::git::{get_repo_root, open_repo};
 use crate::telemetry;
@@ -29,9 +30,44 @@ pub fn check(
         println!();
     }
 
-    let result = run_release_logic(
+    let variant = if json { "json" } else { "text" };
+    let cache_eligible = !verbose && channel.is_none() && !config.has_release_side_effects();
+    let cache_key = cache_eligible
+        .then(|| cache::compute_key(&repo, &root, config_path, variant))
+        .flatten();
+    let cache_dir = cache::cache_dir(&repo);
+
+    if let Some(key) = &cache_key
+        && let Some(hit) = timing.stage("cache lookup", || cache::read(&cache_dir, key))
+    {
+        print_cached(&hit);
+        if comment {
+            post_preview_comment(&repo, &config, &root);
+        }
+        if config.workspace.anonymous_telemetry {
+            telemetry::send_event(telemetry::EventType::Check, None, None, None, None);
+        }
+        return Ok(());
+    }
+
+    let out = run_release_logic(
         &root, &config, true, verbose, json, false, None, channel, false, false, timing,
-    );
+    )?;
+
+    if let (Some(key), Some(out)) = (&cache_key, &out) {
+        cache::write(
+            &cache_dir,
+            key,
+            &CachedRun {
+                json: out.json.clone(),
+                text_lines: out.text_lines.clone(),
+            },
+        );
+    }
+
+    if let Some(out) = out {
+        out.print();
+    }
 
     if comment {
         post_preview_comment(&repo, &config, &root);
@@ -41,5 +77,15 @@ pub fn check(
         telemetry::send_event(telemetry::EventType::Check, None, None, None, None);
     }
 
-    result
+    Ok(())
+}
+
+fn print_cached(hit: &CachedRun) {
+    if let Some(json) = &hit.json {
+        println!("{json}");
+        return;
+    }
+    for line in &hit.text_lines {
+        println!("{line}");
+    }
 }

--- a/src/monorepo/release.rs
+++ b/src/monorepo/release.rs
@@ -42,7 +42,7 @@ pub fn release(
         );
 
     if single_shot {
-        return run_release_logic(
+        let out = run_release_logic(
             &root,
             &config,
             dry_run,
@@ -54,7 +54,11 @@ pub fn release(
             draft,
             force_unlock,
             timing,
-        );
+        )?;
+        if let Some(out) = out {
+            out.print();
+        }
+        return Ok(());
     }
 
     let mut last_err: Option<anyhow::Error> = None;
@@ -79,7 +83,12 @@ pub fn release(
         );
 
         match result {
-            Ok(()) => return Ok(()),
+            Ok(out) => {
+                if let Some(out) = out {
+                    out.print();
+                }
+                return Ok(());
+            }
             Err(e)
                 if attempt < MAX_RELEASE_REGENERATE_ATTEMPTS
                     && crate::git::is_push_rejected_error(&e) =>

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -18,7 +18,7 @@ use crate::telemetry;
 use crate::timing::Timing;
 use crate::versioning::{compute_next_version, truncate_version};
 
-use super::types::{CheckCommit, CheckPackage, CheckResult};
+use super::types::{CheckCommit, CheckPackage, CheckResult, RunOutput};
 use super::util::{
     auto_stage_new_files, collect_dirty_files, is_package_touched, pick_higher_semver,
     tags_for_package,
@@ -35,7 +35,7 @@ use checkpoint::Checkpoint;
 use drafts::publish_pending_drafts;
 use execute::{ReleasePlan, execute_release, print_dry_run_hooks};
 use forced::{Forced, forced_version_for, parse_forced_version};
-use summary::{TagToCreate, print_outputs};
+use summary::{TagToCreate, collect_outputs};
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn run_release_logic(
@@ -50,20 +50,24 @@ pub(super) fn run_release_logic(
     draft: bool,
     force_unlock: bool,
     timing: &mut Timing,
-) -> Result<()> {
+) -> Result<Option<RunOutput>> {
     if config.packages.is_empty() {
         if json {
-            println!(
-                "{}",
-                serde_json::to_string(&CheckResult { packages: vec![] })?
-            );
-            return Ok(());
+            let out = RunOutput {
+                json: Some(serde_json::to_string(&CheckResult { packages: vec![] })?),
+                text_lines: Vec::new(),
+            };
+            return finish(dry_run, out);
         }
-        println!(
-            "{}",
-            "No packages configured. Run `ferrflow init` to create a ferrflow config.".yellow()
-        );
-        return Ok(());
+        let out = RunOutput {
+            json: None,
+            text_lines: vec![
+                "No packages configured. Run `ferrflow init` to create a ferrflow config."
+                    .yellow()
+                    .to_string(),
+            ],
+        };
+        return finish(dry_run, out);
     }
 
     let repo = open_repo(root)?;
@@ -300,11 +304,11 @@ pub(super) fn run_release_logic(
 
             if bump == BumpType::None && !is_date_or_seq {
                 if !json {
-                    println!(
+                    shared_outputs.push(format!(
                         "{} {} — no releasable commits",
                         "○".dimmed(),
                         pkg.name.dimmed()
-                    );
+                    ));
                 }
                 continue;
             }
@@ -585,13 +589,13 @@ pub(super) fn run_release_logic(
     timing.record("per-package compute", compute_start.elapsed());
 
     if json {
-        println!(
-            "{}",
-            serde_json::to_string(&CheckResult {
-                packages: json_packages
-            })?
-        );
-        return Ok(());
+        let out = RunOutput {
+            json: Some(serde_json::to_string(&CheckResult {
+                packages: json_packages,
+            })?),
+            text_lines: Vec::new(),
+        };
+        return finish(dry_run, out);
     }
 
     if any_bumped && !tags_to_create.is_empty() {
@@ -692,11 +696,25 @@ pub(super) fn run_release_logic(
         publish_pending_drafts(&repo, config, root, verbose, &mut shared_outputs)?;
     }
 
-    print_outputs(&pkg_outputs, &shared_outputs);
-
+    let mut text_lines = collect_outputs(&pkg_outputs, &shared_outputs);
     if !any_bumped && !verbose {
-        println!("{}", "Nothing to release.".dimmed());
+        text_lines.push("Nothing to release.".dimmed().to_string());
     }
 
-    Ok(())
+    finish(
+        dry_run,
+        RunOutput {
+            json: None,
+            text_lines,
+        },
+    )
+}
+
+fn finish(dry_run: bool, out: RunOutput) -> Result<Option<RunOutput>> {
+    if dry_run {
+        Ok(Some(out))
+    } else {
+        out.print();
+        Ok(None)
+    }
 }

--- a/src/monorepo/run/summary.rs
+++ b/src/monorepo/run/summary.rs
@@ -8,21 +8,22 @@ pub(super) type TagToCreate = (String, String, String, String, String, i32, bool
 ///
 /// `pkg_outputs` entries are `(pkg_name, lines)`. The name is unused at
 /// print time today but kept for future grouping needs.
-pub(super) fn print_outputs(pkg_outputs: &[(String, Vec<String>)], shared_outputs: &[String]) {
+pub(super) fn collect_outputs(
+    pkg_outputs: &[(String, Vec<String>)],
+    shared_outputs: &[String],
+) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
     for (i, (_, lines)) in pkg_outputs.iter().enumerate() {
         if i > 0 {
-            println!();
+            out.push(String::new());
         }
-        for line in lines {
-            println!("{line}");
-        }
+        out.extend(lines.iter().cloned());
     }
     if !shared_outputs.is_empty() {
-        println!();
-        for line in shared_outputs {
-            println!("{line}");
-        }
+        out.push(String::new());
+        out.extend(shared_outputs.iter().cloned());
     }
+    out
 }
 
 /// Write the per-tag release blurb to `$GITHUB_STEP_SUMMARY` when the

--- a/src/monorepo/tests.rs
+++ b/src/monorepo/tests.rs
@@ -1,6 +1,96 @@
 use super::util::*;
 use crate::config::PackageConfig;
 
+mod cache_flow {
+    use crate::cache;
+    use crate::git::open_repo;
+    use crate::test_utils::{commit_file, init_repo, with_cwd};
+    use crate::timing::Timing;
+
+    fn setup(dir: &std::path::Path) {
+        std::fs::write(
+            dir.join("Cargo.toml"),
+            "[package]\nname = \"app\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join(".ferrflow"),
+            r#"{"package":[{"name":"app","path":".","versionedFiles":[{"path":"Cargo.toml","format":"toml"}]}]}"#,
+        )
+        .unwrap();
+    }
+
+    fn run_check(dir: &std::path::Path) {
+        let config = dir.join(".ferrflow");
+        with_cwd(dir, || {
+            super::super::check(
+                Some(&config),
+                false,
+                false,
+                None,
+                false,
+                &mut Timing::new(false),
+            )
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn first_check_writes_cache_second_hits_with_same_key() {
+        let (dir, _repo) = init_repo();
+        setup(dir.path());
+        commit_file(dir.path(), "a.txt", "x", "feat: a", 1_950_000_000);
+
+        run_check(dir.path());
+
+        let repo = open_repo(dir.path()).unwrap();
+        let cache_dir = cache::cache_dir(&repo);
+        let key = cache::compute_key(
+            &repo,
+            dir.path(),
+            Some(&dir.path().join(".ferrflow")),
+            "text",
+        )
+        .expect("key");
+        let first = cache::read(&cache_dir, &key).expect("cache written on miss");
+
+        run_check(dir.path());
+        let second = cache::read(&cache_dir, &key).expect("still a hit");
+        assert_eq!(first.text_lines, second.text_lines);
+        assert!(!first.text_lines.is_empty());
+    }
+
+    #[test]
+    fn cache_busts_after_a_new_commit() {
+        let (dir, _repo) = init_repo();
+        setup(dir.path());
+        commit_file(dir.path(), "a.txt", "x", "feat: a", 1_950_000_100);
+        run_check(dir.path());
+
+        let repo = open_repo(dir.path()).unwrap();
+        let cache_dir = cache::cache_dir(&repo);
+        let old_key = cache::compute_key(
+            &repo,
+            dir.path(),
+            Some(&dir.path().join(".ferrflow")),
+            "text",
+        )
+        .unwrap();
+
+        commit_file(dir.path(), "b.txt", "y", "feat: b", 1_950_000_200);
+        let repo2 = open_repo(dir.path()).unwrap();
+        let new_key = cache::compute_key(
+            &repo2,
+            dir.path(),
+            Some(&dir.path().join(".ferrflow")),
+            "text",
+        )
+        .unwrap();
+        assert!(cache::read(&cache_dir, &new_key).is_none());
+        assert!(cache::read(&cache_dir, &old_key).is_some());
+    }
+}
+
 #[test]
 fn pick_higher_semver_prefers_tag_when_tag_is_higher() {
     assert_eq!(pick_higher_semver("2.0.0", "3.0.0"), "3.0.0");

--- a/src/monorepo/types.rs
+++ b/src/monorepo/types.rs
@@ -21,3 +21,20 @@ pub(super) struct CheckPackage {
 pub(super) struct CheckResult {
     pub packages: Vec<CheckPackage>,
 }
+
+pub(super) struct RunOutput {
+    pub json: Option<String>,
+    pub text_lines: Vec<String>,
+}
+
+impl RunOutput {
+    pub fn print(&self) {
+        if let Some(json) = &self.json {
+            println!("{json}");
+            return;
+        }
+        for line in &self.text_lines {
+            println!("{line}");
+        }
+    }
+}


### PR DESCRIPTION
Closes #508

## What

Adds a cross-run cache for the dominant cost of `ferrflow check`: the per-package last-tag → HEAD commit walk and bump decision. On CI a PR loops lint → build → test → check on the same commit, recomputing the same result every time. This caches the computed result so repeat invocations on an unchanged (HEAD, tags, config) return instantly.

## What is cached

The rendered dry-run result of `check`: the JSON string (for `--json`) or the text output lines (default). The value type is `cache::CachedRun { json: Option<String>, text_lines: Vec<String> }`, written by capturing the `RunOutput` that the compute path now returns instead of printing inline. A cache hit reprints these verbatim, so hit output is identical to a fresh compute by construction.

## Cache key

Hash of HEAD commit sha + a sha256 of the sorted `refs/tags/* → oid` lines + a sha256 of the config file bytes, plus an output `variant` marker (`text`/`json`) so `check` and `check --json` don't collide. Filename: `<head>-<tags_hash>-<config_hash>-<variant>.json` under `.git/ferrflow-cache/` (resolved via `repo.git_dir()`).

## Which commands use it

- `check` (default and `--json`) reads and writes the cache.
- `status` does NOT — it has a separate, simpler compute (`PackageStatus`), not the shared per-package walk, so wiring it in would not be the same result. Left clean.
- `version` / `tag` are already cheap; uncached on purpose.
- `release` MUST NOT and does NOT touch the cache (always recomputes — mutating on stale data is unsafe). This bounds the blast radius: a cache bug can only affect advisory `check` output.

Caching is also skipped when `--verbose`, a `--channel` override is set, or the config has hooks/publishers configured (those produce side-effecting dry-run previews that aren't part of the cached value).

## Edge cases

- Read-only `.git`: every write is best-effort (atomic temp + rename) and silently no-ops on any IO error — never errors.
- Corrupt/garbage cache file: ignored, falls back to recompute, no panic.
- Freshness: entries older than 5 minutes (mtime) are treated as a miss.
- Prune on write: drop entries older than 7 days and cap at 50 (best-effort, errors ignored).

## New subcommand

`ferrflow cache clear` deletes `.git/ferrflow-cache/`.

## Tests

- `cache.rs`: write→read round-trip, tamper→miss, read-only parent→no-op no-error, freshness window, prune by age + by cap, ignore non-json files, filename varies per key component, and key busts on new HEAD / new tag / config edit (against real temp repos).
- `monorepo/tests.rs`: end-to-end — first `check` writes the cache, second hits with the same key and identical lines; a new commit busts the key.

Verified manually in a temp repo: two `check` runs on the same commit (miss then hit, identical output), a new commit busts it, and `cache clear` removes the dir. `release --dry-run` creates no cache dir.

## Follow-ups (separate repos, out of scope here)

- Public changelog entry (FerrLabs/Changelog) for the new `cache clear` subcommand and the perf win.
- Docs/site mention of `cache clear` on ferrflow.com (FerrFlow-Cloud).