### PR TITLE
fix(build): sync Cargo.lock to the 5.20.0 manifest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "5.19.0"
+version = "5.20.0"
 dependencies = [
  "anyhow",
  "cargo-husky",


### PR DESCRIPTION
## What

The v5.20.0 release commit bumped `Cargo.toml` to `version = "5.20.0"` but left the root `Cargo.lock` pinning `ferrflow 5.19.0`. The manifest and lockfile are out of sync, so `cargo build --locked` fails on `main`.

This runs `cargo update -p ferrflow --offline` and commits only the resulting one-line change so the lock's `ferrflow` entry becomes `5.20.0`.

## Diff scope

Limited to the single `ferrflow` version line in `Cargo.lock` — no unrelated dependency bumps.

## Context

This is the exact class of post-bump lockfile staleness that #498 (auto-update lockfiles after version bump) is meant to prevent. Until that lands, the lock has to be synced by hand after each release — which is what this PR does for 5.20.0.