### PR TITLE
fix(deps): bump memmap2 to 0.9.11 (RUSTSEC-2026-0186)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,9 +1788,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
Closes #603.

`cargo audit --deny warnings` denied `memmap2 0.9.10` (RUSTSEC-2026-0186 — unsound, unchecked pointer offset). It's a transitive dep via `gix` (`gix-commitgraph` / `gix-index` / `gix-odb`).

The advisory's patched constraint is `>=0.9.11`; `cargo update -p memmap2` bumps within the existing `^0.9` range to 0.9.11. Lockfile-only change; `cargo check --locked` passes.