### PR TITLE
refactor(obs): migrate src/git/ logging to tracing macros

### DIFF
--- a/src/git/push.rs
+++ b/src/git/push.rs
@@ -181,7 +181,7 @@ fn shell_push_tags(repo: &Repository, remote_name: &str, tags: &[&str], force: b
         .ok_or_else(|| anyhow!("Remote '{remote_name}' has no URL"))?;
 
     let remote_shas = remote_tag_target_shas(workdir, &push_url, tags).unwrap_or_else(|err| {
-        eprintln!(
+        tracing::warn!(
             "  Warning: could not enumerate remote tag state ({err}); falling back to a plain push"
         );
         HashMap::new()
@@ -202,7 +202,7 @@ fn shell_push_tags(repo: &Repository, remote_name: &str, tags: &[&str], force: b
     }
 
     if !already_synced.is_empty() {
-        eprintln!(
+        tracing::info!(
             "  ↻ Already on remote at the same commit: {}",
             already_synced.join(", ")
         );
@@ -453,7 +453,7 @@ pub fn push(repo: &Repository, remote_name: &str, branch: &str, tags: &[&str]) -
                         .error_code(error_code::GIT_PUSH_BRANCH);
                 }
 
-                eprintln!(
+                tracing::warn!(
                     "Push rejected (non-fast-forward), rebasing on remote and retrying ({attempt}/{MAX_PUSH_RETRIES})..."
                 );
                 fetch_and_rebase(repo, remote_name, branch)?;

--- a/src/git/retry.rs
+++ b/src/git/retry.rs
@@ -16,7 +16,7 @@ where
         match op() {
             Ok(()) => {
                 if attempt > 1 {
-                    eprintln!(
+                    tracing::info!(
                         "{}",
                         format!("  ✓ {label} succeeded on attempt {attempt}/{MAX_ATTEMPTS}")
                             .green()
@@ -29,7 +29,7 @@ where
                 if !transient || attempt == MAX_ATTEMPTS {
                     return Err(err);
                 }
-                eprintln!(
+                tracing::warn!(
                     "{}",
                     format!(
                         "  ⚠ {label} attempt {attempt}/{MAX_ATTEMPTS} failed (transient): {err}; \

--- a/src/git/tags.rs
+++ b/src/git/tags.rs
@@ -316,7 +316,7 @@ pub(super) fn find_last_tag_with_cache(
         let commit_oid = match resolve_tag_to_commit(repo, raw_oid) {
             Some(oid) => oid,
             None => {
-                eprintln!(
+                tracing::warn!(
                     "Warning: tag '{}' points to missing commit {} (likely garbage-collected). Skipping.\n  \
                      Hint: set 'orphanedTagStrategy' to 'treeHash' or 'message' for automatic recovery.\n  \
                      See https://ferrflow.com/docs/configuration/config-file#orphaned-tag-strategy",
@@ -330,7 +330,7 @@ pub(super) fn find_last_tag_with_cache(
         let commit = match repo.find_commit(commit_oid) {
             Ok(c) => c,
             Err(_) => {
-                eprintln!(
+                tracing::warn!(
                     "Warning: tag '{}' points to missing commit {} (likely garbage-collected). Skipping.\n  \
                      Hint: set 'orphanedTagStrategy' to 'treeHash' or 'message' for automatic recovery.\n  \
                      See https://ferrflow.com/docs/configuration/config-file#orphaned-tag-strategy",
@@ -348,11 +348,12 @@ pub(super) fn find_last_tag_with_cache(
         } else {
             let short = &commit_oid.to_string()[..7].to_string();
             if strategy == OrphanedTagStrategy::Warn {
-                eprintln!(
+                tracing::warn!(
                     "Warning: tag '{}' points to orphaned commit {} (not reachable from HEAD).\n  \
                      Hint: set 'orphanedTagStrategy' to 'treeHash' or 'message' for automatic recovery.\n  \
                      See https://ferrflow.com/docs/configuration/config-file#orphaned-tag-strategy",
-                    tag_name, short
+                    tag_name,
+                    short
                 );
                 continue;
             }
@@ -363,7 +364,7 @@ pub(super) fn find_last_tag_with_cache(
                         OrphanedTagStrategy::Message => "message",
                         OrphanedTagStrategy::Warn => unreachable!(),
                     };
-                    eprintln!(
+                    tracing::info!(
                         "Info: tag '{}' was orphaned but matched commit {} on current branch via {}.",
                         tag_name,
                         &matched_oid.to_string()[..7],
@@ -384,10 +385,13 @@ pub(super) fn find_last_tag_with_cache(
                         OrphanedTagStrategy::Message => "message",
                         OrphanedTagStrategy::Warn => unreachable!(),
                     };
-                    eprintln!(
+                    tracing::warn!(
                         "Warning: tag '{}' points to orphaned commit {}. No match found via {}. Skipping.\n  \
                          Hint: re-tag manually with 'git tag -f {} <correct-commit>'",
-                        tag_name, short, strategy_name, tag_name
+                        tag_name,
+                        short,
+                        strategy_name,
+                        tag_name
                     );
                     continue;
                 }


### PR DESCRIPTION
Part of #513 — **stage 2** (migrate `src/git/` call sites). Stacked on #609 (the tracing foundation); review/merge **after** #609. GitHub will retarget this to `main` once #609 merges.

Migrates all 10 `eprintln!` sites in `src/git/` to `tracing` macros:
- `git/retry.rs` (2): retry success → `info!`, transient-failure retry → `warn!` (colored messages preserved — `colored` auto-disables ANSI when piped, so JSON stays clean).
- `git/push.rs` (3): remote-state enumeration failure → `warn!`, "already on remote" → `info!`, non-fast-forward rebase notice → `warn!`.
- `git/tags.rs` (5): orphaned/missing-commit tag warnings → `warn!`, the recovered-via-strategy notice → `info!`.

**Visual identity preserved**: each event keeps its exact original message text (prefixes, emojis, colors), so the human layer (which renders message-only) prints byte-for-byte what the `eprintln!` did. The level is chosen for filtering/JSON. No structured-field changes to the message.

Verified locally: `cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and the full `git::` test suite (87 passed) — no test asserted on the migrated stderr, so nothing broke.

Next stages: `src/monorepo/` (3), `src/forge/` + `src/hooks/` (4), JSON schema docs (5).