### PR TITLE
refactor(monorepo): share HEAD-ancestor cache through orphan-strategy tag lookups

### DIFF
--- a/benches/ferrflow_benchmarks.rs
+++ b/benches/ferrflow_benchmarks.rs
@@ -294,6 +294,7 @@ fn bench_git_operations(c: &mut Criterion) {
                         "v",
                         OrphanedTagStrategy::Warn,
                         &ferrflow::config::default_commit_skip_markers(),
+                        None,
                     )
                     .unwrap(),
                 );
@@ -346,7 +347,8 @@ fn bench_git_operations(c: &mut Criterion) {
         c.bench_function(label, |b| {
             b.iter(|| {
                 black_box(
-                    get_changed_files_since_tag(&repo, "v", OrphanedTagStrategy::Warn).unwrap(),
+                    get_changed_files_since_tag(&repo, "v", OrphanedTagStrategy::Warn, None)
+                        .unwrap(),
                 );
             });
         });
@@ -423,6 +425,7 @@ fn bench_full_check_flow(c: &mut Criterion) {
                     "v",
                     OrphanedTagStrategy::Warn,
                     &ferrflow::config::default_commit_skip_markers(),
+                    None,
                 )
                 .unwrap();
                 for commit in &commits {

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -61,6 +61,7 @@ pub fn generate_only(config_path: Option<&Path>, dry_run: bool) -> Result<()> {
             &tag_prefix,
             config.workspace.orphaned_tag_strategy,
             &skip_markers,
+            None,
         )?;
 
         if commits.is_empty() {

--- a/src/git/commits.rs
+++ b/src/git/commits.rs
@@ -1,21 +1,23 @@
 use anyhow::{Context, Result};
 use gix::ObjectId;
 use gix::revision::walk::Sorting;
+use std::collections::HashSet;
 
 pub use crate::changelog::GitLog;
 use crate::config::OrphanedTagStrategy;
 
 use super::repo::Repository;
 use super::shell::run_git;
-use super::tags::{find_last_stable_tag, find_last_tag_commit};
+use super::tags::{find_last_stable_tag_with_cache, find_last_tag_commit};
 
 pub fn get_commits_since_last_tag(
     repo: &Repository,
     tag_prefix: &str,
     strategy: OrphanedTagStrategy,
     skip_markers: &[String],
+    ancestors: Option<&HashSet<ObjectId>>,
 ) -> Result<Vec<GitLog>> {
-    let last_tag_oid = find_last_tag_commit(repo, tag_prefix, strategy)?;
+    let last_tag_oid = find_last_tag_commit(repo, tag_prefix, strategy, ancestors)?;
     get_commits_since_oid(repo, last_tag_oid, skip_markers)
 }
 
@@ -24,8 +26,10 @@ pub fn get_commits_since_last_stable_tag(
     tag_prefix: &str,
     strategy: OrphanedTagStrategy,
     skip_markers: &[String],
+    ancestors: Option<&HashSet<ObjectId>>,
 ) -> Result<Vec<GitLog>> {
-    let last_tag_oid = find_last_stable_tag(repo, tag_prefix, strategy)?.map(|t| t.commit_oid);
+    let last_tag_oid = find_last_stable_tag_with_cache(repo, tag_prefix, strategy, ancestors)?
+        .map(|t| t.commit_oid);
     get_commits_since_oid(repo, last_tag_oid, skip_markers)
 }
 

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use gix::ObjectId;
+use std::collections::HashSet;
 
 use crate::config::OrphanedTagStrategy;
 
@@ -52,8 +53,9 @@ pub fn get_changed_files_since_tag(
     repo: &Repository,
     tag_prefix: &str,
     strategy: OrphanedTagStrategy,
+    ancestors: Option<&HashSet<ObjectId>>,
 ) -> Result<Vec<String>> {
-    let last_tag_oid = find_last_tag_commit(repo, tag_prefix, strategy)?;
+    let last_tag_oid = find_last_tag_commit(repo, tag_prefix, strategy, ancestors)?;
     get_changed_files_since_oid(repo, last_tag_oid)
 }
 

--- a/src/git/tags.rs
+++ b/src/git/tags.rs
@@ -488,16 +488,9 @@ pub(super) fn find_last_tag_commit(
     repo: &Repository,
     prefix: &str,
     strategy: OrphanedTagStrategy,
+    ancestors: Option<&HashSet<ObjectId>>,
 ) -> Result<Option<ObjectId>> {
-    Ok(find_last_tag(repo, prefix, strategy)?.map(|t| t.commit_oid))
-}
-
-pub(super) fn find_last_stable_tag(
-    repo: &Repository,
-    prefix: &str,
-    strategy: OrphanedTagStrategy,
-) -> Result<Option<TagMatch>> {
-    find_last_stable_tag_with_cache(repo, prefix, strategy, None)
+    Ok(find_last_tag_with_cache(repo, prefix, strategy, ancestors)?.map(|t| t.commit_oid))
 }
 
 pub(super) fn find_last_stable_tag_with_cache(

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -419,6 +419,7 @@ fn get_commits_since_last_tag_no_tags() {
         "v",
         OrphanedTagStrategy::Warn,
         &crate::config::default_commit_skip_markers(),
+        None,
     )
     .unwrap();
     assert_eq!(commits.len(), 2);
@@ -439,6 +440,7 @@ fn get_commits_since_last_tag_with_tag() {
         "v",
         OrphanedTagStrategy::Warn,
         &crate::config::default_commit_skip_markers(),
+        None,
     )
     .unwrap();
     assert_eq!(commits.len(), 2);
@@ -460,6 +462,7 @@ fn get_commits_skips_skip_ci() {
         "v",
         OrphanedTagStrategy::Warn,
         &crate::config::default_commit_skip_markers(),
+        None,
     )
     .unwrap();
     assert_eq!(commits.len(), 1);
@@ -479,6 +482,7 @@ fn get_commits_skips_ci_skip_variant() {
         "v",
         OrphanedTagStrategy::Warn,
         &crate::config::default_commit_skip_markers(),
+        None,
     )
     .unwrap();
     assert_eq!(commits.len(), 1);
@@ -497,6 +501,7 @@ fn get_commits_skip_marker_is_case_insensitive() {
         "v",
         OrphanedTagStrategy::Warn,
         &crate::config::default_commit_skip_markers(),
+        None,
     )
     .unwrap();
     assert_eq!(commits.len(), 0);
@@ -519,6 +524,7 @@ fn get_commits_skip_marker_ignored_in_body() {
         "v",
         OrphanedTagStrategy::Warn,
         &crate::config::default_commit_skip_markers(),
+        None,
     )
     .unwrap();
     assert_eq!(commits.len(), 1);
@@ -533,7 +539,7 @@ fn get_commits_skip_markers_can_be_overridden() {
 
     let custom = vec!["[no release]".to_string()];
     let commits =
-        get_commits_since_last_tag(&repo, "v", OrphanedTagStrategy::Warn, &custom).unwrap();
+        get_commits_since_last_tag(&repo, "v", OrphanedTagStrategy::Warn, &custom, None).unwrap();
     assert_eq!(
         commits.len(),
         1,
@@ -599,7 +605,7 @@ fn get_changed_files_since_tag_all_when_no_tag() {
     create_commit_in_repo(&repo, dir.path(), "a.txt", "first");
     create_commit_in_repo(&repo, dir.path(), "b.txt", "second");
 
-    let files = get_changed_files_since_tag(&repo, "v", OrphanedTagStrategy::Warn).unwrap();
+    let files = get_changed_files_since_tag(&repo, "v", OrphanedTagStrategy::Warn, None).unwrap();
     assert!(files.contains(&"a.txt".to_string()));
     assert!(files.contains(&"b.txt".to_string()));
 }
@@ -611,7 +617,7 @@ fn get_changed_files_since_tag_only_new() {
     create_lightweight_tag(&repo, "v1.0.0");
     create_commit_in_repo(&repo, dir.path(), "b.txt", "second");
 
-    let files = get_changed_files_since_tag(&repo, "v", OrphanedTagStrategy::Warn).unwrap();
+    let files = get_changed_files_since_tag(&repo, "v", OrphanedTagStrategy::Warn, None).unwrap();
     assert!(!files.contains(&"a.txt".to_string()));
     assert!(files.contains(&"b.txt".to_string()));
 }
@@ -1097,10 +1103,44 @@ fn get_commits_since_orphaned_tag_with_recovery() {
         "v",
         OrphanedTagStrategy::TreeHash,
         &crate::config::default_commit_skip_markers(),
+        None,
     )
     .unwrap();
     assert_eq!(commits.len(), 1);
     assert!(commits[0].message.contains("new feature"));
+}
+
+#[test]
+fn ancestor_cache_matches_uncached_on_orphan_recovery() {
+    let (repo, dir) = create_orphaned_tag_scenario("v1.0.0");
+    create_commit_in_repo(&repo, dir.path(), "b.txt", "feat: new feature");
+
+    let ancestors = build_head_ancestors(&repo).unwrap();
+    let markers = crate::config::default_commit_skip_markers();
+    let msgs =
+        |c: &[crate::changelog::GitLog]| c.iter().map(|g| g.message.clone()).collect::<Vec<_>>();
+
+    let uncached =
+        get_commits_since_last_tag(&repo, "v", OrphanedTagStrategy::TreeHash, &markers, None)
+            .unwrap();
+    let cached = get_commits_since_last_tag(
+        &repo,
+        "v",
+        OrphanedTagStrategy::TreeHash,
+        &markers,
+        Some(&ancestors),
+    )
+    .unwrap();
+
+    assert_eq!(msgs(&cached), msgs(&uncached));
+    assert_eq!(cached.len(), 1);
+
+    let files_uncached =
+        get_changed_files_since_tag(&repo, "v", OrphanedTagStrategy::TreeHash, None).unwrap();
+    let files_cached =
+        get_changed_files_since_tag(&repo, "v", OrphanedTagStrategy::TreeHash, Some(&ancestors))
+            .unwrap();
+    assert_eq!(files_cached, files_uncached);
 }
 
 #[test]
@@ -1120,6 +1160,7 @@ fn get_commits_since_last_stable_tag_skips_prereleases() {
         "v",
         OrphanedTagStrategy::Warn,
         &crate::config::default_commit_skip_markers(),
+        None,
     )
     .unwrap();
     assert_eq!(commits.len(), 3);
@@ -1130,6 +1171,7 @@ fn get_commits_since_last_stable_tag_skips_prereleases() {
         "v",
         OrphanedTagStrategy::Warn,
         &crate::config::default_commit_skip_markers(),
+        None,
     )
     .unwrap();
     assert_eq!(commits.len(), 1);

--- a/src/monorepo/run/plan.rs
+++ b/src/monorepo/run/plan.rs
@@ -119,13 +119,14 @@ pub(super) fn compute_plan(
 
     if !touched && config.workspace.recover_missed_releases && is_monorepo {
         let strategy = config.workspace.orphaned_tag_strategy;
-        let files_since_tag =
-            if let (Some(idx), OrphanedTagStrategy::Warn) = (inputs.tag_index, strategy) {
-                let last_oid = idx.find_last_tag_commit(&tag_search_prefix, strategy);
-                get_changed_files_since_oid(repo, last_oid)?
-            } else {
-                get_changed_files_since_tag(repo, &tag_search_prefix, strategy)?
-            };
+        let files_since_tag = if let (Some(idx), OrphanedTagStrategy::Warn) =
+            (inputs.tag_index, strategy)
+        {
+            let last_oid = idx.find_last_tag_commit(&tag_search_prefix, strategy);
+            get_changed_files_since_oid(repo, last_oid)?
+        } else {
+            get_changed_files_since_tag(repo, &tag_search_prefix, strategy, inputs.head_ancestors)?
+        };
         if is_package_touched(pkg, &files_since_tag, true) {
             touched = true;
             recovered = true;
@@ -174,7 +175,13 @@ pub(super) fn compute_plan(
             let stop = idx.find_last_stable_tag_commit(&tag_search_prefix, strategy);
             get_commits_since_oid(repo, stop, &skip_markers)
         } else {
-            get_commits_since_last_stable_tag(repo, &tag_search_prefix, strategy, &skip_markers)
+            get_commits_since_last_stable_tag(
+                repo,
+                &tag_search_prefix,
+                strategy,
+                &skip_markers,
+                inputs.head_ancestors,
+            )
         }
     };
     let commits_since_any = || -> Result<Vec<GitLog>> {
@@ -182,7 +189,13 @@ pub(super) fn compute_plan(
             let stop = idx.find_last_tag_commit(&tag_search_prefix, strategy);
             get_commits_since_oid(repo, stop, &skip_markers)
         } else {
-            get_commits_since_last_tag(repo, &tag_search_prefix, strategy, &skip_markers)
+            get_commits_since_last_tag(
+                repo,
+                &tag_search_prefix,
+                strategy,
+                &skip_markers,
+                inputs.head_ancestors,
+            )
         }
     };
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -69,6 +69,7 @@ pub fn run(
             &tag_search_prefix,
             config.workspace.orphaned_tag_strategy,
             &skip_markers,
+            None,
         )?;
         let has_changes = commits
             .iter()


### PR DESCRIPTION
Closes #471.

## Context

#471 asked to profile and reduce the remaining N+1 in the monorepo per-package loop, with a `TagIndex` that bundles the HEAD-ancestor set, pre-resolved tags, and a prefix lookup helper, plumbed through `get_changed_files_since_tag` / `get_commits_since_last_tag`.

The bulk of that already landed via #466 (ancestor cache), #468 (`TagIndex`), and #592 (parallel per-package planning). Profiling `release --dry-run --timing` on an 80-package synthetic monorepo confirms the **default `Warn` path is already optimal**:

```
build TagIndex            18 ms   <- built once
per-package compute       24 ms   <- ~0.3 ms/pkg, parallel
total                     68 ms
```

No per-package tag-scan stage — the prebuilt index resolves every tag once.

## This change

Completes the issue's remaining literal item: the **non-default orphan strategies** (`treeHash` / `message`) fell off the index and re-ran `is_reachable` with no ancestor cache. This threads `Option<&HashSet<ObjectId>>` through `get_changed_files_since_tag`, `get_commits_since_last_tag`, and `get_commits_since_last_stable_tag` (mirroring the existing `find_last_tag` / `find_last_tag_with_cache` pattern), so the fallback shares the same prebuilt HEAD-ancestor set the `Warn` path already uses. The two strategy paths are now consistent.

**Honest note on impact:** this is framed as a refactor, not a perf win. A/B on a 1200-commit-deep `treeHash` fixture measured 124 ms (cache) vs 125 ms (no cache) — noise. The per-package prefix filter limits reachability checks to ~1 per package, and the dominant cost is `get_commits_since_oid` collecting the actual commits, which no cache touches. The cache only helps the pathological case of one prefix matching many prerelease tags. The remaining structural win (extending `TagIndex` to serve `treeHash`/`message`) is intentionally **out of scope** — it would require precomputing orphan rematch and risks release-correctness for a non-default strategy.

## Tests

- New `ancestor_cache_matches_uncached_on_orphan_recovery` asserts the cached and uncached paths produce identical commits **and** changed-files on the orphan-rematch (`treeHash`) path — guarding the invariant that the cache is a pure reachability speedup with no semantic change.
- Full suite green (819), clippy clean, no dead code.