### PR TITLE
fix(npm): add files allowlist, shim signal/error handling, node engines

### DIFF
--- a/npm/bin/ferrflow.js
+++ b/npm/bin/ferrflow.js
@@ -4,6 +4,7 @@ import { existsSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { createRequire } from "module";
+import { constants } from "os";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
@@ -43,4 +44,11 @@ function getBinaryPath() {
 
 const binary = getBinaryPath();
 const result = spawnSync(binary, process.argv.slice(2), { stdio: "inherit" });
+if (result.error) {
+  console.error(`ferrflow: failed to launch ${binary}: ${result.error.message}`);
+  process.exit(1);
+}
+if (result.signal) {
+  process.exit(128 + (constants.signals[result.signal] ?? 0));
+}
 process.exit(result.status ?? 1);

--- a/npm/package.json
+++ b/npm/package.json
@@ -3,6 +3,12 @@
     "ferrflow": "./bin/ferrflow.js"
   },
   "description": "Universal semantic versioning for monorepos and classic repos",
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "bin"
+  ],
   "homepage": "https://ferrflow.com",
   "keywords": [
     "semver",

--- a/npm/scripts/publish.sh
+++ b/npm/scripts/publish.sh
@@ -33,6 +33,7 @@ for archive in "${!ARCHIVES[@]}"; do
     unzip -q "${WORK_DIR}/${archive}" -d "${pkg_dir}/bin/"
   else
     tar xzf "${WORK_DIR}/${archive}" -C "${pkg_dir}/bin/"
+    chmod +x "${pkg_dir}/bin/ferrflow"
   fi
 
   # Copy package.json, README, and LICENSE


### PR DESCRIPTION
Closes #590.

Three npm-distribution polish items (adapted to the current `@ferrflow/*` package naming):

1. **`files` allowlist** — `npm/package.json` had no `files`, so the wrapper shipped everything under `npm/` (the `scripts/publish*.sh` tooling + the `platforms/*` stubs). Added `"files": ["bin"]`; `npm pack --dry-run` now ships only `bin/ferrflow.js` (+ auto-included README/LICENSE/package.json), with `platforms/` and `scripts/` excluded.
2. **Shim signal/error handling** — `bin/ferrflow.js` ignored `result.error` (ENOENT / not executable → bare exit 1, no message) and lost `result.signal` (binary killed by a signal → exit 1, signal dropped). Now it prints `result.error.message`, and on a signal exits the conventional `128 + signum` (via `os.constants.signals`).
3. **Smaller polish** — `"engines": { "node": ">=18" }` on the wrapper (ESM shim + `require.resolve`/`spawnSync`), and a defensive `chmod +x` on the extracted unix binary in `publish.sh`.

Item 3's platform gap (Windows arm64) is already handled by #591 / #607 (which also added Linux armv7), so it is intentionally out of scope here.

Validated: `package.json` JSON parses, `node --check` on the shim, `bash -n` on publish.sh, and `npm pack --dry-run` confirms the trimmed contents.