### PR TITLE
feat(formats): auto-update lockfiles after version bump

### DIFF
--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -109,6 +109,11 @@
           "description": "Opt-in single-file source of truth for per-package versions, relative to the repo root (e.g. '.ferrflow.manifest.json'). When set, `ferrflow release` writes a full version snapshot to this file as part of the release commit, validates it against the versioned files at release start (a divergence is a hard error — run `ferrflow sync-manifest` to repair), and `status` / `version` read current versions from it. Omit to leave all behaviour unchanged.",
           "examples": [".ferrflow.manifest.json"]
         },
+        "updateLockfiles": {
+          "type": "boolean",
+          "description": "When true, after `ferrflow release` bumps a manifest (Cargo.toml, package.json, pyproject.toml, Gemfile, mix.exs) it refreshes the sibling lockfile (Cargo.lock, package-lock.json / pnpm-lock.yaml / yarn.lock, poetry.lock / uv.lock, Gemfile.lock, mix.lock) with the package manager's offline / lockfile-only mode and stages it in the same release commit. A missing package manager or an unresolvable offline update is warned about, never fatal. Set per-package `updateLockfiles: false` to opt a single package out.",
+          "default": false
+        },
         "registries": {
           "type": "object",
           "description": "Named registry credentials referenced by package.publishers[]. Lets users declare 'the Kellnr token lives in CARGO_REGISTRIES_KELLNR_TOKEN' once and reuse it across every cargo / npm / docker publisher.",
@@ -282,6 +287,10 @@
             "description": "Declarative publish targets evaluated after the GitHub Release is created. Each entry is a self-contained intent — see $defs/publisher for the kinds.",
             "items": { "$ref": "#/$defs/publisher" },
             "default": []
+          },
+          "updateLockfiles": {
+            "type": "boolean",
+            "description": "Per-package override for workspace.updateLockfiles. Set false to skip lockfile refresh for this package even when the workspace default is on; set true to refresh only this package when the workspace default is off. Omit to inherit the workspace setting."
           }
         },
         "additionalProperties": false

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -174,6 +174,7 @@ fn collect_package(path_default: &str, monorepo: bool) -> PackageConfig {
         hooks: None,
         floating_tags: None,
         publishers: vec![],
+        update_lockfiles: None,
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -229,6 +229,7 @@ impl Config {
                     hooks: None,
                     floating_tags: None,
                     publishers: vec![],
+                    update_lockfiles: None,
                 }]
             },
         }

--- a/src/config/package.rs
+++ b/src/config/package.rs
@@ -27,6 +27,8 @@ pub struct PackageConfig {
     /// follow-up PRs.
     #[serde(default)]
     pub publishers: Vec<PublisherConfig>,
+    #[serde(default, alias = "updateLockfiles")]
+    pub update_lockfiles: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Default)]
@@ -110,6 +112,10 @@ impl PackageConfig {
             Some(tags) => tags,
             None => &workspace.floating_tags,
         }
