### PR TITLE
ci: ignore RUSTSEC-2026-0173 (proc-macro-error2 unmaintained)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,8 @@
+[advisories]
+ignore = [
+    # TODO: remove once the transitive dependency that pulls proc-macro-error2
+    # migrates off it. RUSTSEC-2026-0173 is an unmaintained-crate warning (not a
+    # vulnerability) on a dep we don't use directly; it drifts in and out of the
+    # tree with registry state, so it's ignored rather than pinned.
+    "RUSTSEC-2026-0173",
+]

--- a/deny.toml
+++ b/deny.toml
@@ -6,7 +6,12 @@ version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "warn"
-ignore = []
+ignore = [
+    # TODO: remove once the transitive dep pulling proc-macro-error2 migrates off
+    # it. RUSTSEC-2026-0173 is an unmaintained-crate warning (not a vulnerability)
+    # on a dep we don't use directly.
+    "RUSTSEC-2026-0173",
+]
 
 [licenses]
 version = 2


### PR DESCRIPTION
Closes #635.

Unblocks the `Cargo Security` job, which fails on **RUSTSEC-2026-0173** (`proc-macro-error2 is unmaintained`, 2026-06-07) — a transitive, unmaintained-crate *warning* on a dep we don't use directly.

- `.cargo/audit.toml` (new) — ignores the advisory for `cargo audit --deny warnings`.
- `deny.toml` — same ignore for `cargo deny check`.

Both carry a TODO to remove the ignore once the upstream dependency migrates off proc-macro-error2. Scoped to this one advisory; nothing else is silenced.