### PR TITLE
feat(release): optional manifest mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "5.11.0"
+version = "5.11.1"
 dependencies = [
  "anyhow",
  "cargo-husky",

--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -104,6 +104,11 @@
           "description": "When true, `ferrflow release` does not run the configured publishers inline — it defers them to a separate `ferrflow publish` invocation (e.g. a CI job that carries the docker/helm/npm build toolchain the release job lacks). `ferrflow publish` always runs the publishers regardless of this flag.",
           "default": false
         },
+        "manifest_file": {
+          "type": "string",
+          "description": "Opt-in single-file source of truth for per-package versions, relative to the repo root (e.g. '.ferrflow.manifest.json'). When set, `ferrflow release` writes a full version snapshot to this file as part of the release commit, validates it against the versioned files at release start (a divergence is a hard error — run `ferrflow sync-manifest` to repair), and `status` / `version` read current versions from it. Omit to leave all behaviour unchanged.",
+          "examples": [".ferrflow.manifest.json"]
+        },
         "registries": {
           "type": "object",
           "description": "Named registry credentials referenced by package.publishers[]. Lets users declare 'the Kellnr token lives in CARGO_REGISTRIES_KELLNR_TOKEN' once and reuse it across every cargo / npm / docker publisher.",

--- a/schema/manifest.json
+++ b/schema/manifest.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://ferrflow.com/schema/manifest.json",
+  "title": "FerrFlow Version Manifest",
+  "description": "Single-file source of truth for per-package versions, written by `ferrflow release` when workspace.manifest_file is configured. Lists the current version of every configured package as of the last release.",
+  "type": "object",
+  "required": ["version", "packages"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON Schema reference for editor autocompletion."
+    },
+    "version": {
+      "type": "integer",
+      "description": "Manifest schema version. Currently always 1.",
+      "const": 1
+    },
+    "packages": {
+      "type": "object",
+      "description": "Map of package name to its current version. Sorted alphabetically for deterministic diffs.",
+      "additionalProperties": {
+        "type": "string",
+        "description": "The current version of the package."
+      }
+    },
+    "released_at": {
+      "type": "string",
+      "description": "ISO-8601 UTC timestamp of when the manifest was written.",
+      "format": "date-time",
+      "examples": ["2026-05-22T18:30:00Z"]
+    },
+    "commit": {
+      "type": "string",
+      "description": "Short SHA of the release commit (or HEAD at write time)."
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -86,6 +86,10 @@ pub enum Commands {
         /// Config file format (json, json5, toml)
         #[arg(long)]
         format: Option<ConfigFileFormat>,
+        /// Also scaffold a .ferrflow.manifest.json snapshot and enable
+        /// manifest mode in the generated config
+        #[arg(long)]
+        manifest: bool,
     },
     /// Print each package name, current version, and last release tag
     Status {
@@ -131,6 +135,11 @@ pub enum Commands {
         #[command(subcommand)]
         command: CacheCommand,
     },
+    /// Regenerate the version manifest from current filesystem state.
+    /// Requires workspace.manifest_file to be configured. Use this to
+    /// repair a manifest that diverged from the package files (e.g. after
+    /// a crashed release).
+    SyncManifest,
 }
 
 #[derive(Subcommand)]
@@ -153,6 +162,7 @@ impl Commands {
             Commands::Validate { .. } => "validate",
             Commands::Completions { .. } => "completions",
             Commands::Cache { .. } => "cache",
+            Commands::SyncManifest => "sync-manifest",
         }
     }
 }
@@ -205,7 +215,7 @@ impl Cli {
             Commands::Changelog => {
                 crate::changelog::generate_only(self.config.as_deref(), self.dry_run)
             }
-            Commands::Init { format } => crate::config::init(format),
+            Commands::Init { format, manifest } => crate::config::init(format, manifest),
             Commands::Status { output } => {
                 crate::status::run(self.config.as_deref(), &output, timing)
             }
@@ -237,6 +247,7 @@ impl Cli {
             Commands::Cache { command } => match command {
                 CacheCommand::Clear => crate::cache::clear_cwd(),
             },
+            Commands::SyncManifest => crate::manifest::sync_cwd(self.config.as_deref()),
         }
     }
 }
@@ -341,16 +352,38 @@ mod tests {
     #[test]
     fn parse_init_no_format() {
         let cli = parse(&["ferrflow", "init"]);
-        assert!(matches!(cli.command, Commands::Init { format: None }));
+        assert!(matches!(
+            cli.command,
+            Commands::Init {
+                format: None,
+                manifest: false
+            }
+        ));
     }
 
     #[test]
     fn parse_init_with_format() {
         let cli = parse(&["ferrflow", "init", "--format", "toml"]);
         match cli.command {
-            Commands::Init { format } => assert!(format.is_some()),
+            Commands::Init { format, .. } => assert!(format.is_some()),
             _ => panic!("expected Init"),
         }
+    }
+
+    #[test]
+    fn parse_init_with_manifest() {
+        let cli = parse(&["ferrflow", "init", "--manifest"]);
+        match cli.command {
+            Commands::Init { manifest, .. } => assert!(manifest),
+            _ => panic!("expected Init"),
+        }
+    }
+
+    #[test]
+    fn parse_sync_manifest() {
+        let cli = parse(&["ferrflow", "sync-manifest"]);
+        assert!(matches!(cli.command, Commands::SyncManifest));
+        assert_eq!(cli.command.name(), "sync-manifest");
     }
 
     #[test]

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -177,7 +177,9 @@ fn collect_package(path_default: &str, monorepo: bool) -> PackageConfig {
     }
 }
 
