### PR TITLE
ci(release): make npm publish idempotent and harden the build matrix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,9 @@ jobs:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
+      # One flaky target (e.g. a transient crates.io download) must not cancel
+      # the other six and sink the whole release.
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-musl
@@ -76,12 +79,28 @@ jobs:
           rm /tmp/cross.tar.gz
       - name: Build (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: cross build --release --target ${{ matrix.target }}
+        shell: bash
+        run: |
+          n=0
+          until cross build --release --target ${{ matrix.target }}; do
+            n=$((n + 1))
+            [ "$n" -ge 3 ] && { echo "build failed after $n attempts" >&2; exit 1; }
+            echo "build attempt $n failed (likely a transient crate download); retrying in 15s..." >&2
+            sleep 15
+          done
         env:
           FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
       - name: Build (macOS / Windows)
         if: matrix.os != 'ubuntu-latest'
-        run: cargo build --release --target ${{ matrix.target }}
+        shell: bash
+        run: |
+          n=0
+          until cargo build --release --target ${{ matrix.target }}; do
+            n=$((n + 1))
+            [ "$n" -ge 3 ] && { echo "build failed after $n attempts" >&2; exit 1; }
+            echo "build attempt $n failed (likely a transient crate download); retrying in 15s..." >&2
+            sleep 15
+          done
         env:
           FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
       - name: Package (Unix)

--- a/npm/scripts/publish-wasm.sh
+++ b/npm/scripts/publish-wasm.sh
@@ -28,7 +28,11 @@ node -e "
   fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
 "
 
-echo "Publishing @ferrlabs/ferrflow-wasm@${VERSION}..."
-npm publish --access public
+if npm view "@ferrlabs/ferrflow-wasm@${VERSION}" version >/dev/null 2>&1; then
+  echo "@ferrlabs/ferrflow-wasm@${VERSION} already on registry — skipping"
+else
+  echo "Publishing @ferrlabs/ferrflow-wasm@${VERSION}..."
+  npm publish --access public
+fi
 
 echo "Published @ferrlabs/ferrflow-wasm@${VERSION}"

--- a/npm/scripts/publish.sh
+++ b/npm/scripts/publish.sh
@@ -18,6 +18,19 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 NPM_DIR="$(dirname "$SCRIPT_DIR")"
 WORK_DIR="$(mktemp -d)"
 
+# Publish the package in the current directory unless that exact version is
+# already on the registry. Makes a re-run after a partial failure safe (and a
+# release that adds a brand-new platform package skip the ones already pushed)
+# instead of dying on "cannot publish over the previously published version".
+publish_if_new() {
+  local name="$1"
+  if npm view "${name}@${VERSION}" version >/dev/null 2>&1; then
+    echo "  ${name}@${VERSION} already on registry — skipping"
+  else
+    npm publish --access public
+  fi
+}
+
 echo "Downloading release binaries for v${VERSION}..."
 
 for archive in "${!ARCHIVES[@]}"; do
@@ -44,7 +57,7 @@ for archive in "${!ARCHIVES[@]}"; do
   cp "${NPM_DIR}/../LICENSE" "${pkg_dir}/LICENSE" 2>/dev/null || true
   cd "$pkg_dir"
   npm version "$VERSION" --no-git-tag-version --allow-same-version
-  npm publish --access public
+  publish_if_new "@ferrflow/${platform}"
   cd - > /dev/null
 done
 
@@ -65,7 +78,7 @@ node -e "
   require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
 "
 
-npm publish --access public
+publish_if_new ferrflow
 
 echo "Publishing brand alias @ferrlabs/ferrflow@${VERSION}..."
 ALIAS_DIR="$(mktemp -d)"
@@ -76,7 +89,7 @@ node -e "
   pkg.name = '@ferrlabs/ferrflow';
   require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
 "
-npm publish --access public
+publish_if_new "@ferrlabs/ferrflow"
 cd - > /dev/null
 rm -rf "$ALIAS_DIR"
 


### PR DESCRIPTION
Closes #611.

Two release-pipeline fragilities exposed by v5.19.0:

1. **Build matrix too brittle.** A transient crate download on one target cancelled the other six (`fail-fast`) and failed the whole release. → `fail-fast: false` + a 3× retry around `cross build` / `cargo build` (transient crates.io hiccups self-heal instead of nuking the run).
2. **`publish.sh` not idempotent.** A partial npm publish couldn't be completed by re-running — it died on `cannot publish over the previously published version`. → a `publish_if_new` guard (`npm view <pkg>@<version>`) skips anything already on the registry, applied to the platform packages, wrapper, alias, and `publish-wasm.sh`. A re-run after a partial failure now finishes the remaining packages; a release adding a new platform skips the ones already pushed.

Validated: `bash -n` both scripts, YAML parses (fail-fast false, 7 targets).

Note: this lands on `main` so it benefits 5.20.0 onward; it does not retroactively change the `v5.19.0` tag's scripts.