### PR TITLE
feat(cli): add --jobs / FERRFLOW_JOBS to control parallelism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "5.15.1"
+version = "5.15.2"
 dependencies = [
  "anyhow",
  "cargo-husky",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,6 +29,10 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub timing: bool,
 
+    /// Max threads for CPU-parallel work (per-package planning). Default: all cores. `1` forces single-threaded.
+    #[arg(long, global = true, env = "FERRFLOW_JOBS", value_name = "N")]
+    pub jobs: Option<usize>,
+
     #[command(subcommand)]
     pub command: Commands,
 }
@@ -574,6 +578,18 @@ mod tests {
     fn global_timing() {
         let cli = parse(&["ferrflow", "--timing", "check"]);
         assert!(cli.timing);
+    }
+
+    #[test]
+    fn global_jobs_default_none() {
+        let cli = parse(&["ferrflow", "check"]);
+        assert_eq!(cli.jobs, None);
+    }
+
+    #[test]
+    fn global_jobs_flag() {
+        let cli = parse(&["ferrflow", "release", "--jobs", "1", "--dry-run"]);
+        assert_eq!(cli.jobs, Some(1));
     }
 
     #[test]

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -1,0 +1,17 @@
+use std::sync::OnceLock;
+
+static MAX_JOBS: OnceLock<usize> = OnceLock::new();
+
+pub fn init(jobs: Option<usize>) {
+    if let Some(n) = jobs {
+        let n = n.max(1);
+        let _ = MAX_JOBS.set(n);
+        let _ = rayon::ThreadPoolBuilder::new()
+            .num_threads(n)
+            .build_global();
+    }
+}
+
+pub fn max_jobs() -> usize {
+    MAX_JOBS.get().copied().unwrap_or(usize::MAX)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod bot_token;
 mod cache;
 mod changelog;
 mod cli;
+mod concurrency;
 mod config;
 mod conventional_commits;
 mod diff;
@@ -36,6 +37,8 @@ use cli::Cli;
 fn main() {
     let cli = Cli::parse();
     let command_name = cli.command.name();
+
+    concurrency::init(cli.jobs);
 
     telemetry::maybe_print_first_run_notice();
 

--- a/src/monorepo/run/execute.rs
+++ b/src/monorepo/run/execute.rs
@@ -423,10 +423,7 @@ fn push_and_publish(
         let draft = plan.draft;
         let target_sha_ref = target_sha.as_deref();
 
-        let threads = plan
-            .tags_to_create
-            .len()
-            .clamp(1, RELEASE_FORGE_CONCURRENCY);
+        let threads = forge_pool_threads(plan.tags_to_create.len(), crate::concurrency::max_jobs());
         let pool = rayon::ThreadPoolBuilder::new()
             .num_threads(threads)
             .build()
@@ -488,6 +485,10 @@ fn push_and_publish(
 }
 
 const RELEASE_FORGE_CONCURRENCY: usize = 8;
+
+fn forge_pool_threads(tag_count: usize, max_jobs: usize) -> usize {
+    tag_count.clamp(1, RELEASE_FORGE_CONCURRENCY.min(max_jobs))
+}
 
 struct TagReleaseWarning {
     message: String,
@@ -842,6 +843,15 @@ mod tag_release_tests {
         assert!(!line.contains("Published"));
         assert!(line.contains("v1"));
         assert_eq!(forge.create_calls.lock().unwrap().as_slice(), ["v1"]);
+    }
+
+    #[test]
+    fn forge_pool_thread_sizing_respects_max_jobs() {
+        assert_eq!(forge_pool_threads(50, usize::MAX), 8);
+        assert_eq!(forge_pool_threads(3, usize::MAX), 3);
+        assert_eq!(forge_pool_threads(50, 1), 1);
+        assert_eq!(forge_pool_threads(50, 4), 4);
+        assert_eq!(forge_pool_threads(0, usize::MAX), 1);
     }
 
     #[test]


### PR DESCRIPTION
Part of #597.

## What

Adds a global `--jobs <N>` flag (and `FERRFLOW_JOBS` env var; flag wins) controlling how many threads FerrFlow uses for parallel work.

- **Default (unset):** all logical cores — rayon's default, unchanged behaviour.
- **`--jobs N`:** caps CPU-parallel work (per-package planning, #476) to N threads via `rayon::ThreadPoolBuilder::build_global`, and caps the #477 release-HTTP pool to `min(N, 8)`. So `--jobs 1` makes the whole tool single-threaded.

## Why

Since #476/#477 FerrFlow is multi-threaded, which makes the competitive benchmark non-reproducible (scales with runner cores) and unfair against single-threaded competitors. A documented knob lets the benchmark pin `--jobs 1` for the apples-to-apples number (and report the parallel speedup separately), and lets users cap CPU use in constrained CI. Relying on rayon's internal `RAYON_NUM_THREADS` wouldn't cover the #477 forge pool and isn't documented.

## Implementation

- `src/concurrency.rs`: `init(Option<usize>)` builds the global rayon pool and stores the cap; `max_jobs()` exposes it.
- `src/main.rs`: `concurrency::init(cli.jobs)` right after arg parse, before any parallel work.
- `src/monorepo/run/execute.rs`: forge pool sized by the pure `forge_pool_threads(tag_count, max_jobs)`.
- Bin-only module; the wasm/lib build (no `cli` feature, no rayon) is untouched.

## Tests

`forge_pool_threads` sizing (8 cap, `--jobs 1` → 1, `--jobs 4` → 4, empty → 1) and flag/env parsing. Full suite green, clippy + fmt clean, wasm build verified.

Benchmark harness wiring and the ferrflow.com perf-page stats follow in separate PRs (Benchmarks + FerrFlow-Cloud).