### PR TITLE
perf(git): use commit-graph for revision walks

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -93,6 +93,11 @@ runs:
     # via `FERRFLOW_BOT_LOGIN` and `FERRFLOW_BOT_USER_ID` env vars on
     # the calling job.
 
+    - name: Optimize commit-graph
+      if: inputs.mode != 'publish'
+      shell: bash
+      run: git commit-graph write --reachable 2>/dev/null || true
+
     - name: Preview release
       if: inputs.mode == 'preview'
       shell: bash

--- a/src/git/commits.rs
+++ b/src/git/commits.rs
@@ -39,7 +39,10 @@ pub fn get_commits_since_oid(
     skip_markers: &[String],
 ) -> Result<Vec<GitLog>> {
     let head = repo.head_id()?.detach();
-    let mut platform = repo.rev_walk([head]).sorting(Sorting::BreadthFirst);
+    let mut platform = repo
+        .rev_walk([head])
+        .use_commit_graph(true)
+        .sorting(Sorting::BreadthFirst);
     if let Some(stop) = last_tag_oid {
         platform = platform.with_hidden([stop]);
     }

--- a/src/git/tags.rs
+++ b/src/git/tags.rs
@@ -13,6 +13,7 @@ pub fn build_head_ancestors(repo: &Repository) -> Result<HashSet<ObjectId>> {
     let head_id = repo.head_id()?.detach();
     let walk = repo
         .rev_walk([head_id])
+        .use_commit_graph(true)
         .sorting(Sorting::BreadthFirst)
         .all()?;
     let mut set: HashSet<ObjectId> = HashSet::new();
@@ -40,6 +41,7 @@ impl TagIndex {
         let head_id = repo.head_id()?.detach();
         let walk = repo
             .rev_walk([head_id])
+            .use_commit_graph(true)
             .sorting(Sorting::BreadthFirst)
             .all()?;
         let mut ancestors: HashSet<ObjectId> = HashSet::new();
@@ -192,7 +194,12 @@ fn is_reachable(
     if head == commit_oid {
         return true;
     }
-    let walk = match repo.rev_walk([head]).sorting(Sorting::BreadthFirst).all() {
+    let walk = match repo
+        .rev_walk([head])
+        .use_commit_graph(true)
+        .sorting(Sorting::BreadthFirst)
+        .all()
+    {
         Ok(w) => w,
         Err(_) => return false,
     };
@@ -218,6 +225,7 @@ pub(super) fn find_matching_commit(
     let head = repo.head_id().ok()?.detach();
     let walk = repo
         .rev_walk([head])
+        .use_commit_graph(true)
         .sorting(Sorting::ByCommitTime(CommitTimeOrder::NewestFirst))
         .all()
         .ok()?;

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -622,6 +622,34 @@ fn get_changed_files_since_tag_only_new() {
     assert!(files.contains(&"b.txt".to_string()));
 }
 
+#[test]
+fn walks_stay_correct_with_commit_graph_present() {
+    let (dir, repo) = init_repo();
+    create_commit_in_repo(&repo, dir.path(), "a.txt", "feat: first");
+    create_lightweight_tag(&repo, "v1.0.0");
+    create_commit_in_repo(&repo, dir.path(), "b.txt", "fix: second");
+    create_commit_in_repo(&repo, dir.path(), "c.txt", "feat: third");
+    git(dir.path(), &["commit-graph", "write", "--reachable"]);
+
+    let commits = get_commits_since_last_tag(
+        &repo,
+        "v",
+        OrphanedTagStrategy::Warn,
+        &crate::config::default_commit_skip_markers(),
+        None,
+    )
+    .unwrap();
+    assert_eq!(commits.len(), 2);
+    assert!(commits[0].message.contains("third"));
+    assert!(commits[1].message.contains("second"));
+
+    let idx = TagIndex::build(&repo).unwrap();
+    assert!(
+        idx.find_last_tag_commit("v", OrphanedTagStrategy::Warn)
+            .is_some()
+    );
+}
+
 // -----------------------------------------------------------------------
 // create_commit
 // -----------------------------------------------------------------------


### PR DESCRIPTION
Part of #507 (commit-graph; mimalloc already shipped, PGO deferred — see issue comment).

## What

All five `rev_walk` sites in `src/git/tags.rs` and `src/git/commits.rs` (HEAD-ancestor set, `TagIndex::build`, reachability check, orphan rematch, commit collection) now call `.use_commit_graph(true)`. gix treats the commit-graph as an optional cache: if the `.git/objects/info/commit-graph` sidecar is missing or fails to load, it falls back to the object database, so this is behaviour-preserving and zero-risk.

To make the sidecar actually present in CI, `action.yml` gains a best-effort `git commit-graph write --reachable` step (skipped in `publish` mode, `|| true` so it never fails a release) — this runs in every consumer's release/preview job.

## Measured

A/B on a 5000-commit repo (`release --dry-run --timing`), same binary, toggling only the presence of the commit-graph file:

| | per-package compute | total |
|---|---|---|
| no commit-graph | ~84 ms | ~152 ms |
| with commit-graph | ~44 ms | ~72 ms |

≈2× faster walks on large histories. The win scales with history depth; small repos are unaffected (the graph is cheap to skip).

## Tests

`walks_stay_correct_with_commit_graph_present` builds a repo, writes the commit-graph sidecar, and asserts `get_commits_since_last_tag` + `TagIndex::build` return the same results they do without it — guarding against the graph reader changing walk output. Full suite green (827), clippy + fmt clean.