-pub fn init(format: Option<ConfigFileFormat>) -> Result<()> {
+const DEFAULT_MANIFEST_FILE: &str = ".ferrflow.manifest.json";
+
+pub fn init(format: Option<ConfigFileFormat>, manifest: bool) -> Result<()> {
     // Check if any config file already exists
     for handler in CONFIG_FORMATS {
         let path = PathBuf::from(handler.filename());
@@ -218,8 +220,13 @@ pub fn init(format: Option<ConfigFileFormat>) -> Result<()> {
         vec![collect_package(".", false)]
     };
 
+    let mut workspace = WorkspaceConfig::default();
+    if manifest {
+        workspace.manifest_file = Some(DEFAULT_MANIFEST_FILE.to_string());
+    }
+
     let config = Config {
-        workspace: WorkspaceConfig::default(),
+        workspace,
         packages,
     };
 
@@ -227,6 +234,19 @@ pub fn init(format: Option<ConfigFileFormat>) -> Result<()> {
     let filename = handler.filename();
     std::fs::write(filename, &content)?;
     println!("Created {filename}");
+
+    if manifest {
+        let root = std::env::current_dir()?;
+        let packages = crate::manifest::initial_snapshot(&config, &root);
+        let initial = crate::manifest::Manifest::new(
+            packages,
+            crate::manifest::now_utc_iso8601(),
+            String::new(),
+        );
+        crate::manifest::write_atomic(&root.join(DEFAULT_MANIFEST_FILE), &initial)?;
+        println!("Created {DEFAULT_MANIFEST_FILE}");
+    }
+
     println!("Run: ferrflow check");
 
     if config.workspace.anonymous_telemetry {

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -59,6 +59,14 @@ pub struct WorkspaceConfig {
     pub defer_publish: bool,
     #[serde(default)]
     pub changelog: Option<ChangelogConfig>,
+    /// Opt-in single-file source of truth for per-package versions.
+    /// When set (e.g. `".ferrflow.manifest.json"`), `ferrflow release`
+    /// writes a full version snapshot to this path (relative to the repo
+    /// root) as part of the release commit, validates it against the
+    /// versioned files at release start, and `status` / `version` read
+    /// from it. `None` (default) leaves all behaviour unchanged.
+    #[serde(default, alias = "manifestFile")]
+    pub manifest_file: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ pub mod forge;
 #[cfg(feature = "cli")]
 pub mod git;
 #[cfg(feature = "cli")]
+pub mod manifest;
+#[cfg(feature = "cli")]
 pub mod publishers;
 #[cfg(feature = "cli")]
 pub mod telemetry;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod forge;
 mod formats;
 mod git;
 mod hooks;
+mod manifest;
 mod monorepo;
 mod prerelease;
 mod publish;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,0 +1,420 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::config::Config;
+use crate::error_code::{self, ErrorCodeExt};
+use crate::formats::read_version;
+
+const MANIFEST_SCHEMA_URL: &str = "https://ferrflow.com/schema/manifest.json";
+const MANIFEST_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Manifest {
+    #[serde(rename = "$schema")]
+    pub schema: String,
+    pub version: u32,
+    pub packages: BTreeMap<String, String>,
+    pub released_at: String,
+    pub commit: String,
+}
+
+impl Manifest {
+    pub fn new(packages: BTreeMap<String, String>, released_at: String, commit: String) -> Self {
+        Self {
+            schema: MANIFEST_SCHEMA_URL.to_string(),
+            version: MANIFEST_VERSION,
+            packages,
+            released_at,
+            commit,
+        }
+    }
+
+    pub fn version_of(&self, package: &str) -> Option<&str> {
+        self.packages.get(package).map(String::as_str)
+    }
+}
+
+pub fn now_utc_iso8601() -> String {
+    chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
+}
+
+pub fn manifest_path(config: &Config, root: &Path) -> Option<PathBuf> {
+    config
+        .workspace
+        .manifest_file
+        .as_ref()
+        .map(|rel| root.join(rel))
+}
+
+pub fn read(path: &Path) -> Result<Manifest> {
+    let bytes = std::fs::read(path)
+        .with_context(|| format!("failed to read manifest at {}", path.display()))
+        .error_code(error_code::CONFIG_READ_FAILED)?;
+    serde_json::from_slice(&bytes)
+        .with_context(|| format!("failed to parse manifest at {}", path.display()))
+        .error_code(error_code::CONFIG_READ_FAILED)
+}
+
+pub fn read_if_present(path: &Path) -> Result<Option<Manifest>> {
+    if path.exists() {
+        read(path).map(Some)
+    } else {
+        Ok(None)
+    }
+}
+
+pub fn write_atomic(path: &Path, manifest: &Manifest) -> Result<()> {
+    let mut serialized = serde_json::to_string_pretty(manifest)?;
+    serialized.push('\n');
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent).ok();
+    }
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("manifest");
+    let tmp_path = path.with_file_name(format!("{file_name}.{}.tmp", std::process::id()));
+    std::fs::write(&tmp_path, serialized.as_bytes())
+        .with_context(|| format!("failed to write manifest temp file {}", tmp_path.display()))?;
+    if let Err(e) = std::fs::rename(&tmp_path, path) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(e)
+            .with_context(|| format!("failed to move manifest into place at {}", path.display()));
+    }
+    Ok(())
+}
+
+pub fn snapshot_from_files(config: &Config, root: &Path) -> BTreeMap<String, String> {
+    snapshot_with_overrides(config, root, &BTreeMap::new())
+}
+
+pub fn snapshot_with_overrides(
+    config: &Config,
+    root: &Path,
+    overrides: &BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
+    let mut packages = BTreeMap::new();
+    for pkg in &config.packages {
+        let version = overrides.get(&pkg.name).cloned().or_else(|| {
+            pkg.versioned_files
+                .first()
+                .and_then(|vf| read_version(vf, root).ok())
+        });
+        if let Some(version) = version {
+            packages.insert(pkg.name.clone(), version);
+        }
+    }
+    packages
+}
+
+pub fn initial_snapshot(config: &Config, root: &Path) -> BTreeMap<String, String> {
+    config
+        .packages
+        .iter()
+        .map(|pkg| {
+            let version = pkg
+                .versioned_files
+                .first()
+                .and_then(|vf| read_version(vf, root).ok())
+                .unwrap_or_else(|| "0.0.0".to_string());
+            (pkg.name.clone(), version)
+        })
+        .collect()
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Divergence {
+    VersionMismatch {
+        package: String,
+        manifest: String,
+        file: String,
+    },
+    MissingFromManifest(String),
+    NotInConfig(String),
+    PackageUnreadable(String),
+}
+
+impl Divergence {
+    fn describe(&self) -> String {
+        match self {
+            Divergence::VersionMismatch {
+                package,
+                manifest,
+                file,
+            } => format!("{package}: manifest says {manifest} but file says {file}"),
+            Divergence::MissingFromManifest(pkg) => {
+                format!("{pkg}: configured package missing from manifest")
+            }
+            Divergence::NotInConfig(pkg) => {
+                format!("{pkg}: present in manifest but not in config")
+            }
+            Divergence::PackageUnreadable(pkg) => {
+                format!("{pkg}: could not read version from its files")
+            }
+        }
+    }
+}
+
+pub fn diff(manifest: &Manifest, config: &Config, root: &Path) -> Vec<Divergence> {
+    let mut divergences = Vec::new();
+    let mut configured = std::collections::HashSet::new();
+
+    for pkg in &config.packages {
+        configured.insert(pkg.name.as_str());
+        let Some(vf) = pkg.versioned_files.first() else {
+            continue;
+        };
+        let manifest_version = manifest.version_of(&pkg.name);
+        match (read_version(vf, root).ok(), manifest_version) {
+            (Some(file), Some(manifest_ver)) if file != manifest_ver => {
+                divergences.push(Divergence::VersionMismatch {
+                    package: pkg.name.clone(),
+                    manifest: manifest_ver.to_string(),
+                    file,
+                });
+            }
+            (Some(_), Some(_)) => {}
+            (Some(_), None) => {
+                divergences.push(Divergence::MissingFromManifest(pkg.name.clone()));
+            }
+            (None, _) => {
+                divergences.push(Divergence::PackageUnreadable(pkg.name.clone()));
+            }
+        }
+    }
+
+    for name in manifest.packages.keys() {
+        if !configured.contains(name.as_str()) {
+            divergences.push(Divergence::NotInConfig(name.clone()));
+        }
+    }
+
+    divergences
+}
+
+pub fn validate_in_sync(config: &Config, root: &Path) -> Result<()> {
+    let Some(path) = manifest_path(config, root) else {
+        return Ok(());
+    };
+    let Some(manifest) = read_if_present(&path)? else {
+        return Ok(());
+    };
+    let divergences = diff(&manifest, config, root);
+    if divergences.is_empty() {
+        return Ok(());
+    }
+    let detail = divergences
+        .iter()
+        .map(Divergence::describe)
+        .collect::<Vec<_>>()
+        .join("\n  ");
+    Err(anyhow::anyhow!(
+        "manifest out of sync with package files — run `ferrflow sync-manifest` to repair\n  {detail}"
+    ))
+    .error_code(error_code::CONFIG_READ_FAILED)
+}
+
+pub fn sync_cwd(config_path: Option<&Path>) -> Result<()> {
+    use crate::git::{get_repo_root, open_repo};
+
+    let repo = open_repo(&std::env::current_dir()?)?;
+    let root = get_repo_root(&repo)?;
+    let config = Config::load(&root, config_path)?;
+
+    let Some(path) = manifest_path(&config, &root) else {
+        return Err(anyhow::anyhow!(
+            "manifest mode is not enabled — set `workspace.manifest_file` in your config first"
+        ))
+        .error_code(error_code::CONFIG_NOT_FOUND);
+    };
+
+    let packages = snapshot_from_files(&config, &root);
+    let commit = repo
+        .head_id()
+        .ok()
+        .map(|id| {
+            let full = id.to_string();
+            full[..7.min(full.len())].to_string()
+        })
+        .unwrap_or_default();
+    let manifest = Manifest::new(packages, now_utc_iso8601(), commit);
+    write_atomic(&path, &manifest)?;
+    println!(
+        "Wrote {} package version(s) to {}",
+        manifest.packages.len(),
+        path.display()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{FileFormat, PackageConfig, VersionedFile};
+
+    fn pkg(name: &str, path: &str) -> PackageConfig {
+        PackageConfig {
+            name: name.to_string(),
+            path: ".".to_string(),
+            versioned_files: vec![VersionedFile {
+                path: path.to_string(),
+                format: FileFormat::Json,
+                selector: None,
+            }],
+            changelog: None,
+            shared_paths: Vec::new(),
+            depends_on: vec![],
+            versioning: None,
+            tag_template: None,
+            hooks: None,
+            floating_tags: None,
+            publishers: vec![],
+        }
+    }
+
+    fn write_pkg_json(root: &Path, path: &str, version: &str) {
+        std::fs::write(
+            root.join(path),
+            format!("{{\"name\": \"x\", \"version\": \"{version}\"}}"),
+        )
+        .unwrap();
+    }
+
+    fn config_with(packages: Vec<PackageConfig>, manifest_file: Option<&str>) -> Config {
+        let mut config = Config {
+            packages,
+            ..Default::default()
+        };
+        config.workspace.manifest_file = manifest_file.map(str::to_string);
+        config
+    }
+
+    #[test]
+    fn manifest_serializes_sorted_with_schema_and_version() {
+        let mut packages = BTreeMap::new();
+        packages.insert("web".to_string(), "2.0.0".to_string());
+        packages.insert("api".to_string(), "1.3.0".to_string());
+        let manifest = Manifest::new(
+            packages,
+            "2026-05-22T18:30:00Z".to_string(),
+            "abc1234".to_string(),
+        );
+        let json = serde_json::to_string_pretty(&manifest).unwrap();
+        let api_at = json.find("\"api\"").unwrap();
+        let web_at = json.find("\"web\"").unwrap();
+        assert!(api_at < web_at, "packages must be sorted");
+        assert!(json.contains("\"$schema\": \"https://ferrflow.com/schema/manifest.json\""));
+        assert!(json.contains("\"version\": 1"));
+    }
+
+    #[test]
+    fn write_atomic_round_trips_and_leaves_no_temp() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".ferrflow.manifest.json");
+        let mut packages = BTreeMap::new();
+        packages.insert("api".to_string(), "1.0.0".to_string());
+        let manifest = Manifest::new(packages, "t".to_string(), "sha".to_string());
+        write_atomic(&path, &manifest).unwrap();
+        let back = read(&path).unwrap();
+        assert_eq!(back, manifest);
+        let leftovers = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("tmp"))
+            .count();
+        assert_eq!(leftovers, 0);
+    }
+
+    #[test]
+    fn snapshot_reads_every_configured_package() {
+        let dir = tempfile::tempdir().unwrap();
+        write_pkg_json(dir.path(), "api.json", "1.3.0");
+        write_pkg_json(dir.path(), "web.json", "2.0.0");
+        let config = config_with(
+            vec![pkg("api", "api.json"), pkg("web", "web.json")],
+            Some(".ferrflow.manifest.json"),
+        );
+        let snap = snapshot_from_files(&config, dir.path());
+        assert_eq!(snap.get("api").map(String::as_str), Some("1.3.0"));
+        assert_eq!(snap.get("web").map(String::as_str), Some("2.0.0"));
+    }
+
+    #[test]
+    fn diff_flags_version_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        write_pkg_json(dir.path(), "api.json", "1.1.0");
+        let config = config_with(vec![pkg("api", "api.json")], Some("m.json"));
+        let mut packages = BTreeMap::new();
+        packages.insert("api".to_string(), "1.0.0".to_string());
+        let manifest = Manifest::new(packages, "t".to_string(), "sha".to_string());
+        let divergences = diff(&manifest, &config, dir.path());
+        assert_eq!(
+            divergences,
+            vec![Divergence::VersionMismatch {
+                package: "api".to_string(),
+                manifest: "1.0.0".to_string(),
+                file: "1.1.0".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn diff_clean_when_aligned() {
+        let dir = tempfile::tempdir().unwrap();
+        write_pkg_json(dir.path(), "api.json", "1.0.0");
+        let config = config_with(vec![pkg("api", "api.json")], Some("m.json"));
+        let mut packages = BTreeMap::new();
+        packages.insert("api".to_string(), "1.0.0".to_string());
+        let manifest = Manifest::new(packages, "t".to_string(), "sha".to_string());
+        assert!(diff(&manifest, &config, dir.path()).is_empty());
+    }
+
+    #[test]
+    fn diff_flags_missing_and_extra_packages() {
+        let dir = tempfile::tempdir().unwrap();
+        write_pkg_json(dir.path(), "api.json", "1.0.0");
+        let config = config_with(vec![pkg("api", "api.json")], Some("m.json"));
+        let mut packages = BTreeMap::new();
+        packages.insert("ghost".to_string(), "9.9.9".to_string());
+        let manifest = Manifest::new(packages, "t".to_string(), "sha".to_string());
+        let divergences = diff(&manifest, &config, dir.path());
+        assert!(divergences.contains(&Divergence::MissingFromManifest("api".to_string())));
+        assert!(divergences.contains(&Divergence::NotInConfig("ghost".to_string())));
+    }
+
+    #[test]
+    fn validate_in_sync_passes_when_manifest_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        write_pkg_json(dir.path(), "api.json", "1.0.0");
+        let config = config_with(
+            vec![pkg("api", "api.json")],
+            Some(".ferrflow.manifest.json"),
+        );
+        assert!(validate_in_sync(&config, dir.path()).is_ok());
+    }
+
+    #[test]
+    fn validate_in_sync_noop_when_disabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = config_with(vec![pkg("api", "api.json")], None);
+        assert!(validate_in_sync(&config, dir.path()).is_ok());
+    }
+
+    #[test]
+    fn validate_in_sync_errors_on_divergence() {
+        let dir = tempfile::tempdir().unwrap();
+        write_pkg_json(dir.path(), "api.json", "1.1.0");
+        let path = dir.path().join("m.json");
+        let mut packages = BTreeMap::new();
+        packages.insert("api".to_string(), "1.0.0".to_string());
+        write_atomic(&path, &Manifest::new(packages, "t".into(), "sha".into())).unwrap();
+        let config = config_with(vec![pkg("api", "api.json")], Some("m.json"));
+        let err = validate_in_sync(&config, dir.path()).unwrap_err();
+        assert!(format!("{err:?}").contains("sync-manifest"));
+    }
+}

--- a/src/monorepo/release.rs
+++ b/src/monorepo/release.rs
@@ -28,6 +28,10 @@ pub fn release(
     let config = timing.stage("load config", || Config::load(&root, config_path))?;
     drop(repo);
 
+    if !dry_run {
+        crate::manifest::validate_in_sync(&config, &root)?;
+    }
+
     if dry_run {
         println!("{}", "FerrFlow — Release (dry run)".bold().blue());
     } else {

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -617,6 +617,27 @@ pub(super) fn run_release_logic(
     }
 
     if any_bumped && !tags_to_create.is_empty() {
+        if !dry_run && let Some(manifest_rel) = config.workspace.manifest_file.as_deref() {
+            let overrides: std::collections::BTreeMap<String, String> = tags_to_create
+                .iter()
+                .map(|(_, _, _, name, ver, _, _)| (name.clone(), ver.clone()))
+                .collect();
+            let packages = crate::manifest::snapshot_with_overrides(config, root, &overrides);
+            let commit = repo
+                .head_id()
+                .ok()
+                .map(|id| id.to_string()[..7.min(id.to_string().len())].to_string())
+                .unwrap_or_default();
+            let manifest = crate::manifest::Manifest::new(
+                packages,
+                crate::manifest::now_utc_iso8601(),
+                commit,
+            );
+            let manifest_path = root.join(manifest_rel);
+            crate::manifest::write_atomic(&manifest_path, &manifest)?;
+            files_to_commit.push(manifest_rel.to_string());
+        }
+
         // Crash-resume checkpoint (#549). On dry-run we record nothing
         // — the run is read-only by design. Otherwise we either load an
         // in-progress checkpoint left behind by a previous crash, or

--- a/src/monorepo/tests.rs
+++ b/src/monorepo/tests.rs
@@ -91,6 +91,241 @@ mod cache_flow {
     }
 }
 
+mod manifest_flow {
+    use crate::config::Config;
+    use crate::manifest::{self, Manifest};
+    use crate::status::{self, OutputFormat};
+    use crate::test_utils::{commit_file, git, init_repo, with_cwd};
+    use crate::timing::Timing;
+    use std::collections::BTreeMap;
+    use std::path::Path;
+
+    fn add_bare_remote(dir: &Path) -> tempfile::TempDir {
+        let bare = tempfile::tempdir().unwrap();
+        git(dir, &["init", "--bare", &bare.path().to_string_lossy()]);
+        git(
+            dir,
+            &["remote", "add", "origin", &bare.path().to_string_lossy()],
+        );
+        bare
+    }
+
+    fn write_config(dir: &Path, manifest_mode: bool, commit_mode: &str) {
+        let manifest_line = if manifest_mode {
+            r#""manifestFile": ".ferrflow.manifest.json", "#
+        } else {
+            ""
+        };
+        std::fs::write(
+            dir.join(".ferrflow"),
+            format!(
+                r#"{{"workspace": {{{manifest_line}"releaseCommitMode": "{commit_mode}"}}, "package": [
+                    {{"name": "api", "path": "api", "versionedFiles": [{{"path": "api/version.json", "format": "json"}}], "changelog": "api/CHANGELOG.md"}},
+                    {{"name": "web", "path": "web", "versionedFiles": [{{"path": "web/version.json", "format": "json"}}], "changelog": "web/CHANGELOG.md"}}
+                ]}}"#
+            ),
+        )
+        .unwrap();
+    }
+
+    fn write_pkg(dir: &Path, pkg: &str, version: &str) {
+        std::fs::create_dir_all(dir.join(pkg)).unwrap();
+        std::fs::write(
+            dir.join(pkg).join("version.json"),
+            format!("{{\"name\": \"{pkg}\", \"version\": \"{version}\"}}"),
+        )
+        .unwrap();
+    }
+
+    fn run_release(dir: &Path) -> anyhow::Result<()> {
+        let config = dir.join(".ferrflow");
+        with_cwd(dir, || {
+            crate::monorepo::release(
+                Some(&config),
+                false,
+                false,
+                false,
+                None,
+                None,
+                false,
+                false,
+                &mut Timing::new(false),
+            )
+        })
+    }
+
+    #[test]
+    fn release_none_mode_writes_full_sorted_snapshot() {
+        let (dir, _repo) = init_repo();
+        write_pkg(dir.path(), "api", "1.0.0");
+        write_pkg(dir.path(), "web", "2.0.0");
+        write_config(dir.path(), true, "none");
+        commit_file(dir.path(), "seed.txt", "x", "chore: seed", 1_960_000_000);
+        // Only `api` has a releasable commit; `web` stays at its file version.
+        commit_file(
+            dir.path(),
+            "api/feature.txt",
+            "y",
+            "feat: api change",
+            1_960_000_001,
+        );
+        let _remote = add_bare_remote(dir.path());
+
+        run_release(dir.path()).unwrap();
+
+        let manifest_path = dir.path().join(".ferrflow.manifest.json");
+        let manifest = manifest::read(&manifest_path).unwrap();
+        assert_eq!(manifest.version, 1);
+        assert_eq!(manifest.version_of("api"), Some("1.1.0"));
+        assert_eq!(manifest.version_of("web"), Some("2.0.0"));
+
+        let raw = std::fs::read_to_string(&manifest_path).unwrap();
+        let api_at = raw.find("\"api\"").unwrap();
+        let web_at = raw.find("\"web\"").unwrap();
+        assert!(api_at < web_at, "packages must be sorted");
+        serde_json::from_str::<serde_json::Value>(&raw).expect("valid JSON");
+    }
+
+    #[test]
+    fn manifest_off_writes_no_manifest() {
+        let (dir, _repo) = init_repo();
+        write_pkg(dir.path(), "api", "1.0.0");
+        write_pkg(dir.path(), "web", "2.0.0");
+        write_config(dir.path(), false, "none");
+        commit_file(dir.path(), "seed.txt", "x", "chore: seed", 1_961_000_000);
+        commit_file(
+            dir.path(),
+            "api/feature.txt",
+            "y",
+            "feat: api change",
+            1_961_000_001,
+        );
+        let _remote = add_bare_remote(dir.path());
+
+        run_release(dir.path()).unwrap();
+
+        assert!(!dir.path().join(".ferrflow.manifest.json").exists());
+    }
+
+    #[test]
+    fn release_commit_mode_includes_manifest_in_release_commit() {
+        let (dir, _repo) = init_repo();
+        write_pkg(dir.path(), "api", "1.0.0");
+        write_pkg(dir.path(), "web", "2.0.0");
+        write_config(dir.path(), true, "commit");
+        commit_file(dir.path(), "seed.txt", "x", "chore: seed", 1_966_000_000);
+        commit_file(
+            dir.path(),
+            "api/feature.txt",
+            "y",
+            "feat: api change",
+            1_966_000_001,
+        );
+        let _remote = add_bare_remote(dir.path());
+
+        run_release(dir.path()).unwrap();
+
+        let committed = git(dir.path(), &["show", "--name-only", "--format=", "HEAD"]);
+        assert!(
+            committed.contains(".ferrflow.manifest.json"),
+            "manifest must be part of the release commit, got: {committed}"
+        );
+        let manifest = manifest::read(&dir.path().join(".ferrflow.manifest.json")).unwrap();
+        assert_eq!(manifest.version_of("api"), Some("1.1.0"));
+        assert_eq!(manifest.version_of("web"), Some("2.0.0"));
+    }
+
+    #[test]
+    fn diverged_manifest_blocks_release_start() {
+        let (dir, _repo) = init_repo();
+        write_pkg(dir.path(), "api", "1.1.0");
+        write_pkg(dir.path(), "web", "2.0.0");
+        write_config(dir.path(), true, "commit");
+        commit_file(dir.path(), "seed.txt", "x", "chore: seed", 1_962_000_000);
+        commit_file(
+            dir.path(),
+            "api/feature.txt",
+            "y",
+            "feat: api change",
+            1_962_000_001,
+        );
+
+        let mut packages = BTreeMap::new();
+        packages.insert("api".to_string(), "1.0.0".to_string());
+        packages.insert("web".to_string(), "2.0.0".to_string());
+        manifest::write_atomic(
+            &dir.path().join(".ferrflow.manifest.json"),
+            &Manifest::new(packages, "t".into(), "sha".into()),
+        )
+        .unwrap();
+
+        let err = run_release(dir.path()).unwrap_err();
+        assert!(format!("{err:?}").contains("sync-manifest"));
+        // The blocked release must not have mutated the package file.
+        let api = std::fs::read_to_string(dir.path().join("api/version.json")).unwrap();
+        assert!(api.contains("1.1.0"));
+    }
+
+    #[test]
+    fn sync_manifest_regenerates_from_files() {
+        let (dir, _repo) = init_repo();
+        write_pkg(dir.path(), "api", "3.4.5");
+        write_pkg(dir.path(), "web", "6.7.8");
+        write_config(dir.path(), true, "none");
+        commit_file(dir.path(), "seed.txt", "x", "chore: seed", 1_963_000_000);
+        let config = dir.path().join(".ferrflow");
+
+        with_cwd(dir.path(), || manifest::sync_cwd(Some(&config))).unwrap();
+
+        let manifest = manifest::read(&dir.path().join(".ferrflow.manifest.json")).unwrap();
+        assert_eq!(manifest.version_of("api"), Some("3.4.5"));
+        assert_eq!(manifest.version_of("web"), Some("6.7.8"));
+    }
+
+    #[test]
+    fn sync_manifest_errors_when_disabled() {
+        let (dir, _repo) = init_repo();
+        write_pkg(dir.path(), "api", "1.0.0");
+        write_pkg(dir.path(), "web", "2.0.0");
+        write_config(dir.path(), false, "none");
+        commit_file(dir.path(), "seed.txt", "x", "chore: seed", 1_964_000_000);
+        let config = dir.path().join(".ferrflow");
+
+        let err = with_cwd(dir.path(), || manifest::sync_cwd(Some(&config))).unwrap_err();
+        assert!(format!("{err:?}").contains("manifest_file"));
+    }
+
+    #[test]
+    fn status_reads_from_manifest_when_present() {
+        let (dir, _repo) = init_repo();
+        // File says 1.0.0 but manifest says 1.1.0 — status must trust the manifest.
+        write_pkg(dir.path(), "api", "1.0.0");
+        write_pkg(dir.path(), "web", "2.0.0");
+        write_config(dir.path(), true, "none");
+        commit_file(dir.path(), "seed.txt", "x", "chore: seed", 1_965_000_000);
+
+        let mut packages = BTreeMap::new();
+        packages.insert("api".to_string(), "1.1.0".to_string());
+        packages.insert("web".to_string(), "2.0.0".to_string());
+        manifest::write_atomic(
+            &dir.path().join(".ferrflow.manifest.json"),
+            &Manifest::new(packages, "t".into(), "sha".into()),
+        )
+        .unwrap();
+
+        let config = dir.path().join(".ferrflow");
+        let loaded = Config::load(dir.path(), Some(&config)).unwrap();
+        let manifest = manifest::read(&dir.path().join(".ferrflow.manifest.json")).unwrap();
+        let api = loaded.packages.iter().find(|p| p.name == "api").unwrap();
+        assert_eq!(manifest.version_of(&api.name), Some("1.1.0"));
+
+        with_cwd(dir.path(), || {
+            status::run(Some(&config), &OutputFormat::Json, &mut Timing::new(false))
+        })
+        .unwrap();
+    }
+}
+
 #[test]
 fn pick_higher_semver_prefers_tag_when_tag_is_higher() {
     assert_eq!(pick_higher_semver("2.0.0", "3.0.0"), "3.0.0");

--- a/src/query.rs
+++ b/src/query.rs
@@ -25,6 +25,24 @@ fn version_from_tags(
         .map(|(_, version)| version)
 }
 
+fn resolve_version(
+    repo: &Repository,
+    pkg: &crate::config::PackageConfig,
+    config: &Config,
+    root: &std::path::Path,
+    manifest: Option<&crate::manifest::Manifest>,
+) -> Option<String> {
+    manifest
+        .and_then(|m| m.version_of(&pkg.name))
+        .map(str::to_string)
+        .or_else(|| {
+            pkg.versioned_files
+                .first()
+                .and_then(|vf| read_version(vf, root).ok())
+        })
+        .or_else(|| version_from_tags(repo, pkg, &config.workspace, config.is_monorepo()))
+}
+
 #[derive(Serialize)]
 struct VersionEntry {
     name: String,
@@ -53,6 +71,9 @@ pub fn version(
         .error_code(error_code::QUERY_NO_PACKAGES)?;
     }
 
+    let manifest = crate::manifest::manifest_path(&config, &root)
+        .and_then(|path| crate::manifest::read_if_present(&path).ok().flatten());
+
     if let Some(name) = package {
         let pkg = config
             .packages
@@ -61,12 +82,7 @@ pub fn version(
             .ok_or_else(|| anyhow::anyhow!("package '{}' not found", name))
             .error_code(error_code::QUERY_PACKAGE_NOT_FOUND)?;
 
-        let version = pkg
-            .versioned_files
-            .first()
-            .map(|vf| read_version(vf, &root))
-            .transpose()?
-            .or_else(|| version_from_tags(&repo, pkg, &config.workspace, config.is_monorepo()))
+        let version = resolve_version(&repo, pkg, &config, &root, manifest.as_ref())
             .unwrap_or_else(|| "unknown".to_string());
 
         if json {
@@ -85,12 +101,7 @@ pub fn version(
 
     if config.packages.len() == 1 {
         let pkg = &config.packages[0];
-        let version = pkg
-            .versioned_files
-            .first()
-            .map(|vf| read_version(vf, &root))
-            .transpose()?
-            .or_else(|| version_from_tags(&repo, pkg, &config.workspace, config.is_monorepo()))
+        let version = resolve_version(&repo, pkg, &config, &root, manifest.as_ref())
             .unwrap_or_else(|| "unknown".to_string());
 
         if json {
@@ -109,13 +120,7 @@ pub fn version(
             .packages
             .iter()
             .map(|pkg| {
-                let version = pkg
-                    .versioned_files
-                    .first()
-                    .and_then(|vf| read_version(vf, &root).ok())
-                    .or_else(|| {
-                        version_from_tags(&repo, pkg, &config.workspace, config.is_monorepo())
-                    })
+                let version = resolve_version(&repo, pkg, &config, &root, manifest.as_ref())
                     .unwrap_or_else(|| "unknown".to_string());
                 VersionEntry {
                     name: pkg.name.clone(),

--- a/src/status.rs
+++ b/src/status.rs
@@ -38,6 +38,9 @@ pub fn run(
         return Ok(());
     }
 
+    let manifest = crate::manifest::manifest_path(&config, &root)
+        .and_then(|path| crate::manifest::read_if_present(&path).ok().flatten());
+
     let mut statuses: Vec<PackageStatus> = Vec::new();
 
     let compute_start = std::time::Instant::now();
@@ -49,11 +52,16 @@ pub fn run(
             config.workspace.orphaned_tag_strategy,
         )?;
 
-        let version = if let Some(vf) = pkg.versioned_files.first() {
-            read_version(vf, &root).unwrap_or_else(|_| "unknown".to_string())
-        } else {
-            "unknown".to_string()
-        };
+        let version = manifest
+            .as_ref()
+            .and_then(|m| m.version_of(&pkg.name))
+            .map(str::to_string)
+            .or_else(|| {
+                pkg.versioned_files
+                    .first()
+                    .and_then(|vf| read_version(vf, &root).ok())
+            })
+            .unwrap_or_else(|| "unknown".to_string());
 
         let skip_markers = config.workspace.effective_commit_skip_markers();
         let commits = get_commits_since_last_tag(


### PR DESCRIPTION
Opt-in single-file source of truth for per-package versions, gated behind `workspace.manifest_file` (serde alias `manifestFile`). Default (flag unset) = no behaviour change at all.

When set (e.g. `.ferrflow.manifest.json`):
- **Write on release** — after the versioned files are written, FerrFlow atomically writes (temp + rename) a full snapshot of *every* configured package's resulting version (sorted `BTreeMap`, ISO-8601 UTC `released_at`, short release sha), and includes the manifest path in the release commit.
- **Validate at release start** — if the manifest exists, each package's manifest version is compared against its `versioned_files[0]` content via `formats::read_version`. Any divergence (mismatch, missing-from-manifest, or extra-in-manifest) is a hard error: "manifest out of sync with package files — run `ferrflow sync-manifest` to repair". Catches partial/crashed releases before mutating anything.
- **Read on `status` / `version`** — current versions come from the manifest when present, falling back to the per-file read otherwise. Values are identical to the per-file read.

New surface:
- `ferrflow sync-manifest` — regenerate the manifest from current filesystem state (errors clearly if manifest mode isn't configured).
- `ferrflow init --manifest` — scaffold the config with manifest mode enabled plus an initial manifest from current package versions.
- Schemas: `workspace.manifest_file` added to `schema/ferrflow.json`; new `schema/manifest.json` for the manifest file itself.

`check` / `tag` are intentionally untouched (next-version is computed from commits regardless). Manifest module is self-contained at `src/manifest.rs`; reuses `formats::read_version`, chrono, and the temp-file + rename atomic-write pattern. New unit + integration tests cover write/sort/validity, crash-divergence rejection, manifest-first reads, `sync-manifest`, and manifest-off no-op.

Closes #503