### PR TITLE
feat(monorepo): detect dependency cycles and release in topological order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrflow"
-version = "5.20.0"
+version = "5.21.0"
 dependencies = [
  "anyhow",
  "cargo-husky",

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -349,3 +349,11 @@ A package referenced during release was not found in the configuration.
 ### E8002: Floating tag backward move
 
 A floating tag would move to an older version. Use `--force` to override.
+
+### E8003: Dependency cycle
+
+Two or more packages depend on each other through `dependsOn`, directly or
+transitively, so there is no order in which to release them. The error names the
+cycle, e.g. `cycle detected: api → web → api`. Break the loop by removing one of
+the `dependsOn` edges. The check runs before any version is written, so a cyclic
+configuration never produces a partial release.

--- a/src/error_code.rs
+++ b/src/error_code.rs
@@ -278,6 +278,8 @@ pub const QUERY_PACKAGE_NOT_FOUND: ErrorCode = ErrorCode(7002);
 pub const MONOREPO_PACKAGE_NOT_FOUND: ErrorCode = ErrorCode(8001);
 #[allow(dead_code)]
 pub const MONOREPO_PUSH_FAILED: ErrorCode = ErrorCode(8002);
+#[allow(dead_code)]
+pub const MONOREPO_DEPENDENCY_CYCLE: ErrorCode = ErrorCode(8003);
 
 #[cfg(test)]
 mod tests {

--- a/src/monorepo/run/graph.rs
+++ b/src/monorepo/run/graph.rs
@@ -1,0 +1,234 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::config::PackageConfig;
+use crate::error_code;
+
+#[derive(Debug)]
+pub(super) struct Cycle {
+    path: Vec<String>,
+}
+
+impl Cycle {
+    pub(super) fn into_error(self) -> anyhow::Error {
+        let mut rendered = self.path;
+        if let Some(first) = rendered.first().cloned() {
+            rendered.push(first);
+        }
+        anyhow::anyhow!("cycle detected: {}", rendered.join(" → "))
+            .context(error_code::MONOREPO_DEPENDENCY_CYCLE)
+    }
+}
+
+pub(super) fn release_order(packages: &[PackageConfig]) -> Result<Vec<usize>, Cycle> {
+    let index_of: HashMap<&str, usize> = packages
+        .iter()
+        .enumerate()
+        .map(|(i, pkg)| (pkg.name.as_str(), i))
+        .collect();
+
+    let adjacency: Vec<Vec<usize>> = packages
+        .iter()
+        .map(|pkg| {
+            pkg.depends_on
+                .iter()
+                .filter_map(|dep| index_of.get(dep.as_str()).copied())
+                .collect()
+        })
+        .collect();
+
+    let mut order = Vec::with_capacity(packages.len());
+    for component in tarjan_sccs(&adjacency) {
+        let is_cycle = component.len() > 1 || adjacency[component[0]].contains(&component[0]);
+        if is_cycle {
+            let path = cycle_path(&adjacency, &component)
+                .into_iter()
+                .map(|i| packages[i].name.clone())
+                .collect();
+            return Err(Cycle { path });
+        }
+        order.push(component[0]);
+    }
+    Ok(order)
+}
+
+fn tarjan_sccs(adjacency: &[Vec<usize>]) -> Vec<Vec<usize>> {
+    struct Walk<'a> {
+        adjacency: &'a [Vec<usize>],
+        next_index: usize,
+        index: Vec<Option<usize>>,
+        lowlink: Vec<usize>,
+        on_stack: Vec<bool>,
+        stack: Vec<usize>,
+        components: Vec<Vec<usize>>,
+    }
+
+    impl Walk<'_> {
+        fn connect(&mut self, v: usize) {
+            self.index[v] = Some(self.next_index);
+            self.lowlink[v] = self.next_index;
+            self.next_index += 1;
+            self.stack.push(v);
+            self.on_stack[v] = true;
+
+            for w in self.adjacency[v].clone() {
+                match self.index[w] {
+                    None => {
+                        self.connect(w);
+                        self.lowlink[v] = self.lowlink[v].min(self.lowlink[w]);
+                    }
+                    Some(w_index) if self.on_stack[w] => {
+                        self.lowlink[v] = self.lowlink[v].min(w_index);
+                    }
+                    Some(_) => {}
+                }
+            }
+
+            if self.lowlink[v] == self.index[v].expect("v was just indexed") {
+                let mut component = Vec::new();
+                loop {
+                    let w = self.stack.pop().expect("stack holds at least v");
+                    self.on_stack[w] = false;
+                    component.push(w);
+                    if w == v {
+                        break;
+                    }
+                }
+                self.components.push(component);
+            }
+        }
+    }
+
+    let n = adjacency.len();
+    let mut walk = Walk {
+        adjacency,
+        next_index: 0,
+        index: vec![None; n],
+        lowlink: vec![0; n],
+        on_stack: vec![false; n],
+        stack: Vec::new(),
+        components: Vec::new(),
+    };
+    for v in 0..n {
+        if walk.index[v].is_none() {
+            walk.connect(v);
+        }
+    }
+    walk.components
+}
+
+fn cycle_path(adjacency: &[Vec<usize>], component: &[usize]) -> Vec<usize> {
+    let members: HashSet<usize> = component.iter().copied().collect();
+    let start = component[0];
+
+    let mut path = vec![start];
+    let mut current = start;
+    loop {
+        let next = adjacency[current]
+            .iter()
+            .copied()
+            .find(|w| members.contains(w))
+            .expect("a node in a strongly connected component has an in-component edge");
+        if let Some(pos) = path.iter().position(|&n| n == next) {
+            return path[pos..].to_vec();
+        }
+        path.push(next);
+        current = next;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pkg(name: &str, deps: &[&str]) -> PackageConfig {
+        PackageConfig {
+            name: name.to_string(),
+            path: name.to_string(),
+            versioned_files: vec![],
+            changelog: None,
+            shared_paths: vec![],
+            depends_on: deps.iter().map(|s| s.to_string()).collect(),
+            update_lockfiles: None,
+            versioning: None,
+            tag_template: None,
+            floating_tags: None,
+            hooks: None,
+            publishers: vec![],
+        }
+    }
+
+    fn names(packages: &[PackageConfig], order: &[usize]) -> Vec<String> {
+        order.iter().map(|&i| packages[i].name.clone()).collect()
+    }
+
+    fn cycle_message(err: &anyhow::Error) -> String {
+        err.chain()
+            .map(|cause| cause.to_string())
+            .find(|m| m.starts_with("cycle detected"))
+            .expect("a cycle message in the error chain")
+    }
+
+    #[test]
+    fn no_dependencies_preserves_config_order() {
+        let pkgs = [pkg("a", &[]), pkg("b", &[]), pkg("c", &[])];
+        let order = release_order(&pkgs).expect("acyclic");
+        assert_eq!(names(&pkgs, &order), ["a", "b", "c"]);
+    }
+
+    #[test]
+    fn dependency_is_released_before_its_dependent() {
+        let pkgs = [pkg("web", &["api"]), pkg("api", &[])];
+        let order = release_order(&pkgs).expect("acyclic");
+        assert_eq!(names(&pkgs, &order), ["api", "web"]);
+    }
+
+    #[test]
+    fn linear_chain_orders_deepest_dependency_first() {
+        let pkgs = [pkg("a", &["b"]), pkg("b", &["c"]), pkg("c", &[])];
+        let order = release_order(&pkgs).expect("acyclic");
+        assert_eq!(names(&pkgs, &order), ["c", "b", "a"]);
+    }
+
+    #[test]
+    fn unknown_dependency_names_are_ignored() {
+        let pkgs = [pkg("a", &["ghost"]), pkg("b", &[])];
+        let order = release_order(&pkgs).expect("acyclic");
+        assert_eq!(names(&pkgs, &order), ["a", "b"]);
+    }
+
+    #[test]
+    fn two_package_cycle_is_rejected() {
+        let pkgs = [pkg("a", &["b"]), pkg("b", &["a"])];
+        let err = release_order(&pkgs).unwrap_err().into_error();
+        assert_eq!(
+            err.downcast_ref::<error_code::ErrorCode>().map(|c| c.0),
+            Some(8003)
+        );
+        let msg = cycle_message(&err);
+        assert!(
+            msg == "cycle detected: a → b → a" || msg == "cycle detected: b → a → b",
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn self_dependency_is_rejected() {
+        let pkgs = [pkg("a", &["a"])];
+        let err = release_order(&pkgs).unwrap_err().into_error();
+        assert_eq!(cycle_message(&err), "cycle detected: a → a");
+    }
+
+    #[test]
+    fn three_package_cycle_renders_full_path() {
+        let pkgs = [pkg("a", &["b"]), pkg("b", &["c"]), pkg("c", &["a"])];
+        let err = release_order(&pkgs).unwrap_err().into_error();
+        let msg = cycle_message(&err);
+        let path = msg
+            .trim_start_matches("cycle detected: ")
+            .split(" → ")
+            .collect::<Vec<_>>();
+        assert_eq!(path.first(), path.last(), "loop is closed: {msg}");
+        let unique: HashSet<&str> = path.iter().copied().collect();
+        assert_eq!(unique, HashSet::from(["a", "b", "c"]), "{msg}");
+    }
+}

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -25,6 +25,7 @@ mod checkpoint;
 mod drafts;
 mod execute;
 mod forced;
+mod graph;
 mod lock;
 mod plan;
 mod release_json;
@@ -84,6 +85,8 @@ pub(super) fn run_release_logic(
         };
         return finish(dry_run, out);
     }
+
+    let release_order = graph::release_order(&config.packages).map_err(graph::Cycle::into_error)?;
 
     let repo = open_repo(root)?;
 
@@ -208,7 +211,12 @@ pub(super) fn run_release_logic(
         })
         .collect::<Result<Vec<_>>>()?;
 
-    for (pkg_idx, (pkg, plan)) in config.packages.iter().zip(plans).enumerate() {
+    let mut plans: Vec<Option<PackagePlan>> = plans.into_iter().map(Some).collect();
+    for &pkg_idx in &release_order {
+        let pkg = &config.packages[pkg_idx];
+        let plan = plans[pkg_idx]
+            .take()
+            .expect("release_order visits each package exactly once");
         let recovered = match &plan {
             PackagePlan::Skipped { recovered, .. } => *recovered,
             PackagePlan::Bump(bump_plan) => bump_plan.recovered,

--- a/src/monorepo/tests.rs
+++ b/src/monorepo/tests.rs
@@ -894,3 +894,95 @@ mod lockfile_flow {
         }
     }
 }
+
+mod cycle_detection {
+    use crate::config::Config;
+    use crate::monorepo::run::run_release_logic;
+    use crate::test_utils::{commit_file, init_repo, with_cwd};
+    use crate::timing::Timing;
+    use std::path::Path;
+
+    fn write_pkg(dir: &Path, name: &str) {
+        std::fs::create_dir_all(dir.join(name)).unwrap();
+        std::fs::write(
+            dir.join(name).join("package.json"),
+            format!("{{\n  \"name\": \"{name}\",\n  \"version\": \"1.0.0\"\n}}\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn mutual_dependency_aborts_release_without_writing() {
+        let (dir, _repo) = init_repo();
+        let root = dir.path();
+        write_pkg(root, "api");
+        write_pkg(root, "web");
+        std::fs::write(
+            root.join(".ferrflow"),
+            r#"{"package": [
+                {"name": "api", "path": "api", "dependsOn": ["web"], "versionedFiles": [{"path": "api/package.json", "format": "json"}]},
+                {"name": "web", "path": "web", "dependsOn": ["api"], "versionedFiles": [{"path": "web/package.json", "format": "json"}]}
+            ]}"#,
+        )
+        .unwrap();
+        commit_file(
+            root,
+            "api/feature.txt",
+            "x",
+            "feat: api change",
+            1_972_000_000,
+        );
+
+        let config_path = root.join(".ferrflow");
+        let config = Config::load(root, Some(&config_path)).unwrap();
+
+        // A real (non-dry-run) release: if the cycle were not caught up
+        // front, this would start writing version bumps and tags.
+        let err = with_cwd(root, || {
+            run_release_logic(
+                root,
+                &config,
+                false,
+                false,
+                false,
+                false,
+                false,
+                None,
+                None,
+                false,
+                false,
+                &mut Timing::new(false),
+            )?;
+            Ok(())
+        })
+        .unwrap_err();
+
+        assert_eq!(
+            err.downcast_ref::<crate::error_code::ErrorCode>()
+                .map(|c| c.0),
+            Some(8003),
+            "expected MONOREPO_DEPENDENCY_CYCLE"
+        );
+        let message = err
+            .chain()
+            .map(|cause| cause.to_string())
+            .find(|m| m.starts_with("cycle detected"))
+            .expect("cycle message in the error chain");
+        assert!(
+            message.contains("api") && message.contains("web"),
+            "{message}"
+        );
+
+        // No partial release: both version files are untouched.
+        let api = std::fs::read_to_string(root.join("api/package.json")).unwrap();
+        let web = std::fs::read_to_string(root.join("web/package.json")).unwrap();
+        assert!(
+            api.contains("\"version\": \"1.0.0\""),
+            "api untouched: {api}"
+        );
+        assert!(
+            web.contains("\"version\": \"1.0.0\""),
+            "web untouched: {web}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #418.

`dependsOn` was handled as a flat list with no cycle behaviour: the dependency cascade simply capped its fixed-point loop at `packages.len()` rounds to avoid spinning forever, so a cyclic config silently produced an incorrect/partial result instead of a clear error.

This adds a single graph pass (Tarjan SCC) over the package dependency graph, run at the very top of `run_release_logic` — before any git work, lock, or write — so it covers both `ferrflow check` and `ferrflow release` and can never leave a partial release behind:

- **Cycle detection.** Any strongly-connected component with more than one member (or a package depending on itself) is a cycle. The error names the loop, e.g. `cycle detected: api → web → api`, and carries error code `E8003` (`MONOREPO_DEPENDENCY_CYCLE`).
- **Topological ordering.** When the graph is acyclic, the same pass yields a dependencies-first release order (a dependency is released before the packages that depend on it). Packages without any `dependsOn` keep their config order, so existing behaviour is unchanged for the common case.

### Tests
- `graph.rs` unit tests: identity order with no deps, dependency-before-dependent, linear chain, unknown-dependency names ignored, two-package cycle, self-dependency, three-package cycle path rendering.
- Integration test (`cycle_detection`): two packages depending on each other → a real (non-dry-run) release aborts with `E8003`, the message names both packages, no panic, and both version files are left untouched (no partial release).

Full suite green (858 + 668 tests), `cargo fmt` + `clippy` clean.

### Docs
In-repo `docs/errors.md` gains the `E8003` entry. The public docs-site monorepo page + errors reference are updated in a companion `FerrFlow-Cloud` PR (cross-repo changes are kept separate).
