### PR TITLE
perf(monorepo): parallelize per-package planning with rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,6 +624,7 @@ dependencies = [
  "hmac",
  "json5",
  "mimalloc",
+ "rayon",
  "regex",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ workspace = true
 
 [features]
 default = ["cli"]
-cli = ["dep:gix", "dep:gix-traverse", "dep:ureq", "dep:clap", "dep:clap_complete", "dep:colored", "dep:hmac", "dep:mimalloc"]
+cli = ["dep:gix", "dep:gix-traverse", "dep:ureq", "dep:clap", "dep:clap_complete", "dep:colored", "dep:hmac", "dep:mimalloc", "dep:rayon"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -61,6 +61,9 @@ hmac = { version = "0.13", optional = true }
 # revwalk, regex captures). Typical 5-15% wall-time win on alloc-heavy
 # workloads — see #507. CLI-only (no value for the wasm build).
 mimalloc = { version = "0.1", default-features = false, optional = true }
+# rayon: data-parallel per-package planning compute (#476). CLI-only —
+# the wasm build does no git/monorepo scanning, so it must not pull rayon.
+rayon = { version = "1", optional = true }
 # tempfile is used at runtime by the TS config loader to drop the
 # generated wrapper script in a directory we own (security: writing into
 # the user's config directory is a symlink TOCTOU). Tests also use it.

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -6,26 +6,19 @@ use std::path::Path;
 use crate::changelog::{
     ChangelogRender, GitLog, build_section_with, compute_changelog_update, update_changelog_with,
 };
-use crate::config::{Config, OrphanedTagStrategy, PackageConfig, VersioningStrategy};
-use crate::conventional_commits::{BumpType, determine_bump};
+use crate::config::{Config, PackageConfig};
+use crate::conventional_commits::BumpType;
 use crate::diff::unified_diff;
-use crate::formats::{get_handler, read_version, render_new_version, write_version};
-use crate::git::{
-    collect_all_tags, fetch_tags, get_changed_files, get_changed_files_since_oid,
-    get_changed_files_since_tag, get_commits_since_last_stable_tag, get_commits_since_last_tag,
-    get_commits_since_oid, open_repo, tag_exists,
-};
+use crate::formats::{get_handler, render_new_version, write_version};
+use crate::git::{collect_all_tags, fetch_tags, get_changed_files, open_repo, tag_exists};
 use crate::hooks::{HookContext, HookPoint, resolve_hook, resolve_on_failure, run_hook};
 use crate::prerelease::PrereleaseContext;
 use crate::telemetry;
 use crate::timing::Timing;
-use crate::versioning::{compute_next_version, truncate_version};
+use crate::versioning::truncate_version;
 
 use super::types::{CheckCommit, CheckPackage, CheckResult, RunOutput};
-use super::util::{
-    auto_stage_new_files, collect_dirty_files, is_package_touched, pick_higher_semver,
-    tags_for_package,
-};
+use super::util::{auto_stage_new_files, collect_dirty_files};
 
 mod cascade;
 mod checkpoint;
@@ -33,12 +26,15 @@ mod drafts;
 mod execute;
 mod forced;
 mod lock;
+mod plan;
 mod release_json;
 mod summary;
 use checkpoint::Checkpoint;
 use drafts::publish_pending_drafts;
 use execute::{ReleasePlan, execute_release, print_dry_run_hooks};
-use forced::{Forced, forced_version_for, parse_forced_version};
+use forced::{Forced, parse_forced_version};
+use plan::{PackagePlan, PlanInputs, SkipReason, compute_plan};
+use rayon::prelude::*;
 use release_json::{GitInfo, ReleaseJson, ReleasedPackage, SkippedPackage};
 use summary::{TagToCreate, collect_outputs};
 
@@ -190,236 +186,92 @@ pub(super) fn run_release_logic(
     let forced: Option<Forced<'_>> = parse_forced_version(force_version, config.is_monorepo())?;
 
     let compute_start = std::time::Instant::now();
-    for (pkg_idx, pkg) in config.packages.iter().enumerate() {
-        let tag_search_prefix = pkg.tag_prefix(&config.workspace, config.is_monorepo());
 
-        let forced_ver_for_pkg = forced_version_for(&forced, &pkg.name);
+    let thread_safe_repo = repo.clone().into_sync();
+    let plan_inputs = PlanInputs {
+        config,
+        root,
+        tag_index: tag_index.as_ref(),
+        head_ancestors: head_ancestors.as_ref(),
+        all_tags: &all_tags,
+        prerelease_ctx: &prerelease_ctx,
+        forced: &forced,
+        changed_files: &changed_files,
+        short_hash: &short_hash,
+    };
+    let plans: Vec<PackagePlan> = config
+        .packages
+        .par_iter()
+        .map(|pkg| {
+            let repo = thread_safe_repo.to_thread_local();
+            compute_plan(&repo, pkg, &plan_inputs)
+        })
+        .collect::<Result<Vec<_>>>()?;
 
-        let mut touched = is_package_touched(pkg, &changed_files, config.is_monorepo());
-
-        if !touched && config.workspace.recover_missed_releases && config.is_monorepo() {
-            let strategy = config.workspace.orphaned_tag_strategy;
-            let files_since_tag =
-                if let (Some(idx), OrphanedTagStrategy::Warn) = (tag_index.as_ref(), strategy) {
-                    let last_oid = idx.find_last_tag_commit(&tag_search_prefix, strategy);
-                    get_changed_files_since_oid(&repo, last_oid)?
-                } else {
-                    get_changed_files_since_tag(&repo, &tag_search_prefix, strategy)?
-                };
-            if is_package_touched(pkg, &files_since_tag, true) {
-                touched = true;
-                if verbose && !quiet {
-                    println!(
-                        "{} {} — recovering missed release",
-                        "↻".cyan(),
-                        pkg.name.cyan()
-                    );
-                }
-            }
+    for (pkg_idx, (pkg, plan)) in config.packages.iter().zip(plans).enumerate() {
+        let recovered = match &plan {
+            PackagePlan::Skipped { recovered, .. } => *recovered,
+            PackagePlan::Bump(bump_plan) => bump_plan.recovered,
+        };
+        if recovered && verbose && !quiet {
+            println!(
+                "{} {} — recovering missed release",
+                "↻".cyan(),
+                pkg.name.cyan()
+            );
         }
 
-        if !touched && forced_ver_for_pkg.is_none() {
-            if verbose && !quiet {
-                println!(
-                    "{} {} — not touched, skipping",
-                    "○".dimmed(),
-                    pkg.name.dimmed()
-                );
-            }
-            if release_json {
-                skipped.push(SkippedPackage {
-                    package: pkg.name.clone(),
-                    reason: "not touched".to_string(),
-                });
-            }
-            continue;
-        }
-
-        // `versionedFiles` is optional (schema says so, and #531
-        // requested tag-only releases for Docker-image / content repos
-        // that have no version field to bump). Resolve the file-derived
-        // version only when at least one is configured; otherwise let
-        // the tag history alone drive the version computation. The
-        // file-write loop below is already a `for vf in
-        // &pkg.versioned_files` so it naturally no-ops when empty.
-        let pkg_strategy = pkg.effective_versioning(
-            &config.workspace,
-            &tags_for_package(&all_tags, &tag_search_prefix),
-        );
-
-        let file_version = pkg
-            .versioned_files
-            .first()
-            .and_then(|vf| read_version(vf, root).ok());
-        let strategy = config.workspace.orphaned_tag_strategy;
-        // Fast path via the pre-built TagIndex for Warn (default); otherwise
-        // fall back to the per-call form that still uses the ancestor cache.
-        let highest_tag =
-            if let (Some(idx), OrphanedTagStrategy::Warn) = (tag_index.as_ref(), strategy) {
-                idx.find_highest_semver_tag(&tag_search_prefix, strategy)
-            } else {
-                crate::git::find_highest_semver_tag_with_cache(
-                    &repo,
-                    &tag_search_prefix,
-                    strategy,
-                    head_ancestors.as_ref(),
-                )?
-            };
-        let last_tag = highest_tag.as_ref().map(|(tag, _version)| tag.clone());
-        let tag_version = highest_tag.map(|(_tag, version)| version);
-        let current_version = match (tag_version, file_version) {
-            (Some(tag), Some(file)) => pick_higher_semver(&file, &tag),
-            (Some(tag), None) => tag,
-            (None, Some(file)) => file,
-            (None, None) => crate::versioning::bootstrap_version(pkg_strategy),
-        };
-
-        // Helpers that route through TagIndex when the strategy allows it,
-        // falling back to the per-call slow path. Returns commits walked
-        // back to the last (stable or any) tag for the current package.
-        let skip_markers = config.workspace.effective_commit_skip_markers();
-        let commits_since_stable = || -> Result<Vec<crate::git::GitLog>> {
-            if let (Some(idx), OrphanedTagStrategy::Warn) = (tag_index.as_ref(), strategy) {
-                let stop = idx.find_last_stable_tag_commit(&tag_search_prefix, strategy);
-                get_commits_since_oid(&repo, stop, &skip_markers)
-            } else {
-                get_commits_since_last_stable_tag(
-                    &repo,
-                    &tag_search_prefix,
-                    strategy,
-                    &skip_markers,
-                )
-            }
-        };
-        let commits_since_any = || -> Result<Vec<crate::git::GitLog>> {
-            if let (Some(idx), OrphanedTagStrategy::Warn) = (tag_index.as_ref(), strategy) {
-                let stop = idx.find_last_tag_commit(&tag_search_prefix, strategy);
-                get_commits_since_oid(&repo, stop, &skip_markers)
-            } else {
-                get_commits_since_last_tag(&repo, &tag_search_prefix, strategy, &skip_markers)
-            }
-        };
-
-        let (new_version, is_prerelease, commits, bump) = if let Some(fv) = forced_ver_for_pkg {
-            let clean = fv.strip_prefix('v').unwrap_or(fv);
-            let commits = if !prerelease_ctx.is_prerelease() {
-                commits_since_stable().unwrap_or_default()
-            } else {
-                commits_since_any().unwrap_or_default()
-            };
-            (clean.to_string(), false, commits, BumpType::None)
-        } else {
-            let commits = if !prerelease_ctx.is_prerelease() {
-                commits_since_stable()?
-            } else {
-                commits_since_any()?
-            };
-
-            if commits.is_empty() {
-                if verbose && !quiet {
-                    println!("{} {} — no new commits", "○".dimmed(), pkg.name.dimmed());
+        let bump_plan = match plan {
+            PackagePlan::Skipped { reason, .. } => {
+                match reason {
+                    SkipReason::NotTouched => {
+                        if verbose && !quiet {
+                            println!(
+                                "{} {} — not touched, skipping",
+                                "○".dimmed(),
+                                pkg.name.dimmed()
+                            );
+                        }
+                    }
+                    SkipReason::NoNewCommits => {
+                        if verbose && !quiet {
+                            println!("{} {} — no new commits", "○".dimmed(), pkg.name.dimmed());
+                        }
+                    }
+                    SkipReason::NoReleasableCommits => {
+                        if !quiet {
+                            shared_outputs.push(format!(
+                                "{} {} — no releasable commits",
+                                "○".dimmed(),
+                                pkg.name.dimmed()
+                            ));
+                        }
+                    }
+                    SkipReason::VersionUnchanged => {
+                        if verbose && !quiet {
+                            println!("{} {} — version unchanged", "○".dimmed(), pkg.name.dimmed());
+                        }
+                    }
                 }
                 if release_json {
                     skipped.push(SkippedPackage {
                         package: pkg.name.clone(),
-                        reason: "no new commits".to_string(),
+                        reason: reason.json_label().to_string(),
                     });
                 }
                 continue;
             }
-
-            let strategy = pkg.effective_versioning(
-                &config.workspace,
-                &tags_for_package(&all_tags, &tag_search_prefix),
-            );
-
-            let bump = commits
-                .iter()
-                .map(|c| determine_bump(&c.message))
-                .max()
-                .unwrap_or(BumpType::None);
-
-            let is_date_or_seq = matches!(
-                strategy,
-                VersioningStrategy::Calver
-                    | VersioningStrategy::CalverShort
-                    | VersioningStrategy::CalverSeq
-                    | VersioningStrategy::Sequential
-            );
-
-            if bump == BumpType::None && !is_date_or_seq {
-                if !quiet {
-                    shared_outputs.push(format!(
-                        "{} {} — no releasable commits",
-                        "○".dimmed(),
-                        pkg.name.dimmed()
-                    ));
-                }
-                if release_json {
-                    skipped.push(SkippedPackage {
-                        package: pkg.name.clone(),
-                        reason: "no releasable commits".to_string(),
-                    });
-                }
-                continue;
-            }
-
-            let base_version = compute_next_version(&current_version, bump, strategy)?;
-
-            let (new_version, is_prerelease) = if prerelease_ctx.is_prerelease() {
-                let tag_prefix = pkg.tag_prefix(&config.workspace, config.is_monorepo());
-                if let Some(resolved) = prerelease_ctx.compute_identifier(
-                    &base_version,
-                    &tag_prefix,
-                    &all_tags,
-                    &short_hash,
-                ) {
-                    (format!("{base_version}{}", resolved.full_suffix), true)
-                } else {
-                    (base_version, false)
-                }
-            } else {
-                (base_version, false)
-            };
-
-            (new_version, is_prerelease, commits, bump)
+            PackagePlan::Bump(bump_plan) => *bump_plan,
         };
 
-        if current_version == new_version {
-            if verbose && !quiet {
-                println!("{} {} — version unchanged", "○".dimmed(), pkg.name.dimmed());
-            }
-            if release_json {
-                skipped.push(SkippedPackage {
-                    package: pkg.name.clone(),
-                    reason: "version unchanged".to_string(),
-                });
-            }
-            continue;
-        }
-
-        let strategy_label = if forced_ver_for_pkg.is_some() {
-            "forced".to_string()
-        } else {
-            let strategy = pkg.effective_versioning(
-                &config.workspace,
-                &tags_for_package(&all_tags, &tag_search_prefix),
-            );
-            let is_date_or_seq = matches!(
-                strategy,
-                VersioningStrategy::Calver
-                    | VersioningStrategy::CalverShort
-                    | VersioningStrategy::CalverSeq
-                    | VersioningStrategy::Sequential
-            );
-            if is_date_or_seq {
-                format!("{strategy:?}").to_lowercase()
-            } else {
-                bump.to_string()
-            }
-        };
-
-        let tag = pkg.tag_for_version(&config.workspace, config.is_monorepo(), &new_version);
+        let current_version = bump_plan.current_version;
+        let new_version = bump_plan.new_version;
+        let is_prerelease = bump_plan.is_prerelease;
+        let last_tag = bump_plan.last_tag;
+        let commits = bump_plan.commits;
+        let bump = bump_plan.bump;
+        let strategy_label = bump_plan.strategy_label;
+        let tag = bump_plan.tag;
 
         if release_json {
             released.push(ReleasedPackage {

--- a/src/monorepo/run/plan.rs
+++ b/src/monorepo/run/plan.rs
@@ -1,0 +1,509 @@
+use anyhow::Result;
+
+use crate::changelog::GitLog;
+use crate::config::{Config, OrphanedTagStrategy, PackageConfig, VersioningStrategy};
+use crate::conventional_commits::{BumpType, determine_bump};
+use crate::formats::read_version;
+use crate::git::{
+    Repository, TagIndex, find_highest_semver_tag_with_cache, get_changed_files_since_oid,
+    get_changed_files_since_tag, get_commits_since_last_stable_tag, get_commits_since_last_tag,
+    get_commits_since_oid,
+};
+use crate::prerelease::PrereleaseContext;
+use crate::versioning::compute_next_version;
+use gix::ObjectId;
+use std::collections::HashSet;
+use std::path::Path;
+
+use super::super::util::{is_package_touched, pick_higher_semver, tags_for_package};
+use super::forced::{Forced, forced_version_for};
+
+pub(super) enum SkipReason {
+    NotTouched,
+    NoNewCommits,
+    NoReleasableCommits,
+    VersionUnchanged,
+}
+
+impl SkipReason {
+    pub(super) fn json_label(&self) -> &'static str {
+        match self {
+            SkipReason::NotTouched => "not touched",
+            SkipReason::NoNewCommits => "no new commits",
+            SkipReason::NoReleasableCommits => "no releasable commits",
+            SkipReason::VersionUnchanged => "version unchanged",
+        }
+    }
+}
+
+pub(super) struct PackageBump {
+    pub recovered: bool,
+    pub current_version: String,
+    pub new_version: String,
+    pub is_prerelease: bool,
+    pub last_tag: Option<String>,
+    pub commits: Vec<GitLog>,
+    pub bump: BumpType,
+    pub strategy_label: String,
+    pub tag: String,
+}
+
+pub(super) enum PackagePlan {
+    Skipped { reason: SkipReason, recovered: bool },
+    Bump(Box<PackageBump>),
+}
+
+#[cfg(test)]
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum PlanSummary {
+    Skipped {
+        reason: &'static str,
+        recovered: bool,
+    },
+    Bump {
+        current_version: String,
+        new_version: String,
+        tag: String,
+        bump: BumpType,
+        commit_count: usize,
+        is_prerelease: bool,
+        strategy_label: String,
+    },
+}
+
+#[cfg(test)]
+impl PackagePlan {
+    pub(super) fn summary(&self) -> PlanSummary {
+        match self {
+            PackagePlan::Skipped { reason, recovered } => PlanSummary::Skipped {
+                reason: reason.json_label(),
+                recovered: *recovered,
+            },
+            PackagePlan::Bump(b) => PlanSummary::Bump {
+                current_version: b.current_version.clone(),
+                new_version: b.new_version.clone(),
+                tag: b.tag.clone(),
+                bump: b.bump,
+                commit_count: b.commits.len(),
+                is_prerelease: b.is_prerelease,
+                strategy_label: b.strategy_label.clone(),
+            },
+        }
+    }
+}
+
+pub(super) struct PlanInputs<'a> {
+    pub config: &'a Config,
+    pub root: &'a Path,
+    pub tag_index: Option<&'a TagIndex>,
+    pub head_ancestors: Option<&'a HashSet<ObjectId>>,
+    pub all_tags: &'a [String],
+    pub prerelease_ctx: &'a PrereleaseContext,
+    pub forced: &'a Option<Forced<'a>>,
+    pub changed_files: &'a [String],
+    pub short_hash: &'a str,
+}
+
+pub(super) fn compute_plan(
+    repo: &Repository,
+    pkg: &PackageConfig,
+    inputs: &PlanInputs<'_>,
+) -> Result<PackagePlan> {
+    let config = inputs.config;
+    let is_monorepo = config.is_monorepo();
+    let tag_search_prefix = pkg.tag_prefix(&config.workspace, is_monorepo);
+    let forced_ver_for_pkg = forced_version_for(inputs.forced, &pkg.name);
+
+    let mut touched = is_package_touched(pkg, inputs.changed_files, is_monorepo);
+    let mut recovered = false;
+
+    if !touched && config.workspace.recover_missed_releases && is_monorepo {
+        let strategy = config.workspace.orphaned_tag_strategy;
+        let files_since_tag =
+            if let (Some(idx), OrphanedTagStrategy::Warn) = (inputs.tag_index, strategy) {
+                let last_oid = idx.find_last_tag_commit(&tag_search_prefix, strategy);
+                get_changed_files_since_oid(repo, last_oid)?
+            } else {
+                get_changed_files_since_tag(repo, &tag_search_prefix, strategy)?
+            };
+        if is_package_touched(pkg, &files_since_tag, true) {
+            touched = true;
+            recovered = true;
+        }
+    }
+
+    if !touched && forced_ver_for_pkg.is_none() {
+        return Ok(PackagePlan::Skipped {
+            reason: SkipReason::NotTouched,
+            recovered,
+        });
+    }
+
+    let pkg_strategy = pkg.effective_versioning(
+        &config.workspace,
+        &tags_for_package(inputs.all_tags, &tag_search_prefix),
+    );
+
+    let file_version = pkg
+        .versioned_files
+        .first()
+        .and_then(|vf| read_version(vf, inputs.root).ok());
+    let strategy = config.workspace.orphaned_tag_strategy;
+    let highest_tag = if let (Some(idx), OrphanedTagStrategy::Warn) = (inputs.tag_index, strategy) {
+        idx.find_highest_semver_tag(&tag_search_prefix, strategy)
+    } else {
+        find_highest_semver_tag_with_cache(
+            repo,
+            &tag_search_prefix,
+            strategy,
+            inputs.head_ancestors,
+        )?
+    };
+    let last_tag = highest_tag.as_ref().map(|(tag, _version)| tag.clone());
+    let tag_version = highest_tag.map(|(_tag, version)| version);
+    let current_version = match (tag_version, file_version) {
+        (Some(tag), Some(file)) => pick_higher_semver(&file, &tag),
+        (Some(tag), None) => tag,
+        (None, Some(file)) => file,
+        (None, None) => crate::versioning::bootstrap_version(pkg_strategy),
+    };
+
+    let skip_markers = config.workspace.effective_commit_skip_markers();
+    let commits_since_stable = || -> Result<Vec<GitLog>> {
+        if let (Some(idx), OrphanedTagStrategy::Warn) = (inputs.tag_index, strategy) {
+            let stop = idx.find_last_stable_tag_commit(&tag_search_prefix, strategy);
+            get_commits_since_oid(repo, stop, &skip_markers)
+        } else {
+            get_commits_since_last_stable_tag(repo, &tag_search_prefix, strategy, &skip_markers)
+        }
+    };
+    let commits_since_any = || -> Result<Vec<GitLog>> {
+        if let (Some(idx), OrphanedTagStrategy::Warn) = (inputs.tag_index, strategy) {
+            let stop = idx.find_last_tag_commit(&tag_search_prefix, strategy);
+            get_commits_since_oid(repo, stop, &skip_markers)
+        } else {
+            get_commits_since_last_tag(repo, &tag_search_prefix, strategy, &skip_markers)
+        }
+    };
+
+    let prerelease = inputs.prerelease_ctx.is_prerelease();
+
+    let (new_version, is_prerelease, commits, bump) = if let Some(fv) = forced_ver_for_pkg {
+        let clean = fv.strip_prefix('v').unwrap_or(fv);
+        let commits = if !prerelease {
+            commits_since_stable().unwrap_or_default()
+        } else {
+            commits_since_any().unwrap_or_default()
+        };
+        (clean.to_string(), false, commits, BumpType::None)
+    } else {
+        let commits = if !prerelease {
+            commits_since_stable()?
+        } else {
+            commits_since_any()?
+        };
+
+        if commits.is_empty() {
+            return Ok(PackagePlan::Skipped {
+                reason: SkipReason::NoNewCommits,
+                recovered,
+            });
+        }
+
+        let strategy = pkg.effective_versioning(
+            &config.workspace,
+            &tags_for_package(inputs.all_tags, &tag_search_prefix),
+        );
+
+        let bump = commits
+            .iter()
+            .map(|c| determine_bump(&c.message))
+            .max()
+            .unwrap_or(BumpType::None);
+
+        if bump == BumpType::None && !is_date_or_seq(strategy) {
+            return Ok(PackagePlan::Skipped {
+                reason: SkipReason::NoReleasableCommits,
+                recovered,
+            });
+        }
+
+        let base_version = compute_next_version(&current_version, bump, strategy)?;
+
+        let (new_version, is_prerelease) = if prerelease {
+            let tag_prefix = pkg.tag_prefix(&config.workspace, is_monorepo);
+            if let Some(resolved) = inputs.prerelease_ctx.compute_identifier(
+                &base_version,
+                &tag_prefix,
+                inputs.all_tags,
+                inputs.short_hash,
+            ) {
+                (format!("{base_version}{}", resolved.full_suffix), true)
+            } else {
+                (base_version, false)
+            }
+        } else {
+            (base_version, false)
+        };
+
+        (new_version, is_prerelease, commits, bump)
+    };
+
+    if current_version == new_version {
+        return Ok(PackagePlan::Skipped {
+            reason: SkipReason::VersionUnchanged,
+            recovered,
+        });
+    }
+
+    let strategy_label = if forced_ver_for_pkg.is_some() {
+        "forced".to_string()
+    } else {
+        let strategy = pkg.effective_versioning(
+            &config.workspace,
+            &tags_for_package(inputs.all_tags, &tag_search_prefix),
+        );
+        if is_date_or_seq(strategy) {
+            format!("{strategy:?}").to_lowercase()
+        } else {
+            bump.to_string()
+        }
+    };
+
+    let tag = pkg.tag_for_version(&config.workspace, is_monorepo, &new_version);
+
+    Ok(PackagePlan::Bump(Box::new(PackageBump {
+        recovered,
+        current_version,
+        new_version,
+        is_prerelease,
+        last_tag,
+        commits,
+        bump,
+        strategy_label,
+        tag,
+    })))
+}
+
+fn is_date_or_seq(strategy: VersioningStrategy) -> bool {
+    matches!(
+        strategy,
+        VersioningStrategy::Calver
+            | VersioningStrategy::CalverShort
+            | VersioningStrategy::CalverSeq
+            | VersioningStrategy::Sequential
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::git::{TagIndex, build_head_ancestors, collect_all_tags, get_changed_files};
+    use crate::test_utils::{commit_file, git, init_repo};
+    use rayon::prelude::*;
+    use std::path::Path;
+
+    fn write_pkg(dir: &Path, name: &str, version: &str) {
+        std::fs::create_dir_all(dir.join(name)).unwrap();
+        std::fs::write(
+            dir.join(name).join("Cargo.toml"),
+            format!("[package]\nname = \"{name}\"\nversion = \"{version}\"\n"),
+        )
+        .unwrap();
+    }
+
+    fn write_config(dir: &Path, names: &[&str]) {
+        let packages: Vec<String> = names
+            .iter()
+            .map(|n| {
+                format!(
+                    r#"{{"name":"{n}","path":"{n}","versionedFiles":[{{"path":"{n}/Cargo.toml","format":"toml"}}]}}"#
+                )
+            })
+            .collect();
+        std::fs::write(
+            dir.join(".ferrflow"),
+            format!(r#"{{"package":[{}]}}"#, packages.join(",")),
+        )
+        .unwrap();
+    }
+
+    struct Fixture {
+        _dir: tempfile::TempDir,
+        repo: crate::git::Repository,
+        config: Config,
+        root: std::path::PathBuf,
+    }
+
+    fn build_inputs<'a>(
+        fx: &'a Fixture,
+        tag_index: &'a Option<TagIndex>,
+        head_ancestors: &'a Option<std::collections::HashSet<ObjectId>>,
+        all_tags: &'a [String],
+        prerelease_ctx: &'a PrereleaseContext,
+        forced: &'a Option<Forced<'a>>,
+        changed_files: &'a [String],
+    ) -> PlanInputs<'a> {
+        PlanInputs {
+            config: &fx.config,
+            root: &fx.root,
+            tag_index: tag_index.as_ref(),
+            head_ancestors: head_ancestors.as_ref(),
+            all_tags,
+            prerelease_ctx,
+            forced,
+            changed_files,
+            short_hash: "deadbee",
+        }
+    }
+
+    fn plan_all(fx: &Fixture, inputs: &PlanInputs<'_>, parallel: bool) -> Vec<PlanSummary> {
+        if parallel {
+            let thread_safe = fx.repo.clone().into_sync();
+            fx.config
+                .packages
+                .par_iter()
+                .map(|pkg| {
+                    let repo = thread_safe.to_thread_local();
+                    compute_plan(&repo, pkg, inputs).map(|p| p.summary())
+                })
+                .collect::<Result<Vec<_>>>()
+                .unwrap()
+        } else {
+            fx.config
+                .packages
+                .iter()
+                .map(|pkg| compute_plan(&fx.repo, pkg, inputs).map(|p| p.summary()))
+                .collect::<Result<Vec<_>>>()
+                .unwrap()
+        }
+    }
+
+    #[test]
+    fn parallel_planning_matches_sequential_baseline() {
+        let (dir, repo) = init_repo();
+        let root = dir.path().to_path_buf();
+        let names = ["alpha", "beta", "gamma", "delta"];
+        for n in names {
+            write_pkg(&root, n, "1.0.0");
+        }
+        write_config(&root, &names);
+        git(&root, &["add", "-A"]);
+        commit_file(&root, "seed.txt", "x", "chore: seed", 1_950_000_000);
+
+        // One tag per package so each package's commit walk starts from a
+        // distinct baseline — this makes the bump decisions order-sensitive
+        // enough that a racy parallel scan would diverge from sequential.
+        for n in names {
+            git(&root, &["tag", &format!("{n}-v1.0.0")]);
+        }
+        commit_file(
+            &root,
+            "alpha/feat.rs",
+            "x",
+            "feat: alpha feature",
+            1_950_000_100,
+        );
+        commit_file(&root, "beta/fix.rs", "x", "fix: beta fix", 1_950_000_200);
+        commit_file(
+            &root,
+            "gamma/docs.rs",
+            "x",
+            "docs: gamma note",
+            1_950_000_300,
+        );
+
+        let config = Config::load(&root, Some(&root.join(".ferrflow"))).unwrap();
+        let fx = Fixture {
+            _dir: dir,
+            repo,
+            config,
+            root: root.clone(),
+        };
+
+        let all_tags = collect_all_tags(&fx.repo);
+        let head_ancestors = build_head_ancestors(&fx.repo).ok();
+        let tag_index = TagIndex::build(&fx.repo).ok();
+        let prerelease_ctx = PrereleaseContext::resolve(None, "main", None).unwrap();
+        let forced: Option<Forced<'_>> = None;
+        let changed_files = get_changed_files(&fx.repo).unwrap();
+        let inputs = build_inputs(
+            &fx,
+            &tag_index,
+            &head_ancestors,
+            &all_tags,
+            &prerelease_ctx,
+            &forced,
+            &changed_files,
+        );
+
+        let sequential = plan_all(&fx, &inputs, false);
+        let parallel = plan_all(&fx, &inputs, true);
+        let parallel_again = plan_all(&fx, &inputs, true);
+
+        assert_eq!(parallel, sequential);
+        assert_eq!(parallel, parallel_again);
+
+        assert!(
+            parallel
+                .iter()
+                .any(|p| matches!(p, PlanSummary::Bump { .. })),
+            "fixture should produce at least one bump"
+        );
+    }
+
+    #[test]
+    fn one_package_compute_error_aborts_collection() {
+        let (dir, repo) = init_repo();
+        let root = dir.path().to_path_buf();
+        let names = ["good", "broken"];
+        write_pkg(&root, "good", "1.0.0");
+        write_pkg(&root, "broken", "not-a-semver");
+        write_config(&root, &names);
+        git(&root, &["add", "-A"]);
+        commit_file(&root, "seed.txt", "x", "chore: seed", 1_950_000_000);
+        commit_file(&root, "good/feat.rs", "x", "feat: good", 1_950_000_100);
+        commit_file(&root, "broken/feat.rs", "x", "feat: broken", 1_950_000_200);
+
+        let config = Config::load(&root, Some(&root.join(".ferrflow"))).unwrap();
+        let fx = Fixture {
+            _dir: dir,
+            repo,
+            config,
+            root: root.clone(),
+        };
+
+        let all_tags = collect_all_tags(&fx.repo);
+        let head_ancestors = build_head_ancestors(&fx.repo).ok();
+        let tag_index = TagIndex::build(&fx.repo).ok();
+        let prerelease_ctx = PrereleaseContext::resolve(None, "main", None).unwrap();
+        let forced: Option<Forced<'_>> = None;
+        let changed_files = get_changed_files(&fx.repo).unwrap();
+        let inputs = build_inputs(
+            &fx,
+            &tag_index,
+            &head_ancestors,
+            &all_tags,
+            &prerelease_ctx,
+            &forced,
+            &changed_files,
+        );
+
+        let thread_safe = fx.repo.clone().into_sync();
+        let result: Result<Vec<_>> = fx
+            .config
+            .packages
+            .par_iter()
+            .map(|pkg| {
+                let repo = thread_safe.to_thread_local();
+                compute_plan(&repo, pkg, &inputs)
+            })
+            .collect();
+
+        assert!(
+            result.is_err(),
+            "a broken package must abort the collection"
+        );
+    }
+}


### PR DESCRIPTION
Closes #476.

## What

Splits the per-package work in `run_release_logic` into two phases:

- **Phase A — read-only planning (parallelized).** A new `compute_plan` (`src/monorepo/run/plan.rs`) performs the per-package read-only git work: tag resolution via `TagIndex`, the commit walk since the last (stable/any) tag, bump classification, and next-version computation. It returns an owned `PackagePlan` (`Skipped { reason, recovered }` or `Bump`). It mutates no shared state and writes nothing.
- **Phase B — mutation/output (sequential, ordered, unchanged).** Version-file writes, changelog updates, hooks, `tags_to_create`, the dependency cascade, commit/tag/push, and forge releases stay exactly as before, consuming the ordered `Vec<PackagePlan>` the way the old loop consumed each iteration's locals.

Only Phase A is parallelized:

```rust
config.packages.par_iter()
    .map(|pkg| { let repo = thread_safe_repo.to_thread_local(); compute_plan(&repo, pkg, &inputs) })
    .collect::<Result<Vec<_>>>()?
```

## Thread safety

`gix::Repository` is `!Sync`, so it can't be shared across rayon threads. We build a `ThreadSafeRepository` once with `repo.clone().into_sync()` and each task derives its own thread-local repo via `to_thread_local()`. `TagIndex`, `Config`, and the other inputs are immutable and shared by `&`. `collect::<Result<Vec<_>>>()` short-circuits on the first package error (no partial silent loss), and `par_iter().collect()` preserves package-config order, so Phase B sees the same ordering as today.

## Determinism

Output is byte-identical to the sequential version. A test (`parallel_planning_matches_sequential_baseline`) asserts the parallel-collected plans equal a sequential `iter().map(...).collect()` baseline (and equal a second parallel run); a second test (`one_package_compute_error_aborts_collection`) asserts a single failing package aborts the whole collection. All existing monorepo/check/release tests pass unchanged.

## Scope / perf

`rayon` is gated under the `cli` feature (alongside `gix`/`mimalloc`); the wasm build does not pull it. The win materialises only on multi-package monorepos; single-package repos are effectively sequential under `par_iter` with negligible overhead.