### PR TITLE
feat(changelog): configurable sections, scope grouping, commit + compare links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "5.10.0"
+version = "5.11.0"
 dependencies = [
  "anyhow",
  "cargo-husky",

--- a/benches/ferrflow_benchmarks.rs
+++ b/benches/ferrflow_benchmarks.rs
@@ -2,7 +2,7 @@ use std::hint::black_box;
 use std::io::Write;
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use ferrflow::changelog::{build_section, update_changelog};
+use ferrflow::changelog::{ChangelogRender, build_section_with, update_changelog};
 use ferrflow::config::{Config, FileFormat, OrphanedTagStrategy};
 use ferrflow::conventional_commits::{BumpType, determine_bump};
 use ferrflow::formats::get_handler;
@@ -64,7 +64,11 @@ fn bench_changelog(c: &mut Criterion) {
 
         c.bench_function(&format!("changelog/build_{size}"), |b| {
             b.iter(|| {
-                black_box(build_section("1.0.0", &commits));
+                black_box(build_section_with(
+                    "1.0.0",
+                    &commits,
+                    &ChangelogRender::default(),
+                ));
             });
         });
 

--- a/ferrflow-wasm/src/lib.rs
+++ b/ferrflow-wasm/src/lib.rs
@@ -45,7 +45,11 @@ pub fn build_changelog_section(version: &str, commits_json: &str) -> Result<Stri
         })
         .collect();
 
-    Ok(changelog::build_section(version, &commits))
+    Ok(changelog::build_section_with(
+        version,
+        &commits,
+        &changelog::ChangelogRender::default(),
+    ))
 }
 
 #[wasm_bindgen]

--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -144,6 +144,38 @@
             },
             "additionalProperties": false
           }
