### PR TITLE
refactor(formats): share a format-preserving splice helper across handlers

### DIFF
--- a/src/formats/chart_yaml.rs
+++ b/src/formats/chart_yaml.rs
@@ -24,23 +24,7 @@ impl VersionFile for ChartYamlVersionFile {
     }
 
     fn write_version(&self, file_path: &Path, version: &str) -> Result<()> {
-        let content = std::fs::read_to_string(file_path)
-            .with_context(|| format!("Cannot read {}", file_path.display()))
-            .error_code(error_code::CHART_YAML_READ)?;
-        if !version_re().is_match(&content) {
-            Err(anyhow::anyhow!(
-                "No top-level version: key found in {}",
-                file_path.display()
-            ))
-            .error_code(error_code::CHART_YAML_VERSION_NOT_FOUND)?;
-        }
-        let new_content = version_re().replace(&content, |caps: &regex::Captures| {
-            format!("{}{}{}{}", &caps[1], &caps[2], version, &caps[4])
-        });
-        std::fs::write(file_path, new_content.as_ref())
-            .with_context(|| format!("Cannot write {}", file_path.display()))
-            .error_code(error_code::CHART_YAML_WRITE)?;
-        Ok(())
+        super::splice::write_via_splice(self, file_path, version, None)
     }
 
     fn read_version_from_bytes(&self, content: &[u8], filename: &str) -> Result<String> {
@@ -52,6 +36,28 @@ impl VersionFile for ChartYamlVersionFile {
             .map(|c| c[3].to_string())
             .ok_or_else(|| anyhow::anyhow!("No top-level version: key found in {filename}"))
             .error_code(error_code::CHART_YAML_VERSION_NOT_FOUND)
+    }
+}
+
+impl super::splice::FormatPreservingEditor for ChartYamlVersionFile {
+    fn locate_version(
+        &self,
+        content: &str,
+        _selector: Option<&str>,
+    ) -> Result<std::ops::Range<usize>> {
+        version_re()
+            .captures(content)
+            .map(|c| c.get(3).unwrap().range())
+            .ok_or_else(|| anyhow::anyhow!("No top-level version: key found"))
+            .error_code(error_code::CHART_YAML_VERSION_NOT_FOUND)
+    }
+
+    fn read_error(&self) -> crate::error_code::ErrorCode {
+        error_code::CHART_YAML_READ
+    }
+
+    fn write_error(&self) -> crate::error_code::ErrorCode {
+        error_code::CHART_YAML_WRITE
     }
 }
 

--- a/src/formats/gemspec.rs
+++ b/src/formats/gemspec.rs
@@ -22,23 +22,7 @@ impl VersionFile for GemspecVersionFile {
     }
 
     fn write_version(&self, file_path: &Path, version: &str) -> Result<()> {
-        let content = std::fs::read_to_string(file_path)
-            .with_context(|| format!("Cannot read {}", file_path.display()))
-            .error_code(error_code::GEMSPEC_READ)?;
-        if !version_re().is_match(&content) {
-            Err(anyhow::anyhow!(
-                "No `.version = \"…\"` assignment found in {}",
-                file_path.display()
-            ))
-            .error_code(error_code::GEMSPEC_VERSION_NOT_FOUND)?;
-        }
-        let new_content = version_re().replace(&content, |caps: &regex::Captures| {
-            format!("{}{}{}{}", &caps[1], &caps[2], version, &caps[4])
-        });
-        std::fs::write(file_path, new_content.as_ref())
-            .with_context(|| format!("Cannot write {}", file_path.display()))
-            .error_code(error_code::GEMSPEC_WRITE)?;
-        Ok(())
+        super::splice::write_via_splice(self, file_path, version, None)
     }
 
     fn read_version_from_bytes(&self, content: &[u8], filename: &str) -> Result<String> {
@@ -50,6 +34,28 @@ impl VersionFile for GemspecVersionFile {
             .map(|c| c[3].to_string())
             .ok_or_else(|| anyhow::anyhow!("No `.version = \"…\"` assignment found in {filename}"))
             .error_code(error_code::GEMSPEC_VERSION_NOT_FOUND)
+    }
+}
+
+impl super::splice::FormatPreservingEditor for GemspecVersionFile {
+    fn locate_version(
+        &self,
+        content: &str,
+        _selector: Option<&str>,
+    ) -> Result<std::ops::Range<usize>> {
+        version_re()
+            .captures(content)
+            .map(|c| c.get(3).unwrap().range())
+            .ok_or_else(|| anyhow::anyhow!("No `.version = \"…\"` assignment found"))
+            .error_code(error_code::GEMSPEC_VERSION_NOT_FOUND)
+    }
+
+    fn read_error(&self) -> crate::error_code::ErrorCode {
+        error_code::GEMSPEC_READ
+    }
+
+    fn write_error(&self) -> crate::error_code::ErrorCode {
+        error_code::GEMSPEC_WRITE
     }
 }
 

