### PR TITLE
ci: allow the benchmark job to run on workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,7 +451,7 @@ jobs:
     name: Benchmark
     needs: test
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
The competitive benchmark job only runs on push-to-main, so it can't be triggered on demand — re-running the job via `gh run rerun` doesn't regenerate the baseline. Allow it on `workflow_dispatch` too (the `test` dependency already runs on that event).

Lets us refresh the bench manually (e.g. to validate a Benchmarks-action change like the published-binary size measurement) without an unrelated push.

Closes #624
