### PR TITLE
feat(release): add Windows arm64 and Linux armv7 build targets

### DIFF
--- a/.ferrflow
+++ b/.ferrflow
@@ -21,7 +21,9 @@
         { "path": "npm/platforms/linux-arm64/package.json", "format": "json" },
         { "path": "npm/platforms/darwin-x64/package.json", "format": "json" },
         { "path": "npm/platforms/darwin-arm64/package.json", "format": "json" },
-        { "path": "npm/platforms/win32-x64/package.json", "format": "json" }
+        { "path": "npm/platforms/win32-x64/package.json", "format": "json" },
+        { "path": "npm/platforms/win32-arm64/package.json", "format": "json" },
+        { "path": "npm/platforms/linux-arm/package.json", "format": "json" }
       ]
     }
   ]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,14 @@ jobs:
             os: windows-latest
             binary: ferrflow.exe
             archive: ferrflow-windows-x64.zip
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
+            binary: ferrflow.exe
+            archive: ferrflow-windows-arm64.zip
+          - target: armv7-unknown-linux-musleabihf
+            os: ubuntu-latest
+            binary: ferrflow
+            archive: ferrflow-linux-armv7.tar.gz
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,7 @@ runs:
         case "$ARCH" in
           x86_64)        ARCH_NAME="x64" ;;
           aarch64|arm64) ARCH_NAME="arm64" ;;
+          armv7l|armv7)  ARCH_NAME="armv7" ;;
           *)             echo "Unsupported architecture: $ARCH" && exit 1 ;;
         esac
 

--- a/npm/bin/ferrflow.js
+++ b/npm/bin/ferrflow.js
@@ -14,6 +14,8 @@ const PLATFORMS = {
   "darwin-x64": "@ferrflow/darwin-x64",
   "darwin-arm64": "@ferrflow/darwin-arm64",
   "win32-x64": "@ferrflow/win32-x64",
+  "win32-arm64": "@ferrflow/win32-arm64",
+  "linux-arm": "@ferrflow/linux-arm",
 };
 
 function getBinaryPath() {

--- a/npm/package.json
+++ b/npm/package.json
@@ -16,8 +16,10 @@
   "optionalDependencies": {
     "@ferrflow/darwin-arm64": "5.18.0",
     "@ferrflow/darwin-x64": "5.18.0",
+    "@ferrflow/linux-arm": "5.18.0",
     "@ferrflow/linux-arm64": "5.18.0",
     "@ferrflow/linux-x64": "5.18.0",
+    "@ferrflow/win32-arm64": "5.18.0",
     "@ferrflow/win32-x64": "5.18.0"
   },
   "repository": {

--- a/npm/platforms/linux-arm/package.json
+++ b/npm/platforms/linux-arm/package.json
@@ -1,0 +1,16 @@
+{
+  "cpu": [
+    "arm"
+  ],
+  "description": "FerrFlow Linux armv7 binary",
+  "license": "MPL-2.0",
+  "name": "@ferrflow/linux-arm",
+  "os": [
+    "linux"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/FerrLabs/FerrFlow.git"
+  },
+  "version": "5.18.0"
+}

--- a/npm/platforms/win32-arm64/package.json
+++ b/npm/platforms/win32-arm64/package.json
@@ -1,0 +1,16 @@
+{
+  "cpu": [
+    "arm64"
+  ],
+  "description": "FerrFlow Windows arm64 binary",
+  "license": "MPL-2.0",
+  "name": "@ferrflow/win32-arm64",
+  "os": [
+    "win32"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/FerrLabs/FerrFlow.git"
+  },
+  "version": "5.18.0"
+}

--- a/npm/scripts/publish.sh
+++ b/npm/scripts/publish.sh
@@ -10,6 +10,8 @@ declare -A ARCHIVES=(
   ["ferrflow-darwin-x64.tar.gz"]="darwin-x64"
   ["ferrflow-darwin-arm64.tar.gz"]="darwin-arm64"
   ["ferrflow-windows-x64.zip"]="win32-x64"
+  ["ferrflow-windows-arm64.zip"]="win32-arm64"
+  ["ferrflow-linux-armv7.tar.gz"]="linux-arm"
 )
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"


### PR DESCRIPTION
Closes #591.

Expands the release target matrix from 5 to 7, keeping the whole npm distribution chain in lockstep.

## New targets
| Target | OS | CPU | archive | npm package |
|---|---|---|---|---|
| `aarch64-pc-windows-msvc` | Windows | arm64 | `ferrflow-windows-arm64.zip` | `@ferrflow/win32-arm64` |
| `armv7-unknown-linux-musleabihf` | Linux | armv7 (32-bit) | `ferrflow-linux-armv7.tar.gz` | `@ferrflow/linux-arm` |

Windows arm64 cross-compiles natively from the x86_64 `windows-latest` runner (`cargo build --target`); Linux armv7 builds via `cross`, like the existing aarch64-musl target.

## Full chain updated (in lockstep)
1. `.github/workflows/publish.yml` — 2 matrix entries.
2. `npm/platforms/win32-arm64/` + `npm/platforms/linux-arm/` — new platform stubs (correct `os`/`cpu`).
3. `npm/bin/ferrflow.js` — `PLATFORMS` map (Node arch names: `win32-arm64`, `linux-arm`).
4. `npm/package.json` — `optionalDependencies`.
5. `npm/scripts/publish.sh` — archive→platform mapping.
6. `.ferrflow` — `versionedFiles` (so the new stubs get version-bumped on release).
7. `action.yml` — `armv7l`/`armv7` arch case (Windows arm64 already covered by the `aarch64|arm64` case).

Validated: workflow YAML parses (7 targets), all JSON valid, `node --check` on the shim, `bash -n` on publish.sh, and the 4 lists (matrix / PLATFORMS / optionalDeps / publish.sh) are consistent across all 7 platforms.

The new platform packages publish on the next release (the matrix + optionalDeps + publish.sh move together, so the distribution never diverges). Docs install page + changelog tracked separately.