+    }
+
+    pub fn effective_update_lockfiles(&self, workspace: &WorkspaceConfig) -> bool {
+        self.update_lockfiles.unwrap_or(workspace.update_lockfiles)
     }
 }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -215,6 +215,7 @@ fn effective_versioning_inherits_workspace() {
         hooks: None,
         floating_tags: None,
         publishers: vec![],
+        update_lockfiles: None,
     };
     assert_eq!(
         pkg.effective_versioning(&ws, &[]),
@@ -240,6 +241,7 @@ fn effective_versioning_package_overrides() {
         hooks: None,
         floating_tags: None,
         publishers: vec![],
+        update_lockfiles: None,
     };
     assert_eq!(
         pkg.effective_versioning(&ws, &[]),
@@ -262,6 +264,7 @@ fn effective_versioning_autodetects_from_tags_when_unset() {
         hooks: None,
         floating_tags: None,
         publishers: vec![],
+        update_lockfiles: None,
     };
     let tags = vec!["v2024.04.18", "v2024.05.01"];
     assert_eq!(
@@ -285,6 +288,7 @@ fn effective_versioning_falls_back_to_semver_without_tags() {
         hooks: None,
         floating_tags: None,
         publishers: vec![],
+        update_lockfiles: None,
     };
     assert_eq!(
         pkg.effective_versioning(&ws, &[]),
@@ -309,6 +313,7 @@ fn make_pkg(name: &str, tag_template: Option<&str>) -> PackageConfig {
         hooks: None,
         floating_tags: None,
         publishers: vec![],
+        update_lockfiles: None,
     }
 }
 
@@ -348,6 +353,46 @@ fn tag_package_overrides_workspace() {
     let pkg = make_pkg("api", Some("{name}/v{version}"));
     assert_eq!(pkg.tag_for_version(&ws, true, "2.0.0"), "api/v2.0.0");
     assert_eq!(pkg.tag_prefix(&ws, true), "api/v");
+}
+
+#[test]
+fn update_lockfiles_defaults_off() {
+    let ws = WorkspaceConfig::default();
+    let pkg = make_pkg("api", None);
+    assert!(!pkg.effective_update_lockfiles(&ws));
+}
+
+#[test]
+fn update_lockfiles_inherits_workspace_when_unset() {
+    let ws = WorkspaceConfig {
+        update_lockfiles: true,
+        ..WorkspaceConfig::default()
+    };
+    let pkg = make_pkg("api", None);
+    assert!(pkg.effective_update_lockfiles(&ws));
+}
+
+#[test]
+fn update_lockfiles_package_opts_out() {
+    let ws = WorkspaceConfig {
+        update_lockfiles: true,
+        ..WorkspaceConfig::default()
+    };
+    let mut pkg = make_pkg("api", None);
+    pkg.update_lockfiles = Some(false);
+    assert!(!pkg.effective_update_lockfiles(&ws));
+}
+
+#[test]
+fn update_lockfiles_alias_parses() {
+    let cfg: Config = serde_json::from_str(
+        r#"{"workspace": {"updateLockfiles": true}, "package": [
+            {"name": "api", "path": ".", "updateLockfiles": false}
+        ]}"#,
+    )
+    .unwrap();
+    assert!(cfg.workspace.update_lockfiles);
+    assert_eq!(cfg.packages[0].update_lockfiles, Some(false));
 }
 
 #[test]
@@ -524,6 +569,7 @@ fn json_serializes_camel_case() {
             hooks: None,
             floating_tags: None,
             publishers: vec![],
+            update_lockfiles: None,
         }],
     };
     let serialized = handler.serialize(&config).unwrap();
@@ -571,6 +617,7 @@ fn toml_keeps_snake_case() {
             hooks: None,
             floating_tags: None,
             publishers: vec![],
+            update_lockfiles: None,
         }],
     };
     let serialized = handler.serialize(&config).unwrap();
@@ -1177,6 +1224,7 @@ fn tag_prefix_no_version_placeholder() {
         hooks: None,
         floating_tags: None,
         publishers: vec![],
+        update_lockfiles: None,
     };
     // When template has no {version}, prefix is the entire template
     assert_eq!(pkg.tag_prefix(&ws, false), "release-latest");
@@ -1197,6 +1245,7 @@ fn tag_for_version_replaces_placeholders() {
         hooks: None,
         floating_tags: None,
         publishers: vec![],
+        update_lockfiles: None,
     };
     assert_eq!(pkg.tag_for_version(&ws, true, "1.2.3"), "api/v1.2.3");
 }

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -67,6 +67,18 @@ pub struct WorkspaceConfig {
     /// from it. `None` (default) leaves all behaviour unchanged.
     #[serde(default, alias = "manifestFile")]
     pub manifest_file: Option<String>,
+    /// Opt-in lockfile auto-refresh. When `true`, after `ferrflow
+    /// release` bumps a manifest (`Cargo.toml`, `package.json`,
+    /// `pyproject.toml`, `Gemfile`, `mix.exs`) it refreshes the sibling
+    /// lockfile (`Cargo.lock`, `package-lock.json` / `pnpm-lock.yaml` /
+    /// `yarn.lock`, `poetry.lock` / `uv.lock`, `Gemfile.lock`,
+    /// `mix.lock`) with the package manager's offline / lockfile-only
+    /// mode and stages it in the same release commit. Default `false`
+    /// (no behaviour change). A missing package manager or an
+    /// unresolvable offline update is warned about, never fatal. Set
+    /// `package.updateLockfiles = false` to opt a single package out.
+    #[serde(default, alias = "updateLockfiles")]
+    pub update_lockfiles: bool,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]

