### PR TITLE
fix(forge): validate derived API host and document GitLab draft no-op

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,6 +64,8 @@ pub enum Commands {
         channel: Option<String>,
         /// Create releases as drafts (GitHub only). A subsequent `ferrflow release`
         /// without --draft will detect and publish existing drafts automatically.
+        /// On GitLab this is a no-op — the release is published immediately
+        /// (the GitLab releases API has no draft state); a warning is printed.
         #[arg(long)]
         draft: bool,
         /// Break an existing `.git/ferrflow.lock` before acquiring it.

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -86,22 +86,25 @@ pub fn extract_host(url: &str) -> Option<String> {
         let host_port = authority.rsplit('@').next()?;
         // Drop the optional `:port` suffix.
         let host = host_port.split(':').next()?;
-        if host.is_empty() {
-            return None;
-        }
-        Some(host.to_string())
+        valid_host(host)
     } else if url.contains('@') && url.contains(':') {
         // SSH form: `user@host:owner/repo`. Take what's after the LAST '@'
         // and before the first ':'.
         let after_at = url.rsplit('@').next()?;
         let host = after_at.split(':').next()?;
-        if host.is_empty() {
-            return None;
-        }
-        Some(host.to_string())
+        valid_host(host)
     } else {
         None
     }
+}
+
+fn valid_host(host: &str) -> Option<String> {
+    let ok = !host.is_empty()
+        && host.len() <= 253
+        && host
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'.' || b == b'-');
+    ok.then(|| host.to_string())
 }
 
 pub fn extract_repo_slug(url: &str) -> Option<String> {
@@ -471,6 +474,21 @@ mod tests {
     #[test]
     fn extract_host_empty() {
         assert_eq!(extract_host(""), None);
+    }
+
+    #[test]
+    fn extract_host_rejects_non_hostname_chars() {
+        // Defense in depth: a derived "host" that isn't a syntactically
+        // valid hostname must not be used to build the API base and
+        // receive the bearer token.
+        assert_eq!(extract_host("https://ho st/owner/repo"), None);
+        assert_eq!(extract_host("https://host_underscore/o/r"), None);
+        assert_eq!(extract_host("https://h%40ck/o/r"), None);
+        // Legit self-hosted hostnames still pass.
+        assert_eq!(
+            extract_host("https://git.corp.example.com/o/r").as_deref(),
+            Some("git.corp.example.com")
+        );
     }
 
     #[test]


### PR DESCRIPTION
@
Addresses the two remaining forge findings from #553 (the URL-encoding one was already fixed in an earlier PR):

- **Host validation** (`forge/mod.rs`): `extract_host` now rejects any derived "host" that isn't a syntactically valid hostname (embedded `@`, `/`, spaces, `%`, `_`, etc.) before it is used to build the API base and receive the bearer token. Defense-in-depth — the host already comes from the trusted local remote with userinfo stripped, so this is not a live SSRF, but it stops a malformed remote from yielding a bogus token destination. Test added.
- **GitLab draft** (`cli.rs`): the `--draft` help already said "(GitHub only)"; made the GitLab behaviour explicit — on GitLab it's a no-op (the release is published immediately; a warning is printed). Did NOT turn the warning into a hard error: that would break existing GitLab CI that passes `--draft` generically, and erroring late in the flow (after commit+tag) would strand a half-done release.

Part of #553.
@