--- a/src/formats/gradle.rs
+++ b/src/formats/gradle.rs
@@ -80,26 +80,7 @@ impl VersionFile for GradleVersionFile {
     }
 
     fn write_version(&self, file_path: &Path, version: &str) -> Result<()> {
-        let content = std::fs::read_to_string(file_path)
-            .with_context(|| format!("Cannot read {}", file_path.display()))
-            .error_code(error_code::GRADLE_READ)?;
-
-        if !version_re().is_match(&content) {
-            Err(anyhow::anyhow!(
-                "No version field found to update in {}",
-                file_path.display()
-            ))
-            .error_code(error_code::GRADLE_VERSION_NOT_FOUND)?;
-        }
-
-        let new_content = version_re().replace(&content, |caps: &regex::Captures| {
-            format!("{}{}{}{}", &caps[1], &caps[2], version, &caps[4])
-        });
-
-        std::fs::write(file_path, new_content.as_ref())
-            .with_context(|| format!("Cannot write {}", file_path.display()))
-            .error_code(error_code::GRADLE_WRITE)?;
-        Ok(())
+        super::splice::write_via_splice(self, file_path, version, None)
     }
 
     fn read_version_from_bytes(&self, content: &[u8], filename: &str) -> Result<String> {
@@ -111,5 +92,27 @@ impl VersionFile for GradleVersionFile {
             .map(|c| c[3].to_string())
             .ok_or_else(|| anyhow::anyhow!("No version field found in {filename}"))
             .error_code(error_code::GRADLE_VERSION_NOT_FOUND)
+    }
+}
+
+impl super::splice::FormatPreservingEditor for GradleVersionFile {
+    fn locate_version(
+        &self,
+        content: &str,
+        _selector: Option<&str>,
+    ) -> Result<std::ops::Range<usize>> {
+        version_re()
+            .captures(content)
+            .map(|c| c.get(3).unwrap().range())
+            .ok_or_else(|| anyhow::anyhow!("No version field found to update"))
+            .error_code(error_code::GRADLE_VERSION_NOT_FOUND)
+    }
+
+    fn read_error(&self) -> crate::error_code::ErrorCode {
+        error_code::GRADLE_READ
+    }
+
+    fn write_error(&self) -> crate::error_code::ErrorCode {
+        error_code::GRADLE_WRITE
     }
 }

--- a/src/formats/mix_exs.rs
+++ b/src/formats/mix_exs.rs
@@ -22,29 +22,7 @@ impl VersionFile for MixExsVersionFile {
     }
 
     fn write_version(&self, file_path: &Path, version: &str) -> Result<()> {
-        let content = std::fs::read_to_string(file_path)
-            .with_context(|| format!("Cannot read {}", file_path.display()))
-            .error_code(error_code::MIX_EXS_READ)?;
-        if !version_re().is_match(&content) {
-            Err(anyhow::anyhow!(
-                "No `version: \"…\"` literal found in {}",
-                file_path.display()
-            ))
-            .error_code(error_code::MIX_EXS_VERSION_NOT_FOUND)?;
-        }
-        let mut replaced = false;
-        let new_content = version_re().replace_all(&content, |caps: &regex::Captures| {
-            if replaced {
-                caps.get(0).unwrap().as_str().to_string()
-            } else {
-                replaced = true;
-                format!("{}{}{}{}", &caps[1], &caps[2], version, &caps[4])
-            }
-        });
-        std::fs::write(file_path, new_content.as_ref())
-            .with_context(|| format!("Cannot write {}", file_path.display()))
-            .error_code(error_code::MIX_EXS_WRITE)?;
-        Ok(())
+        super::splice::write_via_splice(self, file_path, version, None)
     }
 
     fn read_version_from_bytes(&self, content: &[u8], filename: &str) -> Result<String> {
@@ -56,6 +34,28 @@ impl VersionFile for MixExsVersionFile {
             .map(|c| c[3].to_string())
             .ok_or_else(|| anyhow::anyhow!("No `version: \"…\"` literal found in {filename}"))
             .error_code(error_code::MIX_EXS_VERSION_NOT_FOUND)
+    }
+}
+
+impl super::splice::FormatPreservingEditor for MixExsVersionFile {
+    fn locate_version(
+        &self,
+        content: &str,
+        _selector: Option<&str>,
+    ) -> Result<std::ops::Range<usize>> {
+        version_re()
+            .captures(content)
+            .map(|c| c.get(3).unwrap().range())
+            .ok_or_else(|| anyhow::anyhow!("No `version: \"…\"` literal found"))
+            .error_code(error_code::MIX_EXS_VERSION_NOT_FOUND)
+    }
+
+    fn read_error(&self) -> crate::error_code::ErrorCode {
+        error_code::MIX_EXS_READ
+    }
+
+    fn write_error(&self) -> crate::error_code::ErrorCode {
+        error_code::MIX_EXS_WRITE
     }
 }
 

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -10,6 +10,7 @@ pub mod lockfiles;
 pub mod mix_exs;
 pub mod package_swift;
 pub mod pubspec_yaml;
+mod splice;
 pub mod toml_format;
 pub mod txt;
 pub mod xml;

--- a/src/formats/package_swift.rs
+++ b/src/formats/package_swift.rs
@@ -24,23 +24,7 @@ impl VersionFile for PackageSwiftVersionFile {
     }
 
     fn write_version(&self, file_path: &Path, version: &str) -> Result<()> {
-        let content = std::fs::read_to_string(file_path)
-            .with_context(|| format!("Cannot read {}", file_path.display()))
-            .error_code(error_code::PACKAGE_SWIFT_READ)?;
-        if !version_re().is_match(&content) {
-            Err(anyhow::anyhow!(
-                "No `let <name>Version = \"…\"` declaration found in {}",
-                file_path.display()
-            ))
-            .error_code(error_code::PACKAGE_SWIFT_VERSION_NOT_FOUND)?;
-        }
-        let new_content = version_re().replace(&content, |caps: &regex::Captures| {
-            format!("{}{}{}{}", &caps[1], &caps[2], version, &caps[4])
-        });
-        std::fs::write(file_path, new_content.as_ref())
-            .with_context(|| format!("Cannot write {}", file_path.display()))
-            .error_code(error_code::PACKAGE_SWIFT_WRITE)?;
-        Ok(())
+        super::splice::write_via_splice(self, file_path, version, None)
     }
 
     fn read_version_from_bytes(&self, content: &[u8], filename: &str) -> Result<String> {
@@ -54,6 +38,28 @@ impl VersionFile for PackageSwiftVersionFile {
                 anyhow::anyhow!("No `let <name>Version = \"…\"` declaration found in {filename}")
             })
             .error_code(error_code::PACKAGE_SWIFT_VERSION_NOT_FOUND)
+    }
+}
+
+impl super::splice::FormatPreservingEditor for PackageSwiftVersionFile {
+    fn locate_version(
+        &self,
+        content: &str,
+        _selector: Option<&str>,
+    ) -> Result<std::ops::Range<usize>> {
+        version_re()
+            .captures(content)
+            .map(|c| c.get(3).unwrap().range())
+            .ok_or_else(|| anyhow::anyhow!("No `let <name>Version = \"…\"` declaration found"))
+            .error_code(error_code::PACKAGE_SWIFT_VERSION_NOT_FOUND)
+    }
+
+    fn read_error(&self) -> crate::error_code::ErrorCode {
+        error_code::PACKAGE_SWIFT_READ
+    }
+
+    fn write_error(&self) -> crate::error_code::ErrorCode {
+        error_code::PACKAGE_SWIFT_WRITE
     }
 }
 

--- a/src/formats/pubspec_yaml.rs
+++ b/src/formats/pubspec_yaml.rs
@@ -24,23 +24,7 @@ impl VersionFile for PubspecYamlVersionFile {
     }
 
     fn write_version(&self, file_path: &Path, version: &str) -> Result<()> {
-        let content = std::fs::read_to_string(file_path)
-            .with_context(|| format!("Cannot read {}", file_path.display()))
-            .error_code(error_code::PUBSPEC_READ)?;
-        if !version_re().is_match(&content) {
-            Err(anyhow::anyhow!(
-                "No top-level version: key found in {}",
-                file_path.display()
-            ))
-            .error_code(error_code::PUBSPEC_VERSION_NOT_FOUND)?;
-        }
-        let new_content = version_re().replace(&content, |caps: &regex::Captures| {
-            format!("{}{}{}{}", &caps[1], &caps[2], version, &caps[4])
-        });
-        std::fs::write(file_path, new_content.as_ref())
-            .with_context(|| format!("Cannot write {}", file_path.display()))
-            .error_code(error_code::PUBSPEC_WRITE)?;
-        Ok(())
+        super::splice::write_via_splice(self, file_path, version, None)
     }
 
     fn read_version_from_bytes(&self, content: &[u8], filename: &str) -> Result<String> {
@@ -52,6 +36,28 @@ impl VersionFile for PubspecYamlVersionFile {
             .map(|c| c[3].to_string())
             .ok_or_else(|| anyhow::anyhow!("No top-level version: key found in {filename}"))
             .error_code(error_code::PUBSPEC_VERSION_NOT_FOUND)
+    }
+}
+
+impl super::splice::FormatPreservingEditor for PubspecYamlVersionFile {
+    fn locate_version(
+        &self,
+        content: &str,
+        _selector: Option<&str>,
+    ) -> Result<std::ops::Range<usize>> {
+        version_re()
+            .captures(content)
+            .map(|c| c.get(3).unwrap().range())
+            .ok_or_else(|| anyhow::anyhow!("No top-level version: key found"))
+            .error_code(error_code::PUBSPEC_VERSION_NOT_FOUND)
+    }
+
+    fn read_error(&self) -> crate::error_code::ErrorCode {
+        error_code::PUBSPEC_READ
+    }
+
+    fn write_error(&self) -> crate::error_code::ErrorCode {
+        error_code::PUBSPEC_WRITE
     }
 }
 

--- a/src/formats/splice.rs
+++ b/src/formats/splice.rs
@@ -1,0 +1,32 @@
+use std::ops::Range;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::error_code::{ErrorCode, ErrorCodeExt};
+
+pub(super) trait FormatPreservingEditor {
+    fn locate_version(&self, content: &str, selector: Option<&str>) -> Result<Range<usize>>;
+    fn read_error(&self) -> ErrorCode;
+    fn write_error(&self) -> ErrorCode;
+}
+
+pub(super) fn write_via_splice<E: FormatPreservingEditor>(
+    editor: &E,
+    file_path: &Path,
+    version: &str,
+    selector: Option<&str>,
+) -> Result<()> {
+    let content = std::fs::read_to_string(file_path)
+        .with_context(|| format!("Cannot read {}", file_path.display()))
+        .error_code(editor.read_error())?;
+    let range = editor.locate_version(&content, selector)?;
+    let mut out = String::with_capacity(content.len() - range.len() + version.len());
+    out.push_str(&content[..range.start]);
+    out.push_str(version);
+    out.push_str(&content[range.end..]);
+    std::fs::write(file_path, out)
+        .with_context(|| format!("Cannot write {}", file_path.display()))
+        .error_code(editor.write_error())?;
+    Ok(())
+}


### PR DESCRIPTION
Closes #434.

The regex-splice format handlers each carried a near-identical `write_version`
body: read the file, locate the version token, rebuild the string around it,
write it back. Six of them duplicated that logic verbatim, which is exactly the
"never re-serialize, only splice" contract #434 wanted enforced in one place.

Introduces `formats::splice`:

- `FormatPreservingEditor` — a handler declares only *where* the version lives
  (`locate_version` returns the byte `Range`) and its read/write `ErrorCode`s.
- `write_via_splice` — the shared read → splice range → write path. It copies the
  bytes before and after the located range and drops the new version in between,
  so it can never re-serialize or reflow the surrounding file.

Migrated `gemspec`, `gradle`, `chart_yaml`, `pubspec_yaml`, `package_swift` and
`mix_exs` onto it. `mix_exs` previously emulated first-match-only replacement with
a `replace_all` + flag; splicing the first capture's range is the same behaviour,
less code.

Left as-is (they don't destructively re-serialize, so the trait doesn't fit):
`json` already splices via `find_top_level_string_value_span` with a serde
fallback (#426/#526), `xml` is a streaming splicer, `txt` rewrites the whole file
by design, and `csproj` rebuilds the `<Version>` tag (normalizes rather than
splices).

All 669 lib tests pass; the per-format write tests already assert surrounding
content is untouched.