--- a/src/formats/lockfiles.rs
+++ b/src/formats/lockfiles.rs
@@ -1,0 +1,270 @@
+use std::path::{Path, PathBuf};
+
+use super::join_within_repo;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Manifest {
+    CargoToml,
+    PackageJson,
+    PyprojectToml,
+    Gemfile,
+    MixExs,
+}
+
+impl Manifest {
+    pub fn from_manifest_filename(filename: &str) -> Option<Self> {
+        match filename {
+            "Cargo.toml" => Some(Self::CargoToml),
+            "package.json" => Some(Self::PackageJson),
+            "pyproject.toml" => Some(Self::PyprojectToml),
+            "Gemfile" => Some(Self::Gemfile),
+            "mix.exs" => Some(Self::MixExs),
+            _ => None,
+        }
+    }
+
+    fn lockfiles(self) -> &'static [Lockfile] {
+        match self {
+            Self::CargoToml => &[Lockfile {
+                filename: "Cargo.lock",
+                program: "cargo",
+                base_args: &["update"],
+                update_kind: UpdateKind::PerPackage,
+            }],
+            Self::PackageJson => &[
+                Lockfile {
+                    filename: "package-lock.json",
+                    program: "npm",
+                    base_args: &["install", "--package-lock-only"],
+                    update_kind: UpdateKind::Whole,
+                },
+                Lockfile {
+                    filename: "pnpm-lock.yaml",
+                    program: "pnpm",
+                    base_args: &["install", "--lockfile-only"],
+                    update_kind: UpdateKind::Whole,
+                },
+                Lockfile {
+                    filename: "yarn.lock",
+                    program: "yarn",
+                    base_args: &["install", "--mode=update-lockfile"],
+                    update_kind: UpdateKind::Whole,
+                },
+            ],
+            Self::PyprojectToml => &[
+                Lockfile {
+                    filename: "poetry.lock",
+                    program: "poetry",
+                    base_args: &["lock", "--no-update"],
+                    update_kind: UpdateKind::Whole,
+                },
+                Lockfile {
+                    filename: "uv.lock",
+                    program: "uv",
+                    base_args: &["lock", "--offline"],
+                    update_kind: UpdateKind::Whole,
+                },
+            ],
+            Self::Gemfile => &[Lockfile {
+                filename: "Gemfile.lock",
+                program: "bundle",
+                base_args: &["lock"],
+                update_kind: UpdateKind::Whole,
+            }],
+            Self::MixExs => &[Lockfile {
+                filename: "mix.lock",
+                program: "mix",
+                base_args: &["deps.get"],
+                update_kind: UpdateKind::Whole,
+            }],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum UpdateKind {
+    PerPackage,
+    Whole,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Lockfile {
+    filename: &'static str,
+    program: &'static str,
+    base_args: &'static [&'static str],
+    update_kind: UpdateKind,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum UpdateOutcome {
+    Updated { lockfile_rel: String },
+    NoLockfile,
+    NotOnPath { program: String },
+    UnsupportedManifest,
+    Failed { program: String, detail: String },
+}
+
+pub fn update_for_manifest(
+    repo_root: &Path,
+    manifest_rel: &str,
+    package_name: &str,
+) -> anyhow::Result<UpdateOutcome> {
+    let manifest_path = join_within_repo(repo_root, manifest_rel)?;
+    let filename = match manifest_path.file_name().and_then(|n| n.to_str()) {
+        Some(name) => name,
+        None => return Ok(UpdateOutcome::UnsupportedManifest),
+    };
+    let Some(manifest) = Manifest::from_manifest_filename(filename) else {
+        return Ok(UpdateOutcome::UnsupportedManifest);
+    };
+
+    let manifest_dir = manifest_path.parent().unwrap_or(repo_root);
+
+    for lockfile in manifest.lockfiles() {
+        let Some(lockfile_path) = locate_lockfile(repo_root, manifest_dir, lockfile.filename)
+        else {
+            continue;
+        };
+        return Ok(run_update(
+            repo_root,
+            &lockfile_path,
+            lockfile,
+            package_name,
+        ));
+    }
+
+    Ok(UpdateOutcome::NoLockfile)
+}
+
+fn locate_lockfile(repo_root: &Path, manifest_dir: &Path, filename: &str) -> Option<PathBuf> {
+    let mut dir = manifest_dir;
+    loop {
+        let candidate = dir.join(filename);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if dir == repo_root {
+            return None;
+        }
+        match dir.parent() {
+            Some(parent) => dir = parent,
+            None => return None,
+        }
+    }
+}
+
+fn run_update(
+    repo_root: &Path,
+    lockfile_path: &Path,
+    lockfile: &Lockfile,
+    package_name: &str,
+) -> UpdateOutcome {
+    let lockfile_dir = lockfile_path.parent().unwrap_or(repo_root);
+
+    let mut cmd = std::process::Command::new(lockfile.program);
+    cmd.current_dir(lockfile_dir);
+    cmd.args(lockfile.base_args);
+    if let UpdateKind::PerPackage = lockfile.update_kind {
+        cmd.arg("-p").arg(package_name).arg("--offline");
+    }
+
+    let output = match cmd.output() {
+        Ok(output) => output,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return UpdateOutcome::NotOnPath {
+                program: lockfile.program.to_string(),
+            };
+        }
+        Err(err) => {
+            return UpdateOutcome::Failed {
+                program: lockfile.program.to_string(),
+                detail: err.to_string(),
+            };
+        }
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return UpdateOutcome::Failed {
+            program: lockfile.program.to_string(),
+            detail: first_meaningful_line(&stderr),
+        };
+    }
+
+    let lockfile_rel = lockfile_path
+        .strip_prefix(repo_root)
+        .unwrap_or(lockfile_path)
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    UpdateOutcome::Updated { lockfile_rel }
+}
+
+fn first_meaningful_line(text: &str) -> String {
+    text.lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or("")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_manifest_kind_from_filename() {
+        assert_eq!(
+            Manifest::from_manifest_filename("Cargo.toml"),
+            Some(Manifest::CargoToml)
+        );
+        assert_eq!(
+            Manifest::from_manifest_filename("package.json"),
+            Some(Manifest::PackageJson)
+        );
+        assert_eq!(Manifest::from_manifest_filename("Chart.yaml"), None);
+    }
+
+    #[test]
+    fn unsupported_manifest_is_a_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("Chart.yaml"), "version: 1.0.0\n").unwrap();
+        let outcome = update_for_manifest(dir.path(), "Chart.yaml", "app").unwrap();
+        assert_eq!(outcome, UpdateOutcome::UnsupportedManifest);
+    }
+
+    #[test]
+    fn no_lockfile_when_sibling_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"app\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        let outcome = update_for_manifest(dir.path(), "Cargo.toml", "app").unwrap();
+        assert_eq!(outcome, UpdateOutcome::NoLockfile);
+    }
+
+    #[test]
+    fn locate_lockfile_walks_up_to_repo_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let member = root.join("crates").join("app");
+        std::fs::create_dir_all(&member).unwrap();
+        std::fs::write(root.join("Cargo.lock"), "# lock\n").unwrap();
+
+        let found = locate_lockfile(root, &member, "Cargo.lock").unwrap();
+        assert_eq!(found, root.join("Cargo.lock"));
+    }
+
+    #[test]
+    fn locate_lockfile_does_not_escape_repo_root() {
+        let outer = tempfile::tempdir().unwrap();
+        std::fs::write(outer.path().join("Cargo.lock"), "# lock\n").unwrap();
+        let repo_root = outer.path().join("repo");
+        let member = repo_root.join("crates").join("app");
+        std::fs::create_dir_all(&member).unwrap();
+
+        assert!(locate_lockfile(&repo_root, &member, "Cargo.lock").is_none());
+    }
+}

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -5,6 +5,8 @@ pub mod gomod;
 pub mod gradle;
 pub mod helm;
 pub mod json;
+#[cfg(feature = "cli")]
+pub mod lockfiles;
 pub mod mix_exs;
 pub mod package_swift;
 pub mod pubspec_yaml;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -274,6 +274,7 @@ mod tests {
             hooks: None,
             floating_tags: None,
             publishers: vec![],
+            update_lockfiles: None,
         }
     }
 

--- a/src/monorepo/run/cascade.rs
+++ b/src/monorepo/run/cascade.rs
@@ -155,6 +155,14 @@ pub(super) fn run_dependency_cascade(
                             .or_default()
                             .push(changelog_rel.clone());
                     }
+                    if pkg.effective_update_lockfiles(&config.workspace) {
+                        super::refresh_lockfiles(
+                            pkg,
+                            root,
+                            sink.files_to_commit,
+                            sink.files_per_package.entry(pkg.name.clone()).or_default(),
+                        );
+                    }
                 }
                 sink.pkg_outputs.push((pkg.name.clone(), lines));
             }

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -435,6 +435,15 @@ pub(super) fn run_release_logic(
                 }
             }
 
+            if pkg.effective_update_lockfiles(&config.workspace) {
+                refresh_lockfiles(
+                    pkg,
+                    root,
+                    &mut files_to_commit,
+                    files_per_package.entry(pkg.name.clone()).or_default(),
+                );
+            }
+
             let changelog_render = ChangelogRender {
                 config: config.workspace.changelog.as_ref(),
                 forge_base: forge_base.clone(),
@@ -784,5 +793,41 @@ fn finish(dry_run: bool, out: RunOutput) -> Result<Option<RunOutput>> {
     } else {
         out.print();
         Ok(None)
+    }
+}
+
+pub(super) fn refresh_lockfiles(
+    pkg: &PackageConfig,
+    root: &Path,
+    files_to_commit: &mut Vec<String>,
+    pkg_files: &mut Vec<String>,
+) {
+    use crate::formats::lockfiles::{self, UpdateOutcome};
+
+    let mut handled: HashSet<String> = HashSet::new();
+    for vf in &pkg.versioned_files {
+        let outcome = match lockfiles::update_for_manifest(root, &vf.path, &pkg.name) {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                tracing::warn!(package = %pkg.name, manifest = %vf.path, error = %err, "lockfile update skipped");
+                continue;
+            }
+        };
+        match outcome {
+            UpdateOutcome::Updated { lockfile_rel } => {
+                if handled.insert(lockfile_rel.clone()) {
+                    tracing::info!(package = %pkg.name, lockfile = %lockfile_rel, "refreshed lockfile");
+                    files_to_commit.push(lockfile_rel.clone());
+                    pkg_files.push(lockfile_rel);
+                }
+            }
+            UpdateOutcome::NotOnPath { program } => {
+                tracing::warn!(package = %pkg.name, program = %program, "package manager not on PATH; lockfile left stale");
+            }
+            UpdateOutcome::Failed { program, detail } => {
+                tracing::warn!(package = %pkg.name, program = %program, detail = %detail, "lockfile update failed; lockfile left stale");
+            }
+            UpdateOutcome::NoLockfile | UpdateOutcome::UnsupportedManifest => {}
+        }
     }
 }