+        },
+        "changelog": {
+          "type": "object",
+          "description": "Opt-in changelog rendering. When omitted, FerrFlow renders the classic three sections (Breaking Changes, Features, Bug Fixes) with flat bullets and no links.",
+          "properties": {
+            "sections": {
+              "type": "object",
+              "description": "Map commit-type prefixes to section labels, or false to hide. Keys: feat, fix, perf, docs, refactor, security. When omitted, defaults to feat -> Features and fix -> Bug Fixes (Breaking Changes always shown). 'security' applies to security: and fix(security): commits.",
+              "additionalProperties": {
+                "oneOf": [
+                  { "type": "string", "description": "Section heading label for this commit type." },
+                  { "type": "boolean", "const": false, "description": "Hide this commit type from the changelog." }
+                ]
+              }
+            },
+            "groupByScope": {
+              "type": "boolean",
+              "description": "Group bullets by commit scope using an inline bold prefix (- **api:** add events endpoint). Scopeless commits render first.",
+              "default": false
+            },
+            "includeCommitLinks": {
+              "type": "boolean",
+              "description": "Append a commit link to each bullet (([abc1234](<forge>/commit/abc1234))) when the forge is known. Silently omitted when the remote forge cannot be resolved.",
+              "default": false
+            },
+            "includeCompareLink": {
+              "type": "boolean",
+              "description": "Emit a keep-a-changelog compare footer ([1.2.3]: <forge>/compare/v1.2.2...v1.2.3) when the forge is known and a previous tag exists.",
+              "default": false
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -1,6 +1,10 @@
+use crate::config::ChangelogConfig;
 #[cfg(feature = "cli")]
 use crate::conventional_commits::determine_bump;
-use crate::conventional_commits::{BumpType, CommitCategory, classify_commit, parse_subject};
+use crate::conventional_commits::{
+    BumpType, CommitCategory, breaking_footer_body, classify_commit, is_breaking, parse_header,
+    parse_subject,
+};
 use anyhow::Result;
 use chrono::Local;
 use std::path::Path;
@@ -8,6 +12,14 @@ use std::path::Path;
 pub struct GitLog {
     pub hash: String,
     pub message: String,
+}
+
+#[derive(Default)]
+pub struct ChangelogRender<'a> {
+    pub config: Option<&'a ChangelogConfig>,
+    pub forge_base: Option<String>,
+    pub last_tag: Option<String>,
+    pub new_tag: Option<String>,
 }
 
 #[cfg(feature = "cli")]
@@ -30,6 +42,16 @@ pub fn generate_only(config_path: Option<&Path>, dry_run: bool) -> Result<()> {
         );
         return Ok(());
     }
+
+    let forge_base = config.workspace.changelog.as_ref().and_then(|cl| {
+        if cl.include_commit_links || cl.include_compare_link {
+            crate::git::get_remote_url(&repo, &config.workspace.remote)
+                .as_deref()
+                .and_then(crate::forge::web_base_url)
+        } else {
+            None
+        }
+    });
 
     for pkg in &config.packages {
         let tag_prefix = format!("{}@v", pkg.name);
@@ -55,21 +77,25 @@ pub fn generate_only(config_path: Option<&Path>, dry_run: bool) -> Result<()> {
             continue;
         }
 
+        let highest_tag = find_highest_semver_tag_with_cache(
+            &repo,
+            &tag_prefix,
+            config.workspace.orphaned_tag_strategy,
+            None,
+        )?;
+        let last_tag = highest_tag.as_ref().map(|(tag, _version)| tag.clone());
+
         // `versionedFiles` is optional — see #531. If no file is
         // configured, fall back to the highest existing tag, then to
         // 0.0.0 if there are no tags yet.
         let current_version = match pkg.versioned_files.first() {
             Some(vf) => read_version(vf, &root)?,
-            None => find_highest_semver_tag_with_cache(
-                &repo,
-                &tag_prefix,
-                config.workspace.orphaned_tag_strategy,
-                None,
-            )?
-            .map(|(_tag, version)| version)
-            .unwrap_or_else(|| "0.0.0".to_string()),
+            None => highest_tag
+                .map(|(_tag, version)| version)
+                .unwrap_or_else(|| "0.0.0".to_string()),
         };
         let new_version = bump_version(&current_version, bump)?;
+        let new_tag = pkg.tag_for_version(&config.workspace, config.is_monorepo(), &new_version);
 
         let changelog_path = match &pkg.changelog {
             Some(rel) => crate::formats::join_within_repo(&root, rel)?,
@@ -86,31 +112,45 @@ pub fn generate_only(config_path: Option<&Path>, dry_run: bool) -> Result<()> {
             }
         };
 
-        update_changelog(
+        let render = ChangelogRender {
+            config: config.workspace.changelog.as_ref(),
+            forge_base: forge_base.clone(),
+            last_tag,
+            new_tag: Some(new_tag),
+        };
+
+        update_changelog_with(
             &changelog_path,
             &pkg.name,
             &new_version,
             &commits,
             bump,
             dry_run,
+            &render,
         )?;
     }
 
     Ok(())
 }
 
-pub fn build_section(new_version: &str, commits: &[GitLog]) -> String {
+pub fn build_section_with(
+    new_version: &str,
+    commits: &[GitLog],
+    render: &ChangelogRender,
+) -> String {
+    match render.config {
+        Some(config) => build_rich_section(new_version, commits, config, render),
+        None => build_classic_section(new_version, commits),
+    }
+}
+
+fn build_classic_section(new_version: &str, commits: &[GitLog]) -> String {
     let date = Local::now().format("%Y-%m-%d").to_string();
     let mut breaking = Vec::new();
     let mut features = Vec::new();
     let mut fixes = Vec::new();
     let mut refactors = Vec::new();
 
-    // Reuse the same classifier that drives `determine_bump` so the
-    // changelog can never label a release "Breaking Changes" while the
-    // bump engine computed a minor — and so `refactor:` commits, which
-    // are Patch in the bump engine, no longer disappear from the
-    // rendered section. See #525.
     for commit in commits {
         let subject = parse_subject(&commit.message);
         match classify_commit(&commit.message) {
@@ -148,6 +188,199 @@ pub fn build_section(new_version: &str, commits: &[GitLog]) -> String {
     section
 }
 
+const BREAKING_KEY: &str = "breaking";
+
+fn render_section_key(message: &str) -> Option<&'static str> {
+    if is_breaking(message) {
+        return Some(BREAKING_KEY);
+    }
+    let header = parse_header(message)?;
+    let is_security_scope = header
+        .scope
+        .map(|s| s.eq_ignore_ascii_case("security"))
+        .unwrap_or(false);
+    match header.commit_type {
+        "feat" => Some("feat"),
+        "fix" if is_security_scope => Some("security"),
+        "fix" => Some("fix"),
+        "perf" => Some("perf"),
+        "security" => Some("security"),
+        "docs" => Some("docs"),
+        "refactor" => Some("refactor"),
+        _ => None,
+    }
+}
+
+fn resolve_sections(config: &ChangelogConfig) -> Vec<(&'static str, String)> {
+    let default_label = |key: &str| -> &'static str {
+        match key {
+            "feat" => "Features",
+            "fix" => "Bug Fixes",
+            "perf" => "Performance",
+            "security" => "Security",
+            "docs" => "Documentation",
+            "refactor" => "Code Refactoring",
+            _ => "Changes",
+        }
+    };
+
+    let mut enabled: Vec<(&'static str, String)> = Vec::new();
+    let mut push = |key: &'static str, label: String| {
+        if !enabled.iter().any(|(k, _)| *k == key) {
+            enabled.push((key, label));
+        }
+    };
+
+    match &config.sections {
+        None => {
+            push("feat", default_label("feat").to_string());
+            push("fix", default_label("fix").to_string());
+        }
+        Some(map) => {
+            let ordered = ["feat", "fix", "perf", "security", "docs", "refactor"];
+            let lookup = |key: &str| -> Option<Option<String>> {
+                map.get(key).map(|setting| {
+                    if setting.is_hidden() {
+                        None
+                    } else {
+                        Some(
+                            setting
+                                .label()
+                                .map(|s| s.to_string())
+                                .unwrap_or_else(|| default_label(key).to_string()),
+                        )
+                    }
+                })
+            };
+            for key in ordered {
+                let resolved: &'static str = key;
+                if let Some(Some(label)) = lookup(key) {
+                    push(resolved, label);
+                }
+            }
+        }
+    }
+
+    enabled
+}
+
+struct Entry {
+    scope: Option<String>,
+    text: String,
+}
+
+fn build_rich_section(
+    new_version: &str,
+    commits: &[GitLog],
+    config: &ChangelogConfig,
+    render: &ChangelogRender,
+) -> String {
+    let date = Local::now().format("%Y-%m-%d").to_string();
+    let sections = resolve_sections(config);
+
+    let mut breaking: Vec<Entry> = Vec::new();
+    let mut buckets: std::collections::BTreeMap<&'static str, Vec<Entry>> =
+        std::collections::BTreeMap::new();
+
+    for commit in commits {
+        let Some(key) = render_section_key(&commit.message) else {
+            continue;
+        };
+        let entry = build_entry(commit, config, render);
+        if key == BREAKING_KEY {
+            breaking.push(entry);
+        } else if sections.iter().any(|(k, _)| *k == key) {
+            buckets.entry(key).or_default().push(entry);
+        }
+    }
+
+    let mut section = format!("\n## [{new_version}] - {date}\n");
+
+    if !breaking.is_empty() {
+        section.push_str("\n### Breaking Changes\n\n");
+        section.push_str(&render_entries(&breaking, config.group_by_scope));
+        section.push('\n');
+    }
+
+    for (key, label) in &sections {
+        if let Some(entries) = buckets.get(key)
+            && !entries.is_empty()
+        {
+            section.push_str(&format!("\n### {label}\n\n"));
+            section.push_str(&render_entries(entries, config.group_by_scope));
+            section.push('\n');
+        }
+    }
+
+    if config.include_compare_link
+        && let (Some(base), Some(last), Some(new_tag)) =
+            (&render.forge_base, &render.last_tag, &render.new_tag)
+    {
+        section.push_str(&format!(
+            "\n[{new_version}]: {base}/compare/{last}...{new_tag}\n"
+        ));
+    }
+
+    section
+}
+
+fn build_entry(commit: &GitLog, config: &ChangelogConfig, render: &ChangelogRender) -> Entry {
+    let header = parse_header(&commit.message);
+    let scope = header.as_ref().and_then(|h| h.scope.map(|s| s.to_string()));
+
+    let breaking = is_breaking(&commit.message);
+    let body = if breaking {
+        let desc = breaking_footer_body(&commit.message);
+        match (desc, header.as_ref()) {
+            (Some(d), _) => d,
+            (None, Some(h)) => h.description.to_string(),
+            (None, None) => parse_subject(&commit.message).to_string(),
+        }
+    } else {
+        match header.as_ref() {
+            Some(h) => h.description.to_string(),
+            None => parse_subject(&commit.message).to_string(),
+        }
+    };
+
+    let mut text = body;
+    if config.include_commit_links
+        && let Some(base) = &render.forge_base
+    {
+        let short = &commit.hash;
+        text.push_str(&format!(" ([{short}]({base}/commit/{short}))"));
+    }
+
+    Entry { scope, text }
+}
+
+fn render_entries(entries: &[Entry], group_by_scope: bool) -> String {
+    if !group_by_scope {
+        return entries
+            .iter()
+            .map(|e| format!("- {}", e.text))
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
+
+    let mut sorted: Vec<&Entry> = entries.iter().collect();
+    sorted.sort_by(|a, b| match (&a.scope, &b.scope) {
+        (None, None) => std::cmp::Ordering::Equal,
+        (None, Some(_)) => std::cmp::Ordering::Less,
+        (Some(_), None) => std::cmp::Ordering::Greater,
+        (Some(x), Some(y)) => x.cmp(y),
+    });
+
+    sorted
+        .iter()
+        .map(|e| match &e.scope {
+            Some(scope) => format!("- **{scope}:** {}", e.text),
+            None => format!("- {}", e.text),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 pub fn update_changelog(
     changelog_path: &Path,
     package_name: &str,
@@ -156,11 +389,32 @@ pub fn update_changelog(
     bump: BumpType,
     dry_run: bool,
 ) -> Result<()> {
+    update_changelog_with(
+        changelog_path,
+        package_name,
+        new_version,
+        commits,
+        bump,
+        dry_run,
+        &ChangelogRender::default(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn update_changelog_with(
+    changelog_path: &Path,
+    package_name: &str,
+    new_version: &str,
+    commits: &[GitLog],
+    bump: BumpType,
+    dry_run: bool,
+    render: &ChangelogRender,
+) -> Result<()> {
     if bump == BumpType::None {
         return Ok(());
     }
 
-    let section = build_section(new_version, commits);
+    let section = build_section_with(new_version, commits, render);
 
     if dry_run {
         println!(
@@ -193,6 +447,10 @@ pub fn update_changelog(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn build_section(new_version: &str, commits: &[GitLog]) -> String {
+        build_section_with(new_version, commits, &ChangelogRender::default())
+    }
 
     fn make_commits(messages: &[&str]) -> Vec<GitLog> {
         messages
@@ -436,5 +694,308 @@ mod tests {
         let pos1 = content.find("## [0.2.0]").unwrap();
         let pos2 = content.find("## [0.1.0]").unwrap();
         assert!(pos1 < pos2, "newer version should come first");
+    }
+
+    use crate::config::{ChangelogConfig, SectionSetting};
+    use std::collections::BTreeMap;
+
+    fn sections(pairs: &[(&str, SectionSetting)]) -> BTreeMap<String, SectionSetting> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    fn enabled() -> SectionSetting {
+        SectionSetting::Enabled(true)
+    }
+
+    #[test]
+    fn default_render_is_byte_identical_to_classic() {
+        let commits = make_commits(&[
+            "feat: add login",
+            "feat(ui): new dashboard",
+            "fix: null pointer",
+            "perf: faster query",
+            "refactor: clean up",
+            "feat!: remove old API",
+            "chore: noise",
+        ]);
+        let with_default = build_section_with("1.2.3", &commits, &ChangelogRender::default());
+        let classic = build_classic_section("1.2.3", &commits);
+        assert_eq!(with_default, classic);
+    }
+
+    #[test]
+    fn rich_render_with_no_config_field_matches_classic() {
+        let commits = make_commits(&["feat: a", "fix: b"]);
+        let render = ChangelogRender {
+            config: None,
+            ..Default::default()
+        };
+        assert_eq!(
+            build_section_with("1.0.0", &commits, &render),
+            build_classic_section("1.0.0", &commits)
+        );
+    }
+
+    #[test]
+    fn rich_render_perf_and_security_sections() {
+        let cfg = ChangelogConfig {
+            sections: Some(sections(&[
+                ("feat", enabled()),
+                ("fix", enabled()),
+                ("perf", enabled()),
+                ("security", enabled()),
+            ])),
+            ..Default::default()
+        };
+        let commits = make_commits(&[
+            "feat: new endpoint",
+            "perf: cache results",
+            "fix(security): patch xss",
+            "fix: small bug",
+        ]);
+        let render = ChangelogRender {
+            config: Some(&cfg),
+            ..Default::default()
+        };
+        let s = build_section_with("1.1.0", &commits, &render);
+        assert!(s.contains("### Features"));
+        assert!(s.contains("### Performance"));
+        assert!(s.contains("### Security"));
+        assert!(s.contains("### Bug Fixes"));
+        assert!(s.contains("- cache results"));
+        assert!(s.contains("- patch xss"));
+        let pos_perf = s.find("### Performance").unwrap();
+        let pos_sec = s.find("### Security").unwrap();
+        let pos_fix = s.find("### Bug Fixes").unwrap();
+        assert!(pos_fix < pos_perf, "Bug Fixes precedes Performance");
+        assert!(pos_perf < pos_sec, "Performance precedes Security");
+    }
+
+    #[test]
+    fn rich_render_security_takes_precedence_over_fix() {
+        let cfg = ChangelogConfig {
+            sections: Some(sections(&[("fix", enabled()), ("security", enabled())])),
+            ..Default::default()
+        };
+        let commits = make_commits(&["fix(security): sanitize input"]);
+        let render = ChangelogRender {
+            config: Some(&cfg),
+            ..Default::default()
+        };
+        let s = build_section_with("1.0.1", &commits, &render);
+        assert!(s.contains("### Security"));
+        let sec = s.find("### Security").unwrap();
+        assert!(s[sec..].contains("- sanitize input"));
+    }
+
+    #[test]
+    fn rich_render_docs_opt_in_and_hidden() {
+        let with_docs = ChangelogConfig {
+            sections: Some(sections(&[("docs", enabled())])),
+            ..Default::default()
+        };
+        let commits = make_commits(&["docs: explain config"]);
+        let r = ChangelogRender {
+            config: Some(&with_docs),
+            ..Default::default()
+        };
+        assert!(build_section_with("1.0.1", &commits, &r).contains("### Documentation"));
+
+        let hidden = ChangelogConfig {
+            sections: Some(sections(&[("docs", SectionSetting::Enabled(false))])),
+            ..Default::default()
+        };
+        let r2 = ChangelogRender {
+            config: Some(&hidden),
+            ..Default::default()
+        };
+        assert!(!build_section_with("1.0.1", &commits, &r2).contains("### Documentation"));
+    }
+
+    #[test]
+    fn rich_render_custom_labels() {
+        let cfg = ChangelogConfig {
+            sections: Some(sections(&[(
+                "feat",
+                SectionSetting::Label("New Stuff".to_string()),
+            )])),
+            ..Default::default()
+        };
+        let commits = make_commits(&["feat: x"]);
+        let r = ChangelogRender {
+            config: Some(&cfg),
+            ..Default::default()
+        };
+        let s = build_section_with("1.1.0", &commits, &r);
+        assert!(s.contains("### New Stuff"));
+        assert!(!s.contains("### Features"));
+    }
+
+    #[test]
+    fn rich_render_breaking_uses_footer_body() {
+        let cfg = ChangelogConfig::default();
+        let commits = vec![GitLog {
+            hash: "abc1234".to_string(),
+            message: "feat!: change api\n\nBREAKING CHANGE: the v1 endpoint was removed"
+                .to_string(),
+        }];
+        let r = ChangelogRender {
+            config: Some(&cfg),
+            ..Default::default()
+        };
+        let s = build_section_with("2.0.0", &commits, &r);
+        assert!(s.contains("### Breaking Changes"));
+        assert!(s.contains("- the v1 endpoint was removed"));
+    }
+
+    #[test]
+    fn rich_render_breaking_bang_without_footer_uses_description() {
+        let cfg = ChangelogConfig::default();
+        let commits = make_commits(&["feat!: drop legacy flag"]);
+        let r = ChangelogRender {
+            config: Some(&cfg),
+            ..Default::default()
+        };
+        let s = build_section_with("2.0.0", &commits, &r);
+        assert!(s.contains("### Breaking Changes"));
+        assert!(s.contains("- drop legacy flag"));
+    }
+
+    #[test]
+    fn rich_render_scope_grouping_inline_bold() {
+        let cfg = ChangelogConfig {
+            sections: Some(sections(&[("feat", enabled())])),
+            group_by_scope: true,
+            ..Default::default()
+        };
+        let commits = make_commits(&[
+            "feat(api): add events endpoint",
+            "feat(db): add index",
+            "feat: top-level change",
+        ]);
+        let r = ChangelogRender {
+            config: Some(&cfg),
+            ..Default::default()
+        };
+        let s = build_section_with("1.1.0", &commits, &r);
+        assert!(s.contains("- **api:** add events endpoint"));
+        assert!(s.contains("- **db:** add index"));
+        assert!(s.contains("- top-level change"));
+        assert!(!s.contains("### api"), "scopes must not become subheadings");
+        let pos_scopeless = s.find("- top-level change").unwrap();
+        let pos_api = s.find("- **api:**").unwrap();
+        assert!(pos_scopeless < pos_api, "scopeless entries render first");
+    }
+
+    #[test]
+    fn rich_render_commit_links_when_forge_known() {
+        let cfg = ChangelogConfig {
+            sections: Some(sections(&[("feat", enabled())])),
+            include_commit_links: true,
+            ..Default::default()
+        };
+        let commits = vec![GitLog {
+            hash: "abc1234".to_string(),
+            message: "feat: add endpoint".to_string(),
+        }];
+        let r = ChangelogRender {
+            config: Some(&cfg),
+            forge_base: Some("https://github.com/owner/repo".to_string()),
+            ..Default::default()
+        };
+        let s = build_section_with("1.1.0", &commits, &r);
+        assert!(
+            s.contains("- add endpoint ([abc1234](https://github.com/owner/repo/commit/abc1234))")
+        );
+    }
+
+    #[test]
+    fn rich_render_commit_links_omitted_when_forge_unknown() {
+        let cfg = ChangelogConfig {
+            sections: Some(sections(&[("feat", enabled())])),
+            include_commit_links: true,
+            ..Default::default()
+        };
+        let commits = make_commits(&["feat: add endpoint"]);
+        let r = ChangelogRender {
+            config: Some(&cfg),
+            forge_base: None,
+            ..Default::default()
+        };
+        let s = build_section_with("1.1.0", &commits, &r);
+        assert!(s.contains("- add endpoint"));
+        assert!(!s.contains("(["), "no commit link without a known forge");
+    }
+
+    #[test]
+    fn rich_render_compare_link_when_last_tag_exists() {
+        let cfg = ChangelogConfig {
+            sections: Some(sections(&[("feat", enabled())])),
+            include_compare_link: true,
+            ..Default::default()
+        };
+        let commits = make_commits(&["feat: x"]);
+        let r = ChangelogRender {
+            config: Some(&cfg),
+            forge_base: Some("https://github.com/owner/repo".to_string()),
+            last_tag: Some("v1.2.2".to_string()),
+            new_tag: Some("v1.2.3".to_string()),
+        };
+        let s = build_section_with("1.2.3", &commits, &r);
+        assert!(s.contains("[1.2.3]: https://github.com/owner/repo/compare/v1.2.2...v1.2.3"));
+    }
+
+    #[test]
+    fn rich_render_compare_link_omitted_without_last_tag() {
+        let cfg = ChangelogConfig {
+            sections: Some(sections(&[("feat", enabled())])),
+            include_compare_link: true,
+            ..Default::default()
+        };
+        let commits = make_commits(&["feat: x"]);
+        let r = ChangelogRender {
+            config: Some(&cfg),
+            forge_base: Some("https://github.com/owner/repo".to_string()),
+            last_tag: None,
+            new_tag: Some("v1.0.0".to_string()),
+        };
+        let s = build_section_with("1.0.0", &commits, &r);
+        assert!(!s.contains("/compare/"));
+    }
+
+    #[test]
+    fn rich_render_omitted_sections_drop_commits() {
+        let cfg = ChangelogConfig {
+            sections: Some(sections(&[("feat", enabled())])),
+            ..Default::default()
+        };
+        let commits = make_commits(&["feat: kept", "perf: dropped", "fix: dropped"]);
+        let r = ChangelogRender {
+            config: Some(&cfg),
+            ..Default::default()
+        };
+        let s = build_section_with("1.1.0", &commits, &r);
+        assert!(s.contains("- kept"));
+        assert!(!s.contains("### Performance"));
+        assert!(!s.contains("### Bug Fixes"));
+        assert!(!s.contains("dropped"));
+    }
+
+    #[test]
+    fn rich_render_default_sections_match_feat_fix_only() {
+        let cfg = ChangelogConfig::default();
+        let commits = make_commits(&["feat: f", "fix: b", "perf: p", "docs: d"]);
+        let r = ChangelogRender {
+            config: Some(&cfg),
+            ..Default::default()
+        };
+        let s = build_section_with("1.1.0", &commits, &r);
+        assert!(s.contains("### Features"));
+        assert!(s.contains("### Bug Fixes"));
+        assert!(!s.contains("### Performance"));
+        assert!(!s.contains("### Documentation"));
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -25,7 +25,9 @@ pub use types::{
     ReleaseCommitScope,
 };
 #[allow(unused_imports)]
-pub use workspace::{WorkspaceConfig, default_commit_skip_markers};
+pub use workspace::{
+    ChangelogConfig, SectionSetting, WorkspaceConfig, default_commit_skip_markers,
+};
 
 use format::{CONFIG_FORMATS, DotfileFormat, Json5Format, JsonFormat, TomlFormat};
 #[cfg(feature = "cli")]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -90,6 +90,60 @@ format = "toml"
 }
 
 #[test]
+fn parse_changelog_config_toml() {
+    let toml = r#"
+[workspace.changelog]
+sections = { feat = "Features", fix = "Bug Fixes", perf = "Performance", docs = false }
+group_by_scope = true
+include_commit_links = true
+include_compare_link = true
+
+[[package]]
+name = "app"
+path = "."
+"#;
+    let config: Config = toml_edit::de::from_str(toml).unwrap();
+    let cl = config
+        .workspace
+        .changelog
+        .expect("changelog config present");
+    assert!(cl.group_by_scope);
+    assert!(cl.include_commit_links);
+    assert!(cl.include_compare_link);
+    let sections = cl.sections.expect("sections present");
+    assert_eq!(
+        sections.get("feat").and_then(|s| s.label()),
+        Some("Features")
+    );
+    assert!(sections.get("docs").unwrap().is_hidden());
+    assert!(!sections.get("feat").unwrap().is_hidden());
+}
+
+#[test]
+fn parse_changelog_config_camel_case() {
+    let json = r#"{
+        "workspace": { "changelog": { "groupByScope": true, "includeCommitLinks": true, "includeCompareLink": true } },
+        "package": []
+    }"#;
+    let config: Config = serde_json::from_str(json).unwrap();
+    let cl = config
+        .workspace
+        .changelog
+        .expect("changelog config present");
+    assert!(cl.group_by_scope);
+    assert!(cl.include_commit_links);
+    assert!(cl.include_compare_link);
+    assert!(cl.sections.is_none());
+}
+
+#[test]
+fn changelog_config_defaults_when_absent() {
+    let json = r#"{ "workspace": {}, "package": [] }"#;
+    let config: Config = serde_json::from_str(json).unwrap();
+    assert!(config.workspace.changelog.is_none());
+}
+
+#[test]
 fn parse_versioning_strategies() {
     let json = r#"{
             "workspace": { "versioning": "calver" },

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -57,6 +57,40 @@ pub struct WorkspaceConfig {
     /// publish` always runs the publishers regardless of this flag.
     #[serde(default, alias = "deferPublish")]
     pub defer_publish: bool,
+    #[serde(default)]
+    pub changelog: Option<ChangelogConfig>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct ChangelogConfig {
+    #[serde(default)]
+    pub sections: Option<BTreeMap<String, SectionSetting>>,
+    #[serde(default, alias = "groupByScope")]
+    pub group_by_scope: bool,
+    #[serde(default, alias = "includeCommitLinks")]
+    pub include_commit_links: bool,
+    #[serde(default, alias = "includeCompareLink")]
+    pub include_compare_link: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum SectionSetting {
+    Label(String),
+    Enabled(bool),
+}
+
+impl SectionSetting {
+    pub fn label(&self) -> Option<&str> {
+        match self {
+            SectionSetting::Label(label) => Some(label),
+            SectionSetting::Enabled(_) => None,
+        }
+    }
+
+    pub fn is_hidden(&self) -> bool {
+        matches!(self, SectionSetting::Enabled(false))
+    }
 }
 
 impl WorkspaceConfig {

--- a/src/conventional_commits.rs
+++ b/src/conventional_commits.rs
@@ -103,6 +103,49 @@ pub fn parse_subject(message: &str) -> &str {
     message.lines().next().unwrap_or("").trim()
 }
 
+static HEADER_RE: OnceLock<Regex> = OnceLock::new();
+
+fn header_re() -> &'static Regex {
+    HEADER_RE.get_or_init(|| {
+        Regex::new(r"^(?P<type>[a-z]+)(?:\((?P<scope>[^()]+)\))?(?P<bang>!)?:\s*(?P<desc>.*)$")
+            .unwrap()
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedHeader<'a> {
+    pub commit_type: &'a str,
+    pub scope: Option<&'a str>,
+    pub breaking_bang: bool,
+    pub description: &'a str,
+}
+
+pub fn parse_header(message: &str) -> Option<ParsedHeader<'_>> {
+    let subject = parse_subject(message);
+    let caps = header_re().captures(subject)?;
+    Some(ParsedHeader {
+        commit_type: caps.name("type")?.as_str(),
+        scope: caps.name("scope").map(|m| m.as_str()),
+        breaking_bang: caps.name("bang").is_some(),
+        description: caps.name("desc").map(|m| m.as_str()).unwrap_or(""),
+    })
+}
+
+pub fn is_breaking(message: &str) -> bool {
+    matches!(classify_commit(message), CommitCategory::Breaking)
+}
+
+pub fn breaking_footer_body(message: &str) -> Option<String> {
+    let re = breaking_footer_re();
+    let mat = re.find(message)?;
+    let body = message[mat.end()..].trim();
+    if body.is_empty() {
+        None
+    } else {
+        Some(body.lines().next().unwrap_or("").trim().to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -348,5 +391,60 @@ mod tests {
     fn test_multiline_body_breaking_marker_in_body_does_not_match() {
         let msg = "chore: update deps\n\nfeat!: this is in the body";
         assert_eq!(determine_bump(msg), BumpType::None);
+    }
+
+    #[test]
+    fn test_parse_header_type_scope_desc() {
+        let h = parse_header("feat(api): add events endpoint").unwrap();
+        assert_eq!(h.commit_type, "feat");
+        assert_eq!(h.scope, Some("api"));
+        assert!(!h.breaking_bang);
+        assert_eq!(h.description, "add events endpoint");
+    }
+
+    #[test]
+    fn test_parse_header_breaking_bang() {
+        let h = parse_header("feat!: drop flag").unwrap();
+        assert_eq!(h.commit_type, "feat");
+        assert_eq!(h.scope, None);
+        assert!(h.breaking_bang);
+        assert_eq!(h.description, "drop flag");
+    }
+
+    #[test]
+    fn test_parse_header_scoped_bang() {
+        let h = parse_header("fix(security)!: patch").unwrap();
+        assert_eq!(h.commit_type, "fix");
+        assert_eq!(h.scope, Some("security"));
+        assert!(h.breaking_bang);
+    }
+
+    #[test]
+    fn test_parse_header_non_conventional() {
+        assert!(parse_header("just a message").is_none());
+        assert!(parse_header("feat add no colon").is_none());
+    }
+
+    #[test]
+    fn test_breaking_footer_body_extracts_description() {
+        let msg = "feat: add x\n\nBREAKING CHANGE: the old endpoint is gone";
+        assert_eq!(
+            breaking_footer_body(msg).as_deref(),
+            Some("the old endpoint is gone")
+        );
+    }
+
+    #[test]
+    fn test_breaking_footer_body_none_when_absent() {
+        assert_eq!(breaking_footer_body("feat: add x"), None);
+        assert_eq!(breaking_footer_body("feat!: add x"), None);
+    }
+
+    #[test]
+    fn test_is_breaking() {
+        assert!(is_breaking("feat!: x"));
+        assert!(is_breaking("feat: x\n\nBREAKING CHANGE: y"));
+        assert!(!is_breaking("feat: x"));
+        assert!(!is_breaking("fix: y"));
     }
 }

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -126,6 +126,16 @@ pub fn extract_repo_slug(url: &str) -> Option<String> {
         .filter(|s| s.contains('/') && !s.is_empty())
 }
 
+pub fn web_base_url(remote_url: &str) -> Option<String> {
+    let kind = detect_forge_from_url(remote_url)?;
+    let host = extract_host(remote_url)?;
+    let slug = extract_repo_slug(remote_url)?;
+    match kind {
+        ForgeKind::Github | ForgeKind::Gitlab => Some(format!("https://{host}/{slug}")),
+        ForgeKind::Auto => None,
+    }
+}
+
 pub fn resolve_token(kind: ForgeKind) -> Option<String> {
     if let Ok(token) = std::env::var("FERRFLOW_TOKEN")
         && !token.is_empty()

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -3,7 +3,7 @@ use colored::Colorize;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
-use crate::changelog::{build_section, update_changelog};
+use crate::changelog::{ChangelogRender, build_section_with, update_changelog_with};
 use crate::config::{Config, OrphanedTagStrategy, VersioningStrategy};
 use crate::conventional_commits::{BumpType, determine_bump};
 use crate::formats::{get_handler, read_version, write_version};
@@ -100,6 +100,16 @@ pub(super) fn run_release_logic(
     }
 
     let current_branch = crate::git::resolve_current_branch(&repo, &config.workspace.branch);
+
+    let forge_base = config.workspace.changelog.as_ref().and_then(|cl| {
+        if cl.include_commit_links || cl.include_compare_link {
+            crate::git::get_remote_url(&repo, &config.workspace.remote)
+                .as_deref()
+                .and_then(crate::forge::web_base_url)
+        } else {
+            None
+        }
+    });
 
     let prerelease_ctx = PrereleaseContext::resolve(
         channel,
@@ -215,10 +225,9 @@ pub(super) fn run_release_logic(
         let strategy = config.workspace.orphaned_tag_strategy;
         // Fast path via the pre-built TagIndex for Warn (default); otherwise
         // fall back to the per-call form that still uses the ancestor cache.
-        let tag_version =
+        let highest_tag =
             if let (Some(idx), OrphanedTagStrategy::Warn) = (tag_index.as_ref(), strategy) {
                 idx.find_highest_semver_tag(&tag_search_prefix, strategy)
-                    .map(|(_tag, version)| version)
             } else {
                 crate::git::find_highest_semver_tag_with_cache(
                     &repo,
@@ -226,8 +235,9 @@ pub(super) fn run_release_logic(
                     strategy,
                     head_ancestors.as_ref(),
                 )?
-                .map(|(_tag, version)| version)
             };
+        let last_tag = highest_tag.as_ref().map(|(tag, _version)| tag.clone());
+        let tag_version = highest_tag.map(|(_tag, version)| version);
         let current_version = match (tag_version, file_version) {
             (Some(tag), Some(file)) => pick_higher_semver(&file, &tag),
             (Some(tag), None) => tag,
@@ -502,15 +512,23 @@ pub(super) fn run_release_logic(
                 }
             }
 
+            let changelog_render = ChangelogRender {
+                config: config.workspace.changelog.as_ref(),
+                forge_base: forge_base.clone(),
+                last_tag: last_tag.clone(),
+                new_tag: Some(tag.clone()),
+            };
+
             if let Some(changelog_rel) = &pkg.changelog {
                 let changelog_path = root.join(changelog_rel);
-                update_changelog(
+                update_changelog_with(
                     &changelog_path,
                     &pkg.name,
                     &new_version,
                     &commits,
                     bump,
                     false,
+                    &changelog_render,
                 )?;
                 files_to_commit.push(changelog_rel.clone());
                 files_per_package
@@ -538,7 +556,7 @@ pub(super) fn run_release_logic(
                 }
             }
 
-            let body = build_section(&new_version, &commits);
+            let body = build_section_with(&new_version, &commits, &changelog_render);
             tags_to_create.push((
                 tag.clone(),
                 format!("Release {tag}"),


### PR DESCRIPTION
Closes #497

## Summary

Adds an opt-in `[workspace.changelog]` config that enriches changelog/release rendering. **Default behaviour is byte-identical to today** — with no config, output is the classic three sections (Breaking Changes / Features / Bug Fixes) with flat bullets of full commit subjects, no links, no scope grouping. Everything new is gated behind config.

## Config shape

```toml
[workspace.changelog]
sections = { feat = "Features", fix = "Bug Fixes", perf = "Performance", security = "Security", docs = false }
group_by_scope = true
include_commit_links = true
include_compare_link = true
```

- `sections`: `BTreeMap<String, SectionSetting>` where a value is a label string OR `false` (hidden), via an untagged serde enum. Keys are commit-type prefixes (`feat`/`fix`/`perf`/`docs`/`refactor`/`security`). Omitted -> defaults to feat -> Features, fix -> Bug Fixes (Breaking Changes always shown).
- `group_by_scope` (alias `groupByScope`), `include_commit_links` (`includeCommitLinks`), `include_compare_link` (`includeCompareLink`) — all bool, default false. `ChangelogConfig` derives `Default`.

## Conventions followed (differ from the issue intentionally)

- **Section mapping is render-time** by commit-type prefix; the bump engine (`classify_commit`/`determine_bump`) is untouched. Order: Breaking, Features, Bug Fixes, Performance, Security, then other configured. `security` takes precedence over `fix` for `fix(security):`.
- **Scope grouping is inline bold** (`- **api:** add events endpoint`), sorted by scope with scopeless entries first — NOT `### api` subheadings.
- **No Deprecated/Removed sections** — no conventional-commits signal to derive them.
- Commit links `([<hash>](<forge>/commit/<hash>))` and compare footer `[<ver>]: <forge>/compare/<last>...<new>` only when the forge is resolvable; **forge-unknown silently omits** them (no error).
- Breaking entries render the `BREAKING CHANGE:` footer body when richer mode is active (subject-only under default).

## Tests

`default_render_is_byte_identical_to_classic` proves the no-config path equals the classic renderer. Added coverage for perf/security/docs/feat! sections, security precedence, inline scope grouping, commit links (present + forge-unknown omitted), compare link (present + no-last-tag omitted), custom labels, breaking-footer body, plus config parsing (TOML + camelCase, untagged `false`). All pre-existing `src/changelog.rs` tests pass unchanged.

## Schema

Updated `schema/ferrflow.json` with `workspace.changelog`. The FerrFlow-Cloud mirror (`public/schema/ferrflow.json`) is not touched here — handled separately.