### PR TITLE
chore(npm): consolidate publish surface under @ferrflow, drop @ferrlabs alias

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -330,7 +330,7 @@ jobs:
         run: bash npm/scripts/publish.sh "${{ steps.version.outputs.value }}"
 
   publish-wasm:
-    name: Publish @ferrlabs/ferrflow-wasm
+    name: Publish @ferrflow/wasm
     needs: upload
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ cargo install ferrflow
 npm install -D ferrflow
 ```
 
-(`@ferrlabs/ferrflow` is kept as a published alias for the same package.)
-
 **Docker**
 
 ```bash

--- a/npm/scripts/publish-wasm.sh
+++ b/npm/scripts/publish-wasm.sh
@@ -7,17 +7,17 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
 WASM_DIR="${REPO_DIR}/ferrflow-wasm"
 
-echo "Building @ferrlabs/ferrflow-wasm@${VERSION}..."
+echo "Building @ferrflow/wasm@${VERSION}..."
 
 cd "$WASM_DIR"
-wasm-pack build --target bundler --scope ferrlabs
+wasm-pack build --target bundler --scope ferrflow
 
 cd pkg
 
 node -e "
   const fs = require('fs');
   const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-  pkg.name = '@ferrlabs/ferrflow-wasm';
+  pkg.name = '@ferrflow/wasm';
   pkg.version = '${VERSION}';
   pkg.repository = {
     type: 'git',
@@ -28,11 +28,11 @@ node -e "
   fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
 "
 
-if npm view "@ferrlabs/ferrflow-wasm@${VERSION}" version >/dev/null 2>&1; then
-  echo "@ferrlabs/ferrflow-wasm@${VERSION} already on registry — skipping"
+if npm view "@ferrflow/wasm@${VERSION}" version >/dev/null 2>&1; then
+  echo "@ferrflow/wasm@${VERSION} already on registry — skipping"
 else
-  echo "Publishing @ferrlabs/ferrflow-wasm@${VERSION}..."
+  echo "Publishing @ferrflow/wasm@${VERSION}..."
   npm publish --access public
 fi
 
-echo "Published @ferrlabs/ferrflow-wasm@${VERSION}"
+echo "Published @ferrflow/wasm@${VERSION}"

--- a/npm/scripts/publish.sh
+++ b/npm/scripts/publish.sh
@@ -80,20 +80,7 @@ node -e "
 
 publish_if_new ferrflow
 
-echo "Publishing brand alias @ferrlabs/ferrflow@${VERSION}..."
-ALIAS_DIR="$(mktemp -d)"
-cp -a "${NPM_DIR}/." "${ALIAS_DIR}/"
-cd "$ALIAS_DIR"
-node -e "
-  const pkg = JSON.parse(require('fs').readFileSync('package.json', 'utf8'));
-  pkg.name = '@ferrlabs/ferrflow';
-  require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
-"
-publish_if_new "@ferrlabs/ferrflow"
-cd - > /dev/null
-rm -rf "$ALIAS_DIR"
-
-echo "Published ferrflow@${VERSION} (+ @ferrlabs/ferrflow alias) with all platform packages"
+echo "Published ferrflow@${VERSION} with all platform packages"
 
 # Cleanup
 rm -rf "$WORK_DIR"


### PR DESCRIPTION
Closes #632.

Consolidates FerrFlow's npm surface under a single **product** scope and removes
the `@ferrlabs/*` packages that have 404'd on every release since v5.19.0.

- `@ferrlabs/ferrflow-wasm` → **`@ferrflow/wasm`** (`--scope ferrflow`, pkg name).
- Drop the **`@ferrlabs/ferrflow` brand alias** — the canonical package is the
  unscoped `ferrflow`; a scoped duplicate only adds ambiguity and a second
  publish to keep green.
- Rename the wasm workflow job, drop the alias note in the README.

Both `@ferrlabs/*` packages were never successfully published (E404 on the
`@ferrlabs` scope, which the CI token doesn't own), so there are **zero
consumers** — no migration, no deprecation needed. Everything now publishes
under `@ferrflow`, which the existing token already owns, so the wasm publish is
unblocked without creating an `@ferrlabs` npm org.

Convention-wise this matches how tool ecosystems scope on npm (`@babel/*`,
`@swc/*`, `@esbuild/*`, `@vitejs/*` — product scope, not holding-org scope).
`@ferrlabs/mcp-*` (separate repo, ecosystem-wide) stays under `@ferrlabs` and is
out of scope here.

Follow-up: a FerrFlow-Cloud PR updates the site/docs references from
`@ferrlabs/ferrflow-wasm` to `@ferrflow/wasm`.