--- a/src/monorepo/tests.rs
+++ b/src/monorepo/tests.rs
@@ -530,6 +530,7 @@ fn make_pkg(name: &str, path: &str, shared: &[&str]) -> PackageConfig {
         hooks: None,
         floating_tags: None,
         publishers: vec![],
+        update_lockfiles: None,
     }
 }
 
@@ -676,4 +677,220 @@ fn parse_force_version_invalid_semver() {
     let fv = "not-a-version";
     let clean = fv.strip_prefix('v').unwrap_or(fv);
     assert!(semver::Version::parse(clean).is_err());
+}
+
+mod lockfile_flow {
+    use crate::formats::lockfiles::{self, UpdateOutcome};
+    use crate::test_utils::{commit_file, git, init_repo, with_cwd};
+    use crate::timing::Timing;
+    use std::path::Path;
+
+    fn program_on_path(program: &str) -> bool {
+        std::process::Command::new(program)
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    fn add_bare_remote(dir: &Path) -> tempfile::TempDir {
+        let bare = tempfile::tempdir().unwrap();
+        git(dir, &["init", "--bare", &bare.path().to_string_lossy()]);
+        git(
+            dir,
+            &["remote", "add", "origin", &bare.path().to_string_lossy()],
+        );
+        bare
+    }
+
+    fn write_cargo_workspace(dir: &Path) {
+        std::fs::write(
+            dir.join("Cargo.toml"),
+            "[workspace]\nresolver = \"2\"\nmembers = [\"crates/alpha\", \"crates/beta\"]\n",
+        )
+        .unwrap();
+        for member in ["alpha", "beta"] {
+            let crate_dir = dir.join("crates").join(member);
+            std::fs::create_dir_all(crate_dir.join("src")).unwrap();
+            std::fs::write(
+                crate_dir.join("Cargo.toml"),
+                format!("[package]\nname = \"{member}\"\nversion = \"1.0.0\"\nedition = \"2021\"\n\n[dependencies]\n"),
+            )
+            .unwrap();
+            std::fs::write(crate_dir.join("src").join("lib.rs"), "").unwrap();
+        }
+        std::fs::write(
+            dir.join(".ferrflow"),
+            r#"{"workspace": {"releaseCommitMode": "commit", "updateLockfiles": true}, "package": [
+                {"name": "alpha", "path": "crates/alpha", "versionedFiles": [{"path": "crates/alpha/Cargo.toml", "format": "toml"}], "changelog": "crates/alpha/CHANGELOG.md"},
+                {"name": "beta", "path": "crates/beta", "versionedFiles": [{"path": "crates/beta/Cargo.toml", "format": "toml"}], "changelog": "crates/beta/CHANGELOG.md"}
+            ]}"#,
+        )
+        .unwrap();
+    }
+
+    fn run_release(dir: &Path) -> anyhow::Result<()> {
+        let config = dir.join(".ferrflow");
+        with_cwd(dir, || {
+            crate::monorepo::release(
+                Some(&config),
+                false,
+                false,
+                false,
+                false,
+                None,
+                None,
+                false,
+                false,
+                &mut Timing::new(false),
+            )
+        })
+    }
+
+    fn alpha_version_in_lock(lock: &str) -> Option<String> {
+        let mut in_alpha = false;
+        for line in lock.lines() {
+            let line = line.trim();
+            if line == "[[package]]" {
+                in_alpha = false;
+            } else if line == "name = \"alpha\"" {
+                in_alpha = true;
+            } else if in_alpha && let Some(v) = line.strip_prefix("version = \"") {
+                return Some(v.trim_end_matches('"').to_string());
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn cargo_workspace_refreshes_only_bumped_member() {
+        if !program_on_path("cargo") {
+            return;
+        }
+        let (dir, _repo) = init_repo();
+        let root = dir.path();
+        write_cargo_workspace(root);
+
+        let gen_lock = std::process::Command::new("cargo")
+            .current_dir(root)
+            .args(["generate-lockfile", "--offline"])
+            .output()
+            .unwrap();
+        assert!(
+            gen_lock.status.success(),
+            "generate-lockfile failed: {}",
+            String::from_utf8_lossy(&gen_lock.stderr)
+        );
+
+        commit_file(root, "seed.txt", "x", "chore: seed", 1_970_000_000);
+        commit_file(
+            root,
+            "crates/alpha/feature.txt",
+            "y",
+            "feat: alpha change",
+            1_970_000_001,
+        );
+        let _remote = add_bare_remote(root);
+
+        let before = std::fs::read_to_string(root.join("Cargo.lock")).unwrap();
+        assert_eq!(alpha_version_in_lock(&before).as_deref(), Some("1.0.0"));
+        let beta_before = before.contains("name = \"beta\"");
+
+        run_release(root).unwrap();
+
+        let after = std::fs::read_to_string(root.join("Cargo.lock")).unwrap();
+        assert_eq!(
+            alpha_version_in_lock(&after).as_deref(),
+            Some("1.1.0"),
+            "alpha entry must reflect the bump in Cargo.lock"
+        );
+        assert_eq!(
+            beta_before,
+            after.contains("name = \"beta\""),
+            "beta entry must be untouched"
+        );
+
+        let committed = git(root, &["show", "--name-only", "--format=", "HEAD"]);
+        assert!(
+            committed.contains("Cargo.lock"),
+            "refreshed Cargo.lock must land in the release commit, got: {committed}"
+        );
+    }
+
+    #[test]
+    fn disabled_leaves_lockfile_untouched() {
+        if !program_on_path("cargo") {
+            return;
+        }
+        let (dir, _repo) = init_repo();
+        let root = dir.path();
+        write_cargo_workspace(root);
+        std::fs::write(
+            root.join(".ferrflow"),
+            r#"{"workspace": {"releaseCommitMode": "commit"}, "package": [
+                {"name": "alpha", "path": "crates/alpha", "versionedFiles": [{"path": "crates/alpha/Cargo.toml", "format": "toml"}], "changelog": "crates/alpha/CHANGELOG.md"},
+                {"name": "beta", "path": "crates/beta", "versionedFiles": [{"path": "crates/beta/Cargo.toml", "format": "toml"}], "changelog": "crates/beta/CHANGELOG.md"}
+            ]}"#,
+        )
+        .unwrap();
+
+        let gen_lock = std::process::Command::new("cargo")
+            .current_dir(root)
+            .args(["generate-lockfile", "--offline"])
+            .output()
+            .unwrap();
+        assert!(gen_lock.status.success());
+
+        commit_file(root, "seed.txt", "x", "chore: seed", 1_971_000_000);
+        commit_file(
+            root,
+            "crates/alpha/feature.txt",
+            "y",
+            "feat: alpha change",
+            1_971_000_001,
+        );
+        let _remote = add_bare_remote(root);
+
+        let before = std::fs::read_to_string(root.join("Cargo.lock")).unwrap();
+
+        run_release(root).unwrap();
+
+        let after = std::fs::read_to_string(root.join("Cargo.lock")).unwrap();
+        assert_eq!(
+            before, after,
+            "Cargo.lock must be byte-identical when updateLockfiles is unset"
+        );
+
+        let committed = git(root, &["show", "--name-only", "--format=", "HEAD"]);
+        assert!(
+            !committed.contains("Cargo.lock"),
+            "Cargo.lock must not be staged when the feature is off, got: {committed}"
+        );
+    }
+
+    #[test]
+    fn missing_package_manager_is_not_fatal() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("mix.exs"),
+            "defmodule App.MixProject do\nend\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("mix.lock"), "%{}\n").unwrap();
+
+        let outcome = lockfiles::update_for_manifest(dir.path(), "mix.exs", "app").unwrap();
+        if program_on_path("mix") {
+            assert!(matches!(
+                outcome,
+                UpdateOutcome::Updated { .. } | UpdateOutcome::Failed { .. }
+            ));
+        } else {
+            assert_eq!(
+                outcome,
+                UpdateOutcome::NotOnPath {
+                    program: "mix".to_string()
+                }
+            );
+        }
+    }
 }

--- a/src/validate/tests.rs
+++ b/src/validate/tests.rs
@@ -24,6 +24,7 @@ fn make_package(name: &str, path: &str) -> PackageConfig {
         tag_template: None,
         floating_tags: None,
         publishers: vec![],
+        update_lockfiles: None,
         hooks: None,
     }
 }


### PR DESCRIPTION
Closes #498.

## What

Opt-in auto-refresh of the sibling lockfile after `ferrflow release` bumps a manifest, so downstream `cargo build --locked` / `npm ci` don't break on a stale lock. Default OFF — a repo that doesn't set `updateLockfiles` sees zero behaviour change.

## Dispatch table

New module `src/formats/lockfiles.rs` models manifest → lockfile → updater as an enum + struct table (not stringly-typed):

| Manifest | Lockfile | Command |
|---|---|---|
| Cargo.toml | Cargo.lock | `cargo update -p <pkg> --offline` |
| package.json | package-lock.json | `npm install --package-lock-only` |
| package.json | pnpm-lock.yaml | `pnpm install --lockfile-only` |
| package.json | yarn.lock | `yarn install --mode=update-lockfile` |
| pyproject.toml | poetry.lock | `poetry lock --no-update` |
| pyproject.toml | uv.lock | `uv lock --offline` |
| Gemfile | Gemfile.lock | `bundle lock` |
| mix.exs | mix.lock | `mix deps.get` |

The lockfile is detected by walking up from the manifest's directory to the repo root (lexically contained — reuses `join_within_repo`), so a monorepo's single shared root `Cargo.lock` / pnpm-workspace lock is found from a nested member manifest. For Cargo the per-package `cargo update -p <pkg>` runs incrementally against the shared lock — no N redundant full updates; a shared lockfile is also deduped within a package so it's refreshed once.

## Config (opt-in)

- Workspace: `updateLockfiles: bool` (default `false`), snake_case field with `alias = "updateLockfiles"`, matching the existing serde convention.
- Per-package opt-out: `package.updateLockfiles: Option<bool>` — `Some(false)` skips a single package even when the workspace default is on; `None` inherits. Resolver `PackageConfig::effective_update_lockfiles` mirrors `effective_floating_tags` / `effective_skip_ci`.

## Integration point

`src/monorepo/run/mod.rs::run_release_logic` — after the `versioned_files` `write_version` loop succeeds and before the changelog/commit step, gated on `effective_update_lockfiles`. The refreshed lockfile's repo-relative path is pushed onto both `files_to_commit` and `files_per_package` so it lands in the same release commit. The dependency-cascade write path (`run/cascade.rs`) gets the same treatment via the shared `refresh_lockfiles` helper.

## Robustness

- Package manager not on PATH → `tracing::warn!` and skip (release continues).
- Offline update can't resolve / non-zero exit → `tracing::warn!` with the first stderr line, never fatal.
- All commands use offline / lockfile-only modes — no network.
- New diagnostics use `tracing::warn!` / `info!` (the tracing foundation already on main), kept in the write-version/commit area to avoid colliding with the concurrent `eprintln!`→`tracing` migration.

## Tests

- Real Cargo-workspace fixture: bumping one member runs `cargo update -p <pkg> --offline` and **only** that member's entry changes in `Cargo.lock`; the refreshed lock lands in the release commit.
- `updateLockfiles` unset → `Cargo.lock` byte-identical, not staged (no package-manager invocation in effect).
- Missing-package-manager path asserts the `NotOnPath` skip (gated on whether the tool is present, so it's a real assertion in both environments).
- Config resolver unit tests (default off / inherit / per-package opt-out / camelCase alias parsing).
- Module unit tests for manifest detection, sibling absent, walk-up to repo root, and no-escape past root.

Tested live against `cargo` (available in CI/dev). The npm/pnpm/yarn/poetry/uv/bundle/mix paths share the same dispatch + spawn code path and are covered by the unit tests and the gated "not on PATH" assertion; the full per-manager integration is not run here as those toolchains aren't guaranteed in the test env.

## Cross-repo follow-ups (cannot land here)

- `schema/ferrflow.json` is updated in this PR (source of truth). The byte-identical copy at `FerrFlow-Cloud/packages/site/public/schema/ferrflow.json` must be synced in a follow-up PR on that repo.
- Docs: add `updateLockfiles` (workspace + per-package opt-out) to `FerrFlow-Cloud/packages/site/.../config-file.md`.
- Per repo convention, a tracking issue on `FerrLabs/FerrFlow-Cloud` for the docs + schema-copy + playground work.
