### PR TITLE
refactor(obs): migrate src/monorepo/ diagnostics to tracing macros

### DIFF
--- a/src/monorepo/preview.rs
+++ b/src/monorepo/preview.rs
@@ -47,7 +47,7 @@ pub(super) fn post_preview_comment(repo: &Repository, config: &Config, root: &Pa
     })();
 
     if let Err(e) = result {
-        eprintln!("Warning: failed to post preview comment: {e}");
+        tracing::warn!("Warning: failed to post preview comment: {e}");
     }
 }
 

--- a/src/monorepo/release.rs
+++ b/src/monorepo/release.rs
@@ -103,7 +103,7 @@ pub fn release(
                     && crate::git::is_push_rejected_error(&e) =>
             {
                 eprintln!();
-                eprintln!(
+                tracing::warn!(
                     "{}",
                     format!(
                         "Release attempt {attempt}/{MAX_RELEASE_REGENERATE_ATTEMPTS} \
@@ -112,7 +112,7 @@ pub fn release(
                     )
                     .yellow()
                 );
-                eprintln!(
+                tracing::warn!(
                     "{}",
                     "Resetting working tree to remote tip and regenerating the release commit \
                      against the latest history…"

--- a/src/monorepo/run/drafts.rs
+++ b/src/monorepo/run/drafts.rs
@@ -42,7 +42,7 @@ pub(super) fn publish_pending_drafts(
                         tag.cyan()
                     ));
                 }
-                Err(err) => eprintln!(
+                Err(err) => tracing::warn!(
                     "{}",
                     format!("  Warning: failed to publish draft for {tag}: {err}").yellow()
                 ),
@@ -50,7 +50,7 @@ pub(super) fn publish_pending_drafts(
             Ok(None) => {}
             Err(err) => {
                 if verbose {
-                    eprintln!(
+                    tracing::warn!(
                         "{}",
                         format!("  Warning: failed to check draft release {tag}: {err}").yellow()
                     );

--- a/src/monorepo/run/execute.rs
+++ b/src/monorepo/run/execute.rs
@@ -101,14 +101,14 @@ pub(super) fn execute_release(plan: &mut ReleasePlan<'_>) -> Result<()> {
             }
             checkpoint_advance(plan, Phase::CommitDone)?;
         } else if plan.verbose {
-            eprintln!("  ↻ Resumed: skipping commit (already done)");
+            tracing::info!("  ↻ Resumed: skipping commit (already done)");
         }
         if !checkpoint_is_done(plan, Phase::TagsCreated) {
             create_release_tags(plan)?;
             create_and_move_floating_tags(plan, &mut floating_tag_names)?;
             checkpoint_advance(plan, Phase::TagsCreated)?;
         } else if plan.verbose {
-            eprintln!("  ↻ Resumed: skipping tag creation (already done)");
+            tracing::info!("  ↻ Resumed: skipping tag creation (already done)");
         }
     }
 
@@ -119,7 +119,7 @@ pub(super) fn execute_release(plan: &mut ReleasePlan<'_>) -> Result<()> {
             push_and_publish(plan, mode, &floating_tag_names)?;
             checkpoint_advance(plan, Phase::ReleasesCreated)?;
         } else if plan.verbose {
-            eprintln!("  ↻ Resumed: skipping push + publish (already done)");
+            tracing::info!("  ↻ Resumed: skipping push + publish (already done)");
         }
     }
 
@@ -128,7 +128,7 @@ pub(super) fn execute_release(plan: &mut ReleasePlan<'_>) -> Result<()> {
         run_post_publish_hooks(plan)?;
         checkpoint_advance(plan, Phase::PostPublishDone)?;
     } else if plan.verbose {
-        eprintln!("  ↻ Resumed: skipping post-publish hooks (already done)");
+        tracing::info!("  ↻ Resumed: skipping post-publish hooks (already done)");
     }
 
     Ok(())
@@ -265,7 +265,7 @@ fn run_commit_or_pr(
                                 Ok(()) => {
                                     plan.shared_outputs.push("✓ Auto-merge enabled".to_string())
                                 }
-                                Err(err) => eprintln!(
+                                Err(err) => tracing::warn!(
                                     "{}",
                                     format!("  Warning: failed to enable auto-merge: {err}")
                                         .yellow()
@@ -273,7 +273,7 @@ fn run_commit_or_pr(
                             }
                         }
                     }
-                    Err(err) => eprintln!(
+                    Err(err) => tracing::warn!(
                         "{}",
                         format!(
                             "  Warning: failed to create {}: {err}",
@@ -344,7 +344,7 @@ fn create_and_move_floating_tags(
                         ))
                         .error_code(error_code::MONOREPO_PUSH_FAILED)?;
                     }
-                    eprintln!(
+                    tracing::warn!(
                         "{}",
                         format!(
                             "  ⚠ Floating tag {} moves backward ({} → {})",
@@ -450,7 +450,7 @@ fn push_and_publish(
         for (tag_name, pkg_name, outcome) in outcomes {
             for warning in outcome.warnings {
                 if !warning.verbose_only || plan.verbose {
-                    eprintln!("{}", warning.message.yellow());
+                    tracing::warn!("{}", warning.message.yellow());
                 }
             }
             if let Some(result) = outcome.result {

--- a/src/monorepo/run/lock.rs
+++ b/src/monorepo/run/lock.rs
@@ -66,7 +66,7 @@ impl ReleaseLock {
             }
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                 if take_over_if_stale(&path)? {
-                    eprintln!(
+                    tracing::warn!(
                         "Warning: previous release lock at {} appeared stale; took it over.",
                         path.display()
                     );
@@ -95,7 +95,7 @@ impl ReleaseLock {
         let path = repo_root.join(".git").join("ferrflow.lock");
         if path.exists() {
             let _ = std::fs::remove_file(&path);
-            eprintln!(
+            tracing::warn!(
                 "Warning: --force-unlock removed existing lockfile at {}",
                 path.display()
             );

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -110,7 +110,7 @@ pub(super) fn run_release_logic(
         if let Err(e) = fetch
             && verbose
         {
-            eprintln!("Warning: could not fetch remote tags: {e}");
+            tracing::warn!("Warning: could not fetch remote tags: {e}");
         }
     }
 
@@ -587,7 +587,7 @@ pub(super) fn run_release_logic(
             match Checkpoint::load(root)? {
                 Some(existing) if existing.head_sha == head_sha => {
                     if verbose {
-                        eprintln!(
+                        tracing::info!(
                             "  ↻ Found in-progress release checkpoint at phase {:?}; resuming",
                             existing.phase
                         );


### PR DESCRIPTION
Part of #513 — stage 3 (src/monorepo/ diagnostics). Migrates the `eprintln!` stderr diagnostics to tracing; stdout reports and `--json` data stay as `println!` (command output, not logs).