### PR TITLE
feat(release): add --json output and --dry-run unified file diff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "5.11.1"
+version = "5.13.0"
 dependencies = [
  "anyhow",
  "cargo-husky",

--- a/docs/api/release-output.md
+++ b/docs/api/release-output.md
@@ -1,0 +1,84 @@
+# `release --json` output
+
+`ferrflow release --json` emits a single JSON object on stdout describing
+the release. All other human-readable stdout is suppressed so the object
+is the only thing written (diagnostics and warnings still go to stderr).
+This is the machine-readable counterpart to `check --json` and is meant
+for CI steps that react to what a release just produced.
+
+Combine it with `--dry-run` to get the computed plan without mutating the
+repository.
+
+## Schema
+
+```json
+{
+  "released": [
+    {
+      "package": "api",
+      "previous_version": "1.2.3",
+      "new_version": "1.3.0",
+      "bump_type": "minor",
+      "tag": "api@v1.3.0",
+      "commit_count": 7,
+      "prerelease": false,
+      "forge_release_url": "https://github.com/owner/repo/releases/tag/api@v1.3.0",
+      "forge_release_id": 123456789
+    }
+  ],
+  "skipped": [
+    { "package": "web", "reason": "no releasable commits" }
+  ],
+  "git": {
+    "commit": "abc1234",
+    "tags_pushed": ["api@v1.3.0"],
+    "branch": "main"
+  },
+  "dry_run": false
+}
+```
+
+### Fields
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `released[]` | array | One entry per package that was (or would be) released this run, including dependency-cascade bumps. |
+| `released[].package` | string | Package name from the config. |
+| `released[].previous_version` | string | Version before the bump. |
+| `released[].new_version` | string | Version after the bump. |
+| `released[].bump_type` | string | `major`, `minor`, `patch`, `forced`, or a strategy name (`calver`, `sequential`, …). |
+| `released[].tag` | string | The tag that was (or would be) created. |
+| `released[].commit_count` | number | Number of commits considered for this package's changelog. |
+| `released[].prerelease` | boolean | Whether the new version is a pre-release. |
+| `released[].forge_release_url` | string \| null | URL of the created forge release. `null` on dry-run, when no forge is configured, or when the release was not created. |
+| `released[].forge_release_id` | number \| null | Numeric id of the created forge release (GitHub). `null` on dry-run, on GitLab, or when not created. |
+| `skipped[]` | array | Packages that were considered but not released. |
+| `skipped[].package` | string | Package name. |
+| `skipped[].reason` | string | Why it was skipped (`not touched`, `no new commits`, `no releasable commits`, `version unchanged`). |
+| `git.commit` | string | Short HEAD SHA after the run. |
+| `git.tags_pushed` | array | Tags pushed to the remote. Empty on dry-run. |
+| `git.branch` | string | Branch the release targeted. |
+| `dry_run` | boolean | `true` when `--dry-run` was passed. |
+
+## Dry-run behaviour
+
+With `--dry-run --json`:
+
+- `dry_run` is `true`.
+- `released[]` and `skipped[]` are populated from the computed plan.
+- `git.tags_pushed` is `[]` and the `forge_release_*` fields are `null`
+  (nothing is created or pushed).
+
+## Interaction with `--dry-run --verbose`
+
+`--dry-run --verbose` (without `--json`) prints a unified diff of every
+file a release would change, including the changelog. When both `--json`
+and `--dry-run --verbose` are passed, `--json` wins: only the JSON object
+is emitted and the diffs are suppressed.
+
+## Stability
+
+The field names and structure above are a stable contract. New optional
+fields may be added over time; existing fields will not be removed or
+renamed without a major version bump. Consumers should ignore unknown
+fields rather than failing on them.

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -401,6 +401,46 @@ pub fn update_changelog(
 }
 
 #[allow(clippy::too_many_arguments)]
+fn changelog_existing(changelog_path: &Path, package_name: &str) -> Result<String> {
+    if changelog_path.exists() {
+        Ok(std::fs::read_to_string(changelog_path)?)
+    } else {
+        Ok(format!(
+            "# Changelog\n\nAll notable changes to `{package_name}` will be documented here.\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/).\n"
+        ))
+    }
+}
+
+fn splice_section(existing: &str, section: &str) -> String {
+    if let Some(pos) = existing.find("\n## ") {
+        format!("{}{}{}", &existing[..pos], section, &existing[pos..])
+    } else {
+        format!("{}\n{}", existing.trim_end(), section)
+    }
+}
+
+/// Compute the `(old, new)` changelog contents a release would produce,
+/// without writing anything. Returns `None` when the bump is `None`
+/// (nothing would change). Used by `release --dry-run --verbose` to
+/// render a unified diff of the changelog alongside the versioned files.
+#[cfg(feature = "cli")]
+pub fn compute_changelog_update(
+    changelog_path: &Path,
+    package_name: &str,
+    new_version: &str,
+    commits: &[GitLog],
+    bump: BumpType,
+    render: &ChangelogRender,
+) -> Result<Option<(String, String)>> {
+    if bump == BumpType::None {
+        return Ok(None);
+    }
+    let section = build_section_with(new_version, commits, render);
+    let existing = changelog_existing(changelog_path, package_name)?;
+    let new_content = splice_section(&existing, &section);
+    Ok(Some((existing, new_content)))
+}
+
 pub fn update_changelog_with(
     changelog_path: &Path,
     package_name: &str,
@@ -425,19 +465,8 @@ pub fn update_changelog_with(
         return Ok(());
     }
 
-    let existing = if changelog_path.exists() {
-        std::fs::read_to_string(changelog_path)?
-    } else {
-        format!(
-            "# Changelog\n\nAll notable changes to `{package_name}` will be documented here.\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/).\n"
-        )
-    };
-
-    let new_content = if let Some(pos) = existing.find("\n## ") {
-        format!("{}{}{}", &existing[..pos], section, &existing[pos..])
-    } else {
-        format!("{}\n{}", existing.trim_end(), section)
-    };
+    let existing = changelog_existing(changelog_path, package_name)?;
+    let new_content = splice_section(&existing, &section);
 
     std::fs::write(changelog_path, new_content)?;
     println!("  ✓ Updated {}", changelog_path.display());

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,6 +49,9 @@ pub enum Commands {
     },
     /// Bump versions, update changelogs, create tags and push
     Release {
+        /// Output a single JSON object describing the release
+        #[arg(long)]
+        json: bool,
         /// Allow floating tags to move backward to a lower version
         #[arg(long)]
         force: bool,
@@ -190,6 +193,7 @@ impl Cli {
                 timing,
             ),
             Commands::Release {
+                json,
                 force,
                 force_version,
                 channel,
@@ -199,6 +203,7 @@ impl Cli {
                 self.config.as_deref(),
                 self.dry_run,
                 self.verbose,
+                json,
                 force,
                 force_version.as_deref(),
                 channel.as_deref(),
@@ -295,6 +300,7 @@ mod tests {
         assert!(matches!(
             cli.command,
             Commands::Release {
+                json: false,
                 force: false,
                 force_version: None,
                 channel: None,
@@ -302,6 +308,15 @@ mod tests {
                 force_unlock: false,
             }
         ));
+    }
+
+    #[test]
+    fn parse_release_json() {
+        let cli = parse(&["ferrflow", "release", "--json"]);
+        match cli.command {
+            Commands::Release { json, .. } => assert!(json),
+            _ => panic!("expected Release"),
+        }
     }
 
     #[test]

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,0 +1,206 @@
+const CONTEXT: usize = 1;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum Op {
+    Equal,
+    Delete,
+    Insert,
+}
+
+fn lcs_ops<'a>(old: &[&'a str], new: &[&'a str]) -> Vec<(Op, &'a str)> {
+    let n = old.len();
+    let m = new.len();
+    let mut table = vec![vec![0usize; m + 1]; n + 1];
+    for i in (0..n).rev() {
+        for j in (0..m).rev() {
+            table[i][j] = if old[i] == new[j] {
+                table[i + 1][j + 1] + 1
+            } else {
+                table[i + 1][j].max(table[i][j + 1])
+            };
+        }
+    }
+
+    let mut ops = Vec::with_capacity(n + m);
+    let (mut i, mut j) = (0, 0);
+    while i < n && j < m {
+        if old[i] == new[j] {
+            ops.push((Op::Equal, old[i]));
+            i += 1;
+            j += 1;
+        } else if table[i + 1][j] >= table[i][j + 1] {
+            ops.push((Op::Delete, old[i]));
+            i += 1;
+        } else {
+            ops.push((Op::Insert, new[j]));
+            j += 1;
+        }
+    }
+    while i < n {
+        ops.push((Op::Delete, old[i]));
+        i += 1;
+    }
+    while j < m {
+        ops.push((Op::Insert, new[j]));
+        j += 1;
+    }
+    ops
+}
+
+struct Hunk {
+    old_start: usize,
+    old_len: usize,
+    new_start: usize,
+    new_len: usize,
+    lines: Vec<String>,
+}
+
+fn group_hunks(ops: &[(Op, &str)]) -> Vec<Hunk> {
+    let change_idx: Vec<usize> = ops
+        .iter()
+        .enumerate()
+        .filter(|(_, (op, _))| *op != Op::Equal)
+        .map(|(i, _)| i)
+        .collect();
+    if change_idx.is_empty() {
+        return Vec::new();
+    }
+
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    for &idx in &change_idx {
+        let lo = idx.saturating_sub(CONTEXT);
+        let hi = (idx + CONTEXT).min(ops.len() - 1);
+        match ranges.last_mut() {
+            Some(last) if lo <= last.1 + 1 => last.1 = last.1.max(hi),
+            _ => ranges.push((lo, hi)),
+        }
+    }
+
+    let mut hunks = Vec::with_capacity(ranges.len());
+    for (lo, hi) in ranges {
+        let old_start = 1 + ops[..lo].iter().filter(|(op, _)| *op != Op::Insert).count();
+        let new_start = 1 + ops[..lo].iter().filter(|(op, _)| *op != Op::Delete).count();
+        let (mut old_len, mut new_len) = (0usize, 0usize);
+        let mut lines = Vec::new();
+        for (op, text) in &ops[lo..=hi] {
+            match op {
+                Op::Equal => {
+                    lines.push(format!("   {text}"));
+                    old_len += 1;
+                    new_len += 1;
+                }
+                Op::Delete => {
+                    lines.push(format!("-  {text}"));
+                    old_len += 1;
+                }
+                Op::Insert => {
+                    lines.push(format!("+  {text}"));
+                    new_len += 1;
+                }
+            }
+        }
+        hunks.push(Hunk {
+            old_start,
+            old_len,
+            new_start,
+            new_len,
+            lines,
+        });
+    }
+    hunks
+}
+
+pub fn unified_diff(old: &str, new: &str) -> String {
+    if old == new {
+        return String::new();
+    }
+    let old_lines: Vec<&str> = old.lines().collect();
+    let new_lines: Vec<&str> = new.lines().collect();
+    let ops = lcs_ops(&old_lines, &new_lines);
+    let hunks = group_hunks(&ops);
+
+    let mut out = String::new();
+    for hunk in &hunks {
+        out.push_str(&format!(
+            "@@ -{},{} +{},{} @@\n",
+            hunk.old_start, hunk.old_len, hunk.new_start, hunk.new_len
+        ));
+        for line in &hunk.lines {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_change_yields_empty() {
+        let s = "a\nb\nc\n";
+        assert_eq!(unified_diff(s, s), "");
+    }
+
+    #[test]
+    fn single_line_change_one_hunk() {
+        let old = "  \"name\": \"api\",\n  \"version\": \"1.2.3\",\n  \"private\": true\n";
+        let new = "  \"name\": \"api\",\n  \"version\": \"1.3.0\",\n  \"private\": true\n";
+        let diff = unified_diff(old, new);
+        let hunk_count = diff.matches("@@ ").count();
+        assert_eq!(hunk_count, 1, "expected exactly one hunk:\n{diff}");
+        assert!(diff.contains("-    \"version\": \"1.2.3\","));
+        assert!(diff.contains("+    \"version\": \"1.3.0\","));
+        assert!(diff.contains("     \"name\": \"api\","));
+    }
+
+    #[test]
+    fn multi_line_change() {
+        let old = "line1\nold-a\nold-b\nline4\n";
+        let new = "line1\nnew-a\nnew-b\nline4\n";
+        let diff = unified_diff(old, new);
+        assert!(diff.contains("-  old-a"));
+        assert!(diff.contains("-  old-b"));
+        assert!(diff.contains("+  new-a"));
+        assert!(diff.contains("+  new-b"));
+        assert!(diff.contains("@@ -"));
+    }
+
+    #[test]
+    fn pure_insertion() {
+        let old = "a\nb\n";
+        let new = "a\nb\nc\n";
+        let diff = unified_diff(old, new);
+        assert!(diff.contains("+  c"));
+        assert!(!diff.contains("-  "));
+    }
+
+    #[test]
+    fn pure_deletion() {
+        let old = "a\nb\nc\n";
+        let new = "a\nc\n";
+        let diff = unified_diff(old, new);
+        assert!(diff.contains("-  b"));
+    }
+
+    #[test]
+    fn separate_changes_yield_separate_hunks() {
+        let old = "a\nb\nc\nd\ne\nf\ng\nh\ni\n";
+        let new = "a\nB\nc\nd\ne\nf\ng\nH\ni\n";
+        let diff = unified_diff(old, new);
+        let hunk_count = diff.matches("@@ ").count();
+        assert_eq!(hunk_count, 2, "expected two hunks:\n{diff}");
+    }
+
+    #[test]
+    fn hunk_header_offsets_are_one_based() {
+        let old = "first\nsecond\nthird\n";
+        let new = "first\nSECOND\nthird\n";
+        let diff = unified_diff(old, new);
+        assert!(
+            diff.starts_with("@@ -1,3 +1,3 @@\n"),
+            "unexpected header in:\n{diff}"
+        );
+    }
+}

--- a/src/forge/github.rs
+++ b/src/forge/github.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 
-use super::{Forge, MergeRequestResult};
+use super::{Forge, MergeRequestResult, ReleaseResult};
 use crate::error_code::{self, ErrorCodeExt};
 
 /// Per-page size for paginated GitHub list endpoints. 100 is the API
@@ -69,7 +69,7 @@ impl Forge for GitHubForge {
         prerelease: bool,
         draft: bool,
         target_commitish: Option<&str>,
-    ) -> Result<()> {
+    ) -> Result<ReleaseResult> {
         let url = format!("{}/repos/{}/releases", self.api_base, self.slug);
 
         let mut payload = serde_json::json!({
@@ -83,7 +83,8 @@ impl Forge for GitHubForge {
             payload["target_commitish"] = serde_json::Value::String(sha.to_string());
         }
 
-        self.agent
+        let response: serde_json::Value = self
+            .agent
             .post(&url)
             .header("Authorization", &format!("Bearer {}", self.token))
             .header("Accept", "application/vnd.github+json")
@@ -91,9 +92,15 @@ impl Forge for GitHubForge {
             .header("User-Agent", "ferrflow")
             .send_json(payload)
             .with_context(|| format!("Failed to create GitHub release for {tag}"))
-            .error_code(error_code::GITHUB_CREATE_RELEASE)?;
+            .error_code(error_code::GITHUB_CREATE_RELEASE)?
+            .body_mut()
+            .read_json()
+            .unwrap_or(serde_json::Value::Null);
 
-        Ok(())
+        Ok(ReleaseResult {
+            id: response["id"].as_u64(),
+            url: response["html_url"].as_str().map(str::to_string),
+        })
     }
 
     fn find_draft_release(&self, tag: &str) -> Result<Option<u64>> {

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use colored::Colorize;
 
-use super::{Forge, MergeRequestResult};
+use super::{Forge, MergeRequestResult, ReleaseResult};
 use crate::error_code::{self, ErrorCodeExt};
 
 /// See `github::PER_PAGE` — same justification, same number.
@@ -60,7 +60,7 @@ impl Forge for GitLabForge {
         prerelease: bool,
         draft: bool,
         _target_commitish: Option<&str>,
-    ) -> Result<()> {
+    ) -> Result<ReleaseResult> {
         if draft {
             eprintln!(
                 "{}",
@@ -83,15 +83,22 @@ impl Forge for GitLabForge {
             payload["upcoming_release"] = serde_json::json!(true);
         }
 
-        self.agent
+        let response: serde_json::Value = self
+            .agent
             .post(&url)
             .header("PRIVATE-TOKEN", &self.token)
             .header("User-Agent", "ferrflow")
             .send_json(payload)
             .with_context(|| format!("Failed to create GitLab release for {tag}"))
-            .error_code(error_code::GITLAB_CREATE_RELEASE)?;
+            .error_code(error_code::GITLAB_CREATE_RELEASE)?
+            .body_mut()
+            .read_json()
+            .unwrap_or(serde_json::Value::Null);
 
-        Ok(())
+        Ok(ReleaseResult {
+            id: None,
+            url: response["_links"]["self"].as_str().map(str::to_string),
+        })
     }
 
     fn find_draft_release(&self, _tag: &str) -> Result<Option<u64>> {

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -10,6 +10,12 @@ pub struct MergeRequestResult {
     pub auto_merge_key: String,
 }
 
+#[derive(Default)]
+pub struct ReleaseResult {
+    pub id: Option<u64>,
+    pub url: Option<String>,
+}
+
 pub trait Forge {
     fn create_release(
         &self,
@@ -18,7 +24,7 @@ pub trait Forge {
         prerelease: bool,
         draft: bool,
         target_commitish: Option<&str>,
-    ) -> Result<()>;
+    ) -> Result<ReleaseResult>;
     fn find_draft_release(&self, tag: &str) -> Result<Option<u64>>;
     fn publish_release(&self, release_id: u64) -> Result<()>;
     fn create_merge_request(

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -114,6 +114,25 @@ pub fn write_version(vf: &VersionedFile, repo_root: &Path, version: &str) -> Res
     handler.write_version_with_selector(&path, version, vf.selector.as_deref())
 }
 
+#[cfg(feature = "cli")]
+pub fn render_new_version(vf: &VersionedFile, repo_root: &Path, version: &str) -> Result<String> {
+    use anyhow::Context;
+
+    let path = join_within_repo(repo_root, &vf.path)?;
+    let handler = get_handler(&vf.format);
+    let original = std::fs::read(&path)
+        .with_context(|| format!("Cannot read {} for dry-run diff", path.display()))?;
+
+    let tmp = tempfile::Builder::new()
+        .prefix(".ferrflow-diff-")
+        .tempfile_in(path.parent().unwrap_or(repo_root))?;
+    std::fs::write(tmp.path(), &original)?;
+    handler.write_version_with_selector(tmp.path(), version, vf.selector.as_deref())?;
+    let rendered = std::fs::read_to_string(tmp.path())
+        .with_context(|| format!("Cannot read rendered version for {}", path.display()))?;
+    Ok(rendered)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ pub mod versioning;
 #[cfg(feature = "cli")]
 pub mod cache;
 #[cfg(feature = "cli")]
+pub mod diff;
+#[cfg(feature = "cli")]
 pub mod forge;
 #[cfg(feature = "cli")]
 pub mod git;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod changelog;
 mod cli;
 mod config;
 mod conventional_commits;
+mod diff;
 mod error_code;
 mod forge;
 mod formats;

--- a/src/monorepo/check.rs
+++ b/src/monorepo/check.rs
@@ -51,7 +51,7 @@ pub fn check(
     }
 
     let out = run_release_logic(
-        &root, &config, true, verbose, json, false, None, channel, false, false, timing,
+        &root, &config, true, verbose, json, false, false, None, channel, false, false, timing,
     )?;
 
     if let (Some(key), Some(out)) = (&cache_key, &out) {

--- a/src/monorepo/release.rs
+++ b/src/monorepo/release.rs
@@ -15,6 +15,7 @@ pub fn release(
     config_path: Option<&Path>,
     dry_run: bool,
     verbose: bool,
+    json: bool,
     force: bool,
     force_version: Option<&str>,
     channel: Option<&str>,
@@ -32,12 +33,14 @@ pub fn release(
         crate::manifest::validate_in_sync(&config, &root)?;
     }
 
-    if dry_run {
-        println!("{}", "FerrFlow — Release (dry run)".bold().blue());
-    } else {
-        println!("{}", "FerrFlow — Release".bold().green());
+    if !json {
+        if dry_run {
+            println!("{}", "FerrFlow — Release (dry run)".bold().blue());
+        } else {
+            println!("{}", "FerrFlow — Release".bold().green());
+        }
+        println!();
     }
-    println!();
 
     let single_shot = dry_run
         || matches!(
@@ -52,6 +55,7 @@ pub fn release(
             dry_run,
             verbose,
             false,
+            json,
             force,
             force_version,
             channel,
@@ -78,6 +82,7 @@ pub fn release(
             dry_run,
             verbose,
             false,
+            json,
             force,
             force_version,
             channel,

--- a/src/monorepo/run/cascade.rs
+++ b/src/monorepo/run/cascade.rs
@@ -10,6 +10,7 @@ use crate::versioning::compute_next_version;
 
 use super::super::types::CheckPackage;
 use super::super::util::tags_for_package;
+use super::release_json::ReleasedPackage;
 use super::summary::TagToCreate;
 use crate::changelog::update_changelog;
 
@@ -19,6 +20,7 @@ use crate::changelog::update_changelog;
 pub(super) struct CascadeSink<'a> {
     pub any_bumped: &'a mut bool,
     pub json_packages: &'a mut Vec<CheckPackage>,
+    pub released: &'a mut Vec<ReleasedPackage>,
     pub files_to_commit: &'a mut Vec<String>,
     pub files_per_package: &'a mut HashMap<String, Vec<String>>,
     pub tags_to_create: &'a mut Vec<TagToCreate>,
@@ -29,12 +31,14 @@ pub(super) struct CascadeSink<'a> {
 /// Patch-bump every package that depends (transitively) on a package
 /// already bumped this run. Iterates to a fixed point, capped at
 /// `packages.len()` rounds to break circular dependencies.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn run_dependency_cascade(
     config: &Config,
     root: &Path,
     all_tags: &[String],
     channel: Option<&str>,
     json: bool,
+    release_json: bool,
     dry_run: bool,
     sink: &mut CascadeSink<'_>,
 ) -> anyhow::Result<()> {
@@ -87,6 +91,20 @@ pub(super) fn run_dependency_cascade(
                 .filter(|d| sink.bumped_names.contains(*d))
                 .map(|s| s.as_str())
                 .collect();
+
+            if release_json {
+                sink.released.push(ReleasedPackage {
+                    package: pkg.name.clone(),
+                    previous_version: current_version.clone(),
+                    new_version: new_version.clone(),
+                    bump_type: "patch".to_string(),
+                    tag: tag.clone(),
+                    commit_count: 0,
+                    prerelease: false,
+                    forge_release_url: None,
+                    forge_release_id: None,
+                });
+            }
 
             if json {
                 sink.json_packages.push(CheckPackage {

--- a/src/monorepo/run/execute.rs
+++ b/src/monorepo/run/execute.rs
@@ -16,6 +16,7 @@ use crate::versioning::truncate_version;
 
 use super::checkpoint::{Checkpoint, Phase};
 use super::summary::{TagToCreate, write_github_step_summary};
+use crate::forge::ReleaseResult;
 use crate::monorepo::preview::build_forge_instance;
 use crate::monorepo::util::{auto_stage_new_files, collect_dirty_files};
 
@@ -41,6 +42,9 @@ pub(super) struct ReleasePlan<'a> {
     pub files_per_package: &'a mut HashMap<String, Vec<String>>,
     pub pkg_outputs: &'a mut Vec<(String, Vec<String>)>,
     pub shared_outputs: &'a mut Vec<String>,
+    /// Per-tag forge release metadata captured from `create_release`,
+    /// surfaced in `release --json`. Empty on dry-run.
+    pub forge_results: &'a mut Vec<(String, ReleaseResult)>,
     /// Crash-resume marker, persisted at `.git/ferrflow.checkpoint.json`
     /// as each phase succeeds. `None` on dry-run (we never write
     /// anything in that mode) and on resumed runs that already finished
@@ -461,7 +465,8 @@ fn push_and_publish(
                 plan.draft,
                 target_sha.as_deref(),
             ) {
-                Ok(()) => {
+                Ok(result) => {
+                    plan.forge_results.push((tag_name.clone(), result));
                     if let Some((_, lines)) = plan
                         .pkg_outputs
                         .iter_mut()

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -3,10 +3,13 @@ use colored::Colorize;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
-use crate::changelog::{ChangelogRender, build_section_with, update_changelog_with};
-use crate::config::{Config, OrphanedTagStrategy, VersioningStrategy};
+use crate::changelog::{
+    ChangelogRender, GitLog, build_section_with, compute_changelog_update, update_changelog_with,
+};
+use crate::config::{Config, OrphanedTagStrategy, PackageConfig, VersioningStrategy};
 use crate::conventional_commits::{BumpType, determine_bump};
-use crate::formats::{get_handler, read_version, write_version};
+use crate::diff::unified_diff;
+use crate::formats::{get_handler, read_version, render_new_version, write_version};
 use crate::git::{
     collect_all_tags, fetch_tags, get_changed_files, get_changed_files_since_oid,
     get_changed_files_since_tag, get_commits_since_last_stable_tag, get_commits_since_last_tag,
@@ -30,11 +33,13 @@ mod drafts;
 mod execute;
 mod forced;
 mod lock;
+mod release_json;
 mod summary;
 use checkpoint::Checkpoint;
 use drafts::publish_pending_drafts;
 use execute::{ReleasePlan, execute_release, print_dry_run_hooks};
 use forced::{Forced, forced_version_for, parse_forced_version};
+use release_json::{GitInfo, ReleaseJson, ReleasedPackage, SkippedPackage};
 use summary::{TagToCreate, collect_outputs};
 
 #[allow(clippy::too_many_arguments)]
@@ -44,6 +49,7 @@ pub(super) fn run_release_logic(
     dry_run: bool,
     verbose: bool,
     json: bool,
+    release_json: bool,
     force: bool,
     force_version: Option<&str>,
     channel: Option<&str>,
@@ -52,6 +58,19 @@ pub(super) fn run_release_logic(
     timing: &mut Timing,
 ) -> Result<Option<RunOutput>> {
     if config.packages.is_empty() {
+        if release_json {
+            let out = RunOutput {
+                json: Some(
+                    ReleaseJson {
+                        dry_run,
+                        ..Default::default()
+                    }
+                    .to_json()?,
+                ),
+                text_lines: Vec::new(),
+            };
+            return finish(dry_run, out);
+        }
         if json {
             let out = RunOutput {
                 json: Some(serde_json::to_string(&CheckResult { packages: vec![] })?),
@@ -145,7 +164,9 @@ pub(super) fn run_release_logic(
 
     let changed_files = get_changed_files(&repo)?;
 
-    if verbose && !json && !changed_files.is_empty() {
+    let quiet = json || release_json;
+
+    if verbose && !quiet && !changed_files.is_empty() {
         println!("Changed files in last commit:");
         for f in &changed_files {
             println!("  {}", f.dimmed());
@@ -155,6 +176,8 @@ pub(super) fn run_release_logic(
 
     let mut any_bumped = false;
     let mut json_packages: Vec<CheckPackage> = Vec::new();
+    let mut released: Vec<ReleasedPackage> = Vec::new();
+    let mut skipped: Vec<SkippedPackage> = Vec::new();
     let mut files_to_commit: Vec<String> = Vec::new();
     let mut files_per_package: HashMap<String, Vec<String>> = HashMap::new();
     let mut tags_to_create: Vec<TagToCreate> = Vec::new();
@@ -185,7 +208,7 @@ pub(super) fn run_release_logic(
                 };
             if is_package_touched(pkg, &files_since_tag, true) {
                 touched = true;
-                if verbose && !json {
+                if verbose && !quiet {
                     println!(
                         "{} {} — recovering missed release",
                         "↻".cyan(),
@@ -196,12 +219,18 @@ pub(super) fn run_release_logic(
         }
 
         if !touched && forced_ver_for_pkg.is_none() {
-            if verbose && !json {
+            if verbose && !quiet {
                 println!(
                     "{} {} — not touched, skipping",
                     "○".dimmed(),
                     pkg.name.dimmed()
                 );
+            }
+            if release_json {
+                skipped.push(SkippedPackage {
+                    package: pkg.name.clone(),
+                    reason: "not touched".to_string(),
+                });
             }
             continue;
         }
@@ -287,8 +316,14 @@ pub(super) fn run_release_logic(
             };
 
             if commits.is_empty() {
-                if verbose && !json {
+                if verbose && !quiet {
                     println!("{} {} — no new commits", "○".dimmed(), pkg.name.dimmed());
+                }
+                if release_json {
+                    skipped.push(SkippedPackage {
+                        package: pkg.name.clone(),
+                        reason: "no new commits".to_string(),
+                    });
                 }
                 continue;
             }
@@ -313,12 +348,18 @@ pub(super) fn run_release_logic(
             );
 
             if bump == BumpType::None && !is_date_or_seq {
-                if !json {
+                if !quiet {
                     shared_outputs.push(format!(
                         "{} {} — no releasable commits",
                         "○".dimmed(),
                         pkg.name.dimmed()
                     ));
+                }
+                if release_json {
+                    skipped.push(SkippedPackage {
+                        package: pkg.name.clone(),
+                        reason: "no releasable commits".to_string(),
+                    });
                 }
                 continue;
             }
@@ -345,8 +386,14 @@ pub(super) fn run_release_logic(
         };
 
         if current_version == new_version {
-            if verbose && !json {
+            if verbose && !quiet {
                 println!("{} {} — version unchanged", "○".dimmed(), pkg.name.dimmed());
+            }
+            if release_json {
+                skipped.push(SkippedPackage {
+                    package: pkg.name.clone(),
+                    reason: "version unchanged".to_string(),
+                });
             }
             continue;
         }
@@ -373,6 +420,30 @@ pub(super) fn run_release_logic(
         };
 
         let tag = pkg.tag_for_version(&config.workspace, config.is_monorepo(), &new_version);
+
+        if release_json {
+            released.push(ReleasedPackage {
+                package: pkg.name.clone(),
+                previous_version: current_version.clone(),
+                new_version: new_version.clone(),
+                bump_type: strategy_label.clone(),
+                tag: tag.clone(),
+                commit_count: commits.len(),
+                prerelease: is_prerelease,
+                forge_release_url: None,
+                forge_release_id: None,
+            });
+        }
+
+        if dry_run && verbose && !quiet {
+            let changelog_render = ChangelogRender {
+                config: config.workspace.changelog.as_ref(),
+                forge_base: forge_base.clone(),
+                last_tag: last_tag.clone(),
+                new_tag: Some(tag.clone()),
+            };
+            emit_dry_run_diffs(pkg, root, &new_version, &commits, bump, &changelog_render);
+        }
 
         if json {
             let check_commits: Vec<CheckCommit> = commits
@@ -587,6 +658,7 @@ pub(super) fn run_release_logic(
         let mut sink = cascade::CascadeSink {
             any_bumped: &mut any_bumped,
             json_packages: &mut json_packages,
+            released: &mut released,
             files_to_commit: &mut files_to_commit,
             files_per_package: &mut files_per_package,
             tags_to_create: &mut tags_to_create,
@@ -599,6 +671,7 @@ pub(super) fn run_release_logic(
             &all_tags,
             prerelease_ctx.channel.as_deref(),
             json,
+            release_json,
             dry_run,
             &mut sink,
         )?;
@@ -615,6 +688,8 @@ pub(super) fn run_release_logic(
         };
         return finish(dry_run, out);
     }
+
+    let mut forge_results: Vec<(String, crate::forge::ReleaseResult)> = Vec::new();
 
     if any_bumped && !tags_to_create.is_empty() {
         if !dry_run && let Some(manifest_rel) = config.workspace.manifest_file.as_deref() {
@@ -697,6 +772,7 @@ pub(super) fn run_release_logic(
             files_per_package: &mut files_per_package,
             pkg_outputs: &mut pkg_outputs,
             shared_outputs: &mut shared_outputs,
+            forge_results: &mut forge_results,
             checkpoint: checkpoint.as_mut(),
         };
         let release_start = std::time::Instant::now();
@@ -725,6 +801,7 @@ pub(super) fn run_release_logic(
             files_per_package: &mut files_per_package,
             pkg_outputs: &mut pkg_outputs,
             shared_outputs: &mut shared_outputs,
+            forge_results: &mut forge_results,
             checkpoint: None,
         };
         print_dry_run_hooks(&plan)?;
@@ -733,6 +810,45 @@ pub(super) fn run_release_logic(
 
     if !any_bumped && !draft && !dry_run {
         publish_pending_drafts(&repo, config, root, verbose, &mut shared_outputs)?;
+    }
+
+    if release_json {
+        for (tag, result) in &forge_results {
+            if let Some(rp) = released.iter_mut().find(|rp| &rp.tag == tag) {
+                rp.forge_release_url = result.url.clone();
+                rp.forge_release_id = result.id;
+            }
+        }
+        let commit = repo
+            .head_id()
+            .ok()
+            .map(|id| id.to_string()[..7.min(id.to_string().len())].to_string())
+            .unwrap_or_default();
+        let tags_pushed = if dry_run {
+            Vec::new()
+        } else {
+            tags_to_create
+                .iter()
+                .map(|(t, _, _, _, _, _, _)| t.clone())
+                .collect()
+        };
+        let payload = ReleaseJson {
+            released,
+            skipped,
+            git: GitInfo {
+                commit,
+                tags_pushed,
+                branch: target_branch.clone(),
+            },
+            dry_run,
+        };
+        return finish(
+            dry_run,
+            RunOutput {
+                json: Some(payload.to_json()?),
+                text_lines: Vec::new(),
+            },
+        );
     }
 
     let mut text_lines = collect_outputs(&pkg_outputs, &shared_outputs);
@@ -747,6 +863,67 @@ pub(super) fn run_release_logic(
             text_lines,
         },
     )
+}
+
+fn emit_dry_run_diffs(
+    pkg: &PackageConfig,
+    root: &Path,
+    new_version: &str,
+    commits: &[GitLog],
+    bump: BumpType,
+    changelog_render: &ChangelogRender,
+) {
+    for (path, diff) in
+        collect_dry_run_diffs(pkg, root, new_version, commits, bump, changelog_render)
+    {
+        println!("{}", path.bold());
+        print!("{diff}");
+        println!();
+    }
+}
+
+pub(super) fn collect_dry_run_diffs(
+    pkg: &PackageConfig,
+    root: &Path,
+    new_version: &str,
+    commits: &[GitLog],
+    bump: BumpType,
+    changelog_render: &ChangelogRender,
+) -> Vec<(String, String)> {
+    let mut diffs = Vec::new();
+    for vf in &pkg.versioned_files {
+        if !get_handler(&vf.format).modifies_file() {
+            continue;
+        }
+        let (Ok(old), Ok(new)) = (
+            std::fs::read_to_string(root.join(&vf.path)),
+            render_new_version(vf, root, new_version),
+        ) else {
+            continue;
+        };
+        let diff = unified_diff(&old, &new);
+        if !diff.is_empty() {
+            diffs.push((vf.path.clone(), diff));
+        }
+    }
+
+    if let Some(changelog_rel) = &pkg.changelog {
+        let changelog_path = root.join(changelog_rel);
+        if let Ok(Some((old, new))) = compute_changelog_update(
+            &changelog_path,
+            &pkg.name,
+            new_version,
+            commits,
+            bump,
+            changelog_render,
+        ) {
+            let diff = unified_diff(&old, &new);
+            if !diff.is_empty() {
+                diffs.push((changelog_rel.clone(), diff));
+            }
+        }
+    }
+    diffs
 }
 
 fn finish(dry_run: bool, out: RunOutput) -> Result<Option<RunOutput>> {

--- a/src/monorepo/run/release_json.rs
+++ b/src/monorepo/run/release_json.rs
@@ -1,0 +1,41 @@
+use serde::Serialize;
+
+#[derive(Serialize, Default)]
+pub(super) struct ReleaseJson {
+    pub released: Vec<ReleasedPackage>,
+    pub skipped: Vec<SkippedPackage>,
+    pub git: GitInfo,
+    pub dry_run: bool,
+}
+
+#[derive(Serialize)]
+pub(super) struct ReleasedPackage {
+    pub package: String,
+    pub previous_version: String,
+    pub new_version: String,
+    pub bump_type: String,
+    pub tag: String,
+    pub commit_count: usize,
+    pub prerelease: bool,
+    pub forge_release_url: Option<String>,
+    pub forge_release_id: Option<u64>,
+}
+
+#[derive(Serialize)]
+pub(super) struct SkippedPackage {
+    pub package: String,
+    pub reason: String,
+}
+
+#[derive(Serialize, Default)]
+pub(super) struct GitInfo {
+    pub commit: String,
+    pub tags_pushed: Vec<String>,
+    pub branch: String,
+}
+
+impl ReleaseJson {
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+}

--- a/src/monorepo/tests.rs
+++ b/src/monorepo/tests.rs
@@ -145,6 +145,7 @@ mod manifest_flow {
                 false,
                 false,
                 false,
+                false,
                 None,
                 None,
                 false,
@@ -323,6 +324,166 @@ mod manifest_flow {
             status::run(Some(&config), &OutputFormat::Json, &mut Timing::new(false))
         })
         .unwrap();
+    }
+}
+
+mod release_json_diff {
+    use crate::changelog::{ChangelogRender, GitLog};
+    use crate::config::Config;
+    use crate::conventional_commits::BumpType;
+    use crate::monorepo::run::{collect_dry_run_diffs, run_release_logic};
+    use crate::test_utils::{commit_file, init_repo, with_cwd};
+    use crate::timing::Timing;
+    use std::path::Path;
+
+    fn write_config(dir: &Path) {
+        std::fs::write(
+            dir.join(".ferrflow"),
+            r#"{"workspace": {"releaseCommitMode": "none"}, "package": [
+                {"name": "api", "path": "api", "versionedFiles": [{"path": "api/package.json", "format": "json"}], "changelog": "api/CHANGELOG.md"},
+                {"name": "web", "path": "web", "versionedFiles": [{"path": "web/package.json", "format": "json"}], "changelog": "web/CHANGELOG.md"}
+            ]}"#,
+        )
+        .unwrap();
+    }
+
+    fn write_pkg(dir: &Path, pkg: &str, version: &str) {
+        std::fs::create_dir_all(dir.join(pkg)).unwrap();
+        std::fs::write(
+            dir.join(pkg).join("package.json"),
+            format!("{{\n  \"name\": \"{pkg}\",\n  \"version\": \"{version}\",\n  \"private\": true\n}}\n"),
+        )
+        .unwrap();
+    }
+
+    fn dry_run_json(dir: &Path) -> serde_json::Value {
+        let config_path = dir.join(".ferrflow");
+        let config = Config::load(dir, Some(&config_path)).unwrap();
+        let mut captured: Option<String> = None;
+        with_cwd(dir, || {
+            let out = run_release_logic(
+                dir,
+                &config,
+                true,
+                false,
+                false,
+                true,
+                false,
+                None,
+                None,
+                false,
+                false,
+                &mut Timing::new(false),
+            )?;
+            captured = out.expect("dry-run returns output").json;
+            Ok(())
+        })
+        .unwrap();
+        let raw = captured.expect("json set");
+        serde_json::from_str(&raw).expect("valid JSON")
+    }
+
+    #[test]
+    fn dry_run_json_has_expected_shape() {
+        let (dir, _repo) = init_repo();
+        write_pkg(dir.path(), "api", "1.2.3");
+        write_pkg(dir.path(), "web", "2.0.0");
+        write_config(dir.path());
+        commit_file(dir.path(), "seed.txt", "x", "chore: seed", 1_970_000_000);
+        commit_file(
+            dir.path(),
+            "api/feature.txt",
+            "y",
+            "feat: api change",
+            1_970_000_001,
+        );
+
+        let v = dry_run_json(dir.path());
+
+        assert_eq!(v["dry_run"], true);
+        assert_eq!(v["git"]["branch"], "main");
+        assert_eq!(
+            v["git"]["tags_pushed"].as_array().unwrap().len(),
+            0,
+            "dry-run pushes nothing"
+        );
+
+        let released = v["released"].as_array().unwrap();
+        assert_eq!(released.len(), 1);
+        let api = &released[0];
+        assert_eq!(api["package"], "api");
+        assert_eq!(api["previous_version"], "1.2.3");
+        assert_eq!(api["new_version"], "1.3.0");
+        assert_eq!(api["bump_type"], "minor");
+        assert_eq!(api["tag"], "api@v1.3.0");
+        assert_eq!(api["commit_count"], 2);
+        assert_eq!(api["prerelease"], false);
+        assert!(api["forge_release_url"].is_null());
+        assert!(api["forge_release_id"].is_null());
+
+        let skipped = v["skipped"].as_array().unwrap();
+        assert_eq!(skipped.len(), 1);
+        assert_eq!(skipped[0]["package"], "web");
+        assert!(skipped[0]["reason"].is_string());
+    }
+
+    #[test]
+    fn empty_release_yields_empty_released() {
+        let (dir, _repo) = init_repo();
+        write_pkg(dir.path(), "api", "1.2.3");
+        write_pkg(dir.path(), "web", "2.0.0");
+        write_config(dir.path());
+        commit_file(dir.path(), "seed.txt", "x", "chore: seed", 1_971_000_000);
+
+        let v = dry_run_json(dir.path());
+
+        assert_eq!(v["released"].as_array().unwrap().len(), 0);
+        let skipped = v["skipped"].as_array().unwrap();
+        assert_eq!(skipped.len(), 2);
+        assert_eq!(v["dry_run"], true);
+    }
+
+    #[test]
+    fn dry_run_diff_covers_versioned_file_and_changelog() {
+        let (dir, _repo) = init_repo();
+        write_pkg(dir.path(), "api", "1.2.3");
+        std::fs::write(
+            dir.path().join("api/CHANGELOG.md"),
+            "# Changelog\n\n## [1.2.3]\n\n- old\n",
+        )
+        .unwrap();
+        write_config(dir.path());
+
+        let config_path = dir.path().join(".ferrflow");
+        let config = Config::load(dir.path(), Some(&config_path)).unwrap();
+        let pkg = config.packages.iter().find(|p| p.name == "api").unwrap();
+        let commits = vec![GitLog {
+            hash: "abc1234".to_string(),
+            message: "feat: api change".to_string(),
+        }];
+        let render = ChangelogRender::default();
+
+        let diffs =
+            collect_dry_run_diffs(pkg, dir.path(), "1.3.0", &commits, BumpType::Minor, &render);
+
+        let paths: Vec<&str> = diffs.iter().map(|(p, _)| p.as_str()).collect();
+        assert!(
+            paths.contains(&"api/package.json"),
+            "versioned file diff missing: {paths:?}"
+        );
+        assert!(
+            paths.contains(&"api/CHANGELOG.md"),
+            "changelog diff missing: {paths:?}"
+        );
+
+        let pkg_diff = &diffs
+            .iter()
+            .find(|(p, _)| p == "api/package.json")
+            .unwrap()
+            .1;
+        assert!(pkg_diff.contains("@@ -"));
+        assert!(pkg_diff.contains("-    \"version\": \"1.2.3\","));
+        assert!(pkg_diff.contains("+    \"version\": \"1.3.0\","));
     }
 }
 


### PR DESCRIPTION
Closes #502.

Adds two separable, opt-in features to `ferrflow release`.

## Part 1 — `release --json`
New `--json` flag on the `Release` subcommand (mirrors `check`/`status`/`version`/`tag`). Emits a single JSON object on stdout and suppresses human-readable output. Built from the same per-package data the human summary uses, so the two never drift.

```json
{
  "released": [
    { "package": "api", "previous_version": "1.2.3", "new_version": "1.3.0",
      "bump_type": "minor", "tag": "api@v1.3.0", "commit_count": 7,
      "prerelease": false, "forge_release_url": "https://…", "forge_release_id": 123456789 }
  ],
  "skipped": [ { "package": "web", "reason": "no relevant commits" } ],
  "git": { "commit": "abc1234", "tags_pushed": ["api@v1.3.0"], "branch": "main" },
  "dry_run": false
}
```

`forge_release_url`/`forge_release_id` are populated from the forge `create_release` response (now returns a `ReleaseResult`); `null` on dry-run, non-GitHub, or when not created. On `--dry-run --json`: `dry_run: true`, `tags_pushed: []`, forge fields null, with `released[]`/`skipped[]` from the computed plan. Empty release → `released: []`, `skipped` populated.

## Part 2 — `--dry-run` unified file diff
When `dry_run && verbose`, emits a unified diff for every `versioned_files` entry that would change plus the changelog file. The new content is produced through the existing format handlers (via a small `render_new_version` seam) and the changelog `compute_changelog_update` seam, so dry-run renders exactly what a real run would write — without writing.

Diff is an in-tree line-based unified-diff (`src/diff.rs`, LCS + hunk grouping with context) rather than adding the `similar` crate — FerrFlow is dependency-conscious and the in-tree version is ~140 lines with its own unit tests.

When both `--json` and `--dry-run --verbose` are set, `--json` wins (JSON only, no diffs).

## Docs
`docs/api/release-output.md` documents the schema, dry-run behaviour, the `--json`/diff interaction, and a stability note.

## Tests
- `release --dry-run --json` shape (released/skipped/git/dry_run)
- empty release → `released: []`
- dry-run diff covers each versioned file + changelog
- in-tree diff fn unit tests (single-line, multi-line, no-change, insert/delete, multi-hunk, header offsets)

`cargo fmt` clean, `cargo build --features cli` exit 0, `cargo test --features cli` 815 pass, `cargo clippy --features cli --all-targets -- -D warnings` clean.