### PR TITLE
perf(ci): PGO build for the x64-linux release binary

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,7 @@ jobs:
           rm /tmp/cross.tar.gz
       - name: Generate fixtures (PGO profiling workload, x64-linux only)
         if: matrix.target == 'x86_64-unknown-linux-musl'
-        uses: FerrLabs/Fixtures@v1
+        uses: FerrLabs/Fixtures@7db03266c337749bef6f0d5c1e956b112b337b9c # v1
         with:
           definitions: tests/fixtures/definitions
       - name: Install musl tools (PGO x64-linux)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,8 +77,32 @@ jobs:
             https://github.com/cross-rs/cross/releases/latest/download/cross-x86_64-unknown-linux-musl.tar.gz
           tar xz -C "$HOME/.cargo/bin" -f /tmp/cross.tar.gz
           rm /tmp/cross.tar.gz
+      - name: Generate fixtures (PGO profiling workload, x64-linux only)
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        uses: FerrLabs/Fixtures@v1
+        with:
+          definitions: tests/fixtures/definitions
+      - name: Install musl tools (PGO x64-linux)
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+      - name: Build x64-linux (PGO, #619)
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        shell: bash
+        run: |
+          if ! bash scripts/pgo-build.sh x86_64-unknown-linux-musl; then
+            echo "::warning::PGO build failed — falling back to LTO-only cross build for x64-linux"
+            n=0
+            until cross build --release --target x86_64-unknown-linux-musl; do
+              n=$((n + 1))
+              [ "$n" -ge 3 ] && { echo "fallback build failed after $n attempts" >&2; exit 1; }
+              echo "fallback build attempt $n failed; retrying in 15s..." >&2
+              sleep 15
+            done
+          fi
+        env:
+          FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
       - name: Build (Linux)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && matrix.target != 'x86_64-unknown-linux-musl'
         shell: bash
         run: |
           n=0

--- a/scripts/pgo-build.sh
+++ b/scripts/pgo-build.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Profile-Guided Optimization build for the x86_64-unknown-linux-musl release
+# binary (issue #619). Scoped to x64-linux only: a musl x86_64 binary runs
+# natively on the x86 CI runner, so the instrument -> profile -> optimize loop
+# is clean here. Every other release target keeps the LTO-only build.
+#
+# PGO is done with plain rustc flags (-Cprofile-generate / -Cprofile-use) rather
+# than a helper crate, so the exact toolchain contract is visible. The optimized
+# pass layers -Cprofile-use on top of the [profile.release] LTO from Cargo.toml.
+#
+# Usage: scripts/pgo-build.sh [target]
+# Env:   FIXTURES_DIR  directory of generated fixture git repos (profiling load)
+
+TARGET="${1:-x86_64-unknown-linux-musl}"
+FIXTURES_DIR="${FIXTURES_DIR:-fixtures-generated}"
+BIN_NAME="ferrflow"
+PROF_DIR="$(pwd)/target/pgo-data"
+BIN_PATH="$(pwd)/target/${TARGET}/release/${BIN_NAME}"
+
+echo "==> PGO build for ${TARGET}"
+rustup target add "$TARGET"
+rustup component add llvm-tools-preview
+
+LLVM_PROFDATA="$(find "$(rustc --print sysroot)" -name 'llvm-profdata*' -type f | head -1)"
+if [ -z "${LLVM_PROFDATA}" ]; then
+  echo "llvm-profdata not found in sysroot" >&2
+  exit 1
+fi
+
+rm -rf "$PROF_DIR"
+mkdir -p "$PROF_DIR"
+
+echo "==> Instrumented build (-Cprofile-generate)"
+RUSTFLAGS="-Cprofile-generate=${PROF_DIR}" \
+  cargo build --release --target "$TARGET"
+
+# Give the profiling run realistic commit/tag volume on the hot walking paths.
+git fetch --unshallow 2>/dev/null || git fetch --depth=2000 2>/dev/null || true
+git fetch --tags 2>/dev/null || true
+
+echo "==> Collecting profiles"
+# Breadth: each generated fixture exercises a distinct commit/version/changelog
+# path. Some fixtures are intentionally malformed, so ignore exit codes.
+if [ -d "$FIXTURES_DIR" ]; then
+  while IFS= read -r gitdir; do
+    repo="$(dirname "$gitdir")"
+    ( cd "$repo" && "$BIN_PATH" check >/dev/null 2>&1 ) || true
+    ( cd "$repo" && "$BIN_PATH" version >/dev/null 2>&1 ) || true
+  done < <(find "$FIXTURES_DIR" -type d -name .git)
+fi
+# Volume: this repo's own deep history — the closest always-available stand-in
+# for a large monorepo on the commit-walking / tag-index hot paths.
+"$BIN_PATH" check >/dev/null 2>&1 || true
+"$BIN_PATH" version >/dev/null 2>&1 || true
+"$BIN_PATH" tag >/dev/null 2>&1 || true
+
+shopt -s nullglob
+profraws=("$PROF_DIR"/*.profraw)
+if [ ${#profraws[@]} -eq 0 ]; then
+  echo "no .profraw profiles were produced — instrumented run collected nothing" >&2
+  exit 1
+fi
+echo "==> Merging ${#profraws[@]} profile(s)"
+"$LLVM_PROFDATA" merge -o "$PROF_DIR/merged.profdata" "${profraws[@]}"
+
+echo "==> Optimized build (-Cprofile-use + release LTO)"
+RUSTFLAGS="-Cprofile-use=${PROF_DIR}/merged.profdata -Cllvm-args=-pgo-warn-missing-function" \
+  cargo build --release --target "$TARGET"
+
+echo "==> PGO build complete: target/${TARGET}/release/${BIN_NAME}"


### PR DESCRIPTION
Closes #619.

Adds a Profile-Guided Optimization build for the **x64-linux release binary only**
(`x86_64-unknown-linux-musl`). Every other target keeps the LTO-only build,
untouched.

## What changed
- **`scripts/pgo-build.sh`** — instrument (`-Cprofile-generate`) → run the
  instrumented binary over the generated fixtures + this repo's own deep history
  (the always-available stand-in for a large monorepo on the commit-walking /
  tag-index hot paths) → `llvm-profdata merge` → optimize (`-Cprofile-use`) on
  top of the existing `[profile.release]` LTO. Plain rustc flags, no helper
  crate, so the toolchain contract is fully visible.
- **`publish.yml`** — for `x86_64-unknown-linux-musl` only: generate fixtures
  (`FerrLabs/Fixtures@v1`), install `musl-tools`, run the PGO script. The x64
  target is built **natively** (musl x86_64 runs on the x86 runner, so
  instrument→run→optimize is clean) instead of via `cross`. arm64 / armv7 /
  darwin / windows still go through the existing `cross` / `cargo` path.
- **Release safety**: if the PGO build fails for any reason, the step falls back
  to the LTO-only `cross` build, so a PGO hiccup never blocks the x64 release.

## Why draft — not ready to merge
Per the issue this is **bench-gated**: PGO ships only if the win is real on this
target. That decision needs a measurement I can't produce locally:

1. **First CI run must validate the mechanism** — musl + the LLVM profiling
   runtime linking, and that `.profraw` profiles are actually produced. If the
   instrumented build can't link the profiler runtime on musl-static, the
   fallback kicks in (release stays safe) but PGO wouldn't apply — that shows up
   in the job log.
2. **Bench delta must be measured** — compare the PGO x64 binary vs the current
   LTO-only one on the competitive bench. **Do not merge if any
   `*_full_check_flow` regresses**; if the delta doesn't materialize, close this
   without shipping (the issue explicitly allows that outcome).

I could not run the release CI or the bench here, so I'm leaving this as a draft
for that validation rather than auto-merging.

## Out of scope (unchanged, per issue)
arm64 / musl-arm / darwin / windows PGO, and local-dev PGO builds.
