### PR TITLE
feat(npm): publish CLI as unscoped `ferrflow` with `@ferrflow/*` platform packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Quality Gate](https://sonar.ferrlabs.com/api/project_badges/measure?project=ferrflow&metric=alert_status&token=sqb_53f0d93466bd01a6c6a94a15125d5aa8390c67fa)](https://sonar.ferrlabs.com/dashboard?id=ferrflow)
 [![Coverage](https://sonar.ferrlabs.com/api/project_badges/measure?project=ferrflow&metric=coverage&token=sqb_53f0d93466bd01a6c6a94a15125d5aa8390c67fa)](https://sonar.ferrlabs.com/dashboard?id=ferrflow)
 [![License](https://img.shields.io/github/license/FerrLabs/FerrFlow)](LICENSE)
-[![Socket Badge](https://badge.socket.dev/npm/package/@ferrlabs/ferrflow/latest)](https://badge.socket.dev/npm/package/@ferrlabs/ferrflow/latest)
+[![Socket Badge](https://badge.socket.dev/npm/package/ferrflow/latest)](https://badge.socket.dev/npm/package/ferrflow/latest)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/FerrLabs/FerrFlow/badge)](https://scorecard.dev/viewer/?uri=github.com/FerrLabs/FerrFlow)
 
 Universal semantic versioning for monorepos and classic repos.
@@ -45,8 +45,10 @@ cargo install ferrflow
 **npm**
 
 ```bash
-npm install -D @ferrlabs/ferrflow
+npm install -D ferrflow
 ```
+
+(`@ferrlabs/ferrflow` is kept as a published alias for the same package.)
 
 **Docker**
 

--- a/npm/bin/ferrflow.js
+++ b/npm/bin/ferrflow.js
@@ -9,11 +9,11 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 
 const PLATFORMS = {
-  "linux-x64": "@ferrlabs/ferrflow-linux-x64",
-  "linux-arm64": "@ferrlabs/ferrflow-linux-arm64",
-  "darwin-x64": "@ferrlabs/ferrflow-darwin-x64",
-  "darwin-arm64": "@ferrlabs/ferrflow-darwin-arm64",
-  "win32-x64": "@ferrlabs/ferrflow-win32-x64",
+  "linux-x64": "@ferrflow/linux-x64",
+  "linux-arm64": "@ferrflow/linux-arm64",
+  "darwin-x64": "@ferrflow/darwin-x64",
+  "darwin-arm64": "@ferrflow/darwin-arm64",
+  "win32-x64": "@ferrflow/win32-x64",
 };
 
 function getBinaryPath() {

--- a/npm/package.json
+++ b/npm/package.json
@@ -12,13 +12,13 @@
     "release"
   ],
   "license": "MPL-2.0",
-  "name": "@ferrlabs/ferrflow",
+  "name": "ferrflow",
   "optionalDependencies": {
-    "@ferrlabs/ferrflow-darwin-arm64": "5.17.0",
-    "@ferrlabs/ferrflow-darwin-x64": "5.17.0",
-    "@ferrlabs/ferrflow-linux-arm64": "5.17.0",
-    "@ferrlabs/ferrflow-linux-x64": "5.17.0",
-    "@ferrlabs/ferrflow-win32-x64": "5.17.0"
+    "@ferrflow/darwin-arm64": "5.17.0",
+    "@ferrflow/darwin-x64": "5.17.0",
+    "@ferrflow/linux-arm64": "5.17.0",
+    "@ferrflow/linux-x64": "5.17.0",
+    "@ferrflow/win32-x64": "5.17.0"
   },
   "repository": {
     "type": "git",

--- a/npm/platforms/darwin-arm64/package.json
+++ b/npm/platforms/darwin-arm64/package.json
@@ -4,7 +4,7 @@
   ],
   "description": "FerrFlow macOS arm64 binary",
   "license": "MPL-2.0",
-  "name": "@ferrlabs/ferrflow-darwin-arm64",
+  "name": "@ferrflow/darwin-arm64",
   "os": [
     "darwin"
   ],

--- a/npm/platforms/darwin-x64/package.json
+++ b/npm/platforms/darwin-x64/package.json
@@ -4,7 +4,7 @@
   ],
   "description": "FerrFlow macOS x64 binary",
   "license": "MPL-2.0",
-  "name": "@ferrlabs/ferrflow-darwin-x64",
+  "name": "@ferrflow/darwin-x64",
   "os": [
     "darwin"
   ],

--- a/npm/platforms/linux-arm64/package.json
+++ b/npm/platforms/linux-arm64/package.json
@@ -4,7 +4,7 @@
   ],
   "description": "FerrFlow Linux arm64 binary",
   "license": "MPL-2.0",
-  "name": "@ferrlabs/ferrflow-linux-arm64",
+  "name": "@ferrflow/linux-arm64",
   "os": [
     "linux"
   ],

--- a/npm/platforms/linux-x64/package.json
+++ b/npm/platforms/linux-x64/package.json
@@ -4,7 +4,7 @@
   ],
   "description": "FerrFlow Linux x64 binary",
   "license": "MPL-2.0",
-  "name": "@ferrlabs/ferrflow-linux-x64",
+  "name": "@ferrflow/linux-x64",
   "os": [
     "linux"
   ],

--- a/npm/platforms/win32-x64/package.json
+++ b/npm/platforms/win32-x64/package.json
@@ -4,7 +4,7 @@
   ],
   "description": "FerrFlow Windows x64 binary",
   "license": "MPL-2.0",
-  "name": "@ferrlabs/ferrflow-win32-x64",
+  "name": "@ferrflow/win32-x64",
   "os": [
     "win32"
   ],

--- a/npm/scripts/publish.sh
+++ b/npm/scripts/publish.sh
@@ -20,7 +20,7 @@ echo "Downloading release binaries for v${VERSION}..."
 
 for archive in "${!ARCHIVES[@]}"; do
   platform="${ARCHIVES[$archive]}"
-  echo "  ${archive} -> @ferrlabs/ferrflow-${platform}"
+  echo "  ${archive} -> @ferrflow/${platform}"
 
   gh release download "v${VERSION}" -p "$archive" -D "$WORK_DIR"
 
@@ -64,7 +64,20 @@ node -e "
 
 npm publish --access public
 
-echo "Published ferrflow@${VERSION} with all platform packages"
+echo "Publishing brand alias @ferrlabs/ferrflow@${VERSION}..."
+ALIAS_DIR="$(mktemp -d)"
+cp -a "${NPM_DIR}/." "${ALIAS_DIR}/"
+cd "$ALIAS_DIR"
+node -e "
+  const pkg = JSON.parse(require('fs').readFileSync('package.json', 'utf8'));
+  pkg.name = '@ferrlabs/ferrflow';
+  require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+"
+npm publish --access public
+cd - > /dev/null
+rm -rf "$ALIAS_DIR"
+
+echo "Published ferrflow@${VERSION} (+ @ferrlabs/ferrflow alias) with all platform packages"
 
 # Cleanup
 rm -rf "$WORK_DIR"


### PR DESCRIPTION
Closes #605.

Makes `npm i ferrflow` the canonical install and moves the per-platform binary packages under a dedicated `@ferrflow` scope. `@ferrlabs/ferrflow` is kept as a published alias.

## Changes

- `npm/package.json` → name `ferrflow` (was `@ferrlabs/ferrflow`); `optionalDependencies` → `@ferrflow/<plat>`
- `npm/platforms/*/package.json` → `@ferrflow/<plat>` (5 packages)
- `npm/bin/ferrflow.js` → `PLATFORMS` map resolves `@ferrflow/<plat>`
- `npm/scripts/publish.sh` → publishes `@ferrflow/<plat>` + `ferrflow`, then generates and publishes the `@ferrlabs/ferrflow` alias (same wrapper, scoped name, same `@ferrflow/*` deps)
- `README.md` → install shows `npm i -D ferrflow`; Socket badge points at `ferrflow`; notes the alias

## ⚠️ Do NOT merge until the npm side is ready

This intentionally skips auto-merge. Merging triggers a release whose `publish-npm` job will try to publish `@ferrflow/<plat>`. Before merging:

1. Create the **`@ferrflow`** scope/org on npmjs.
2. Ensure the `NPM_TOKEN` CI secret is an automation token with publish rights to: `@ferrflow` scope, the unscoped `ferrflow` name, and the `@ferrlabs` scope.

Failure mode if released early: `set -e` aborts the script on the first `@ferrflow/<plat>` publish, so no broken wrapper gets pushed — but the release job goes red.

## Out of scope

- `@ferrlabs/ferrflow-wasm` (separate, has a cross-repo consumer in the playground)
- Deprecating old `@ferrlabs/ferrflow-<plat>` packages (optional follow-up)