### PR TITLE
feat(obs): migrate publishers, hooks, and gitlab forge to tracing

### DIFF
--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -62,7 +62,7 @@ impl Forge for GitLabForge {
         _target_commitish: Option<&str>,
     ) -> Result<ReleaseResult> {
         if draft {
-            eprintln!(
+            tracing::warn!(
                 "{}",
                 "Warning: --draft is not supported on GitLab. The release will be created as \
                  published immediately. Use a tag-protected branch or a manual approval gate if \

--- a/src/hooks/runner.rs
+++ b/src/hooks/runner.rs
@@ -17,7 +17,7 @@ pub fn run_hook(
     working_dir: &Path,
 ) -> Result<()> {
     if dry_run {
-        println!(
+        tracing::info!(
             "  {} {} {}",
             "⊙".dimmed(),
             format!("[{}]", point.label()).dimmed(),
@@ -26,7 +26,7 @@ pub fn run_hook(
         return Ok(());
     }
 
-    println!(
+    tracing::info!(
         "  {} {} {}",
         "▸".cyan(),
         format!("[{}]", point.label()).cyan(),
@@ -115,7 +115,7 @@ fn handle_failure(
         ))
         .error_code(error_code::HOOK_FAILED)?,
         OnFailure::Continue => {
-            eprintln!(
+            tracing::warn!(
                 "{}",
                 format!(
                     "  Warning: hook [{}] failed (exit {}): {}",

--- a/src/publishers/cargo.rs
+++ b/src/publishers/cargo.rs
@@ -108,10 +108,11 @@ pub fn run(
                 .get((attempt - 1) as usize)
                 .copied()
                 .unwrap_or(15);
-            eprintln!(
+            tracing::warn!(
                 "  ↻ {} publish hit a transient registry error on {} (attempt {attempt}/{MAX_PUBLISH_ATTEMPTS}); \
                  retrying in {backoff}s — likely index lag on a just-published dependency",
-                ctx.package_name, registry_label
+                ctx.package_name,
+                registry_label
             );
             std::thread::sleep(std::time::Duration::from_secs(backoff));
             continue;

--- a/src/publishers/mod.rs
+++ b/src/publishers/mod.rs
@@ -71,7 +71,7 @@ pub fn run_all(publishers: &[PublisherConfig], ctx: &PublishContext<'_>) -> Resu
     if publishers.is_empty() {
         return Ok(());
     }
-    println!(
+    tracing::info!(
         "  {} {} publishers:",
         "→".cyan(),
         publishers.len().to_string().cyan()
@@ -82,16 +82,16 @@ pub fn run_all(publishers: &[PublisherConfig], ctx: &PublishContext<'_>) -> Resu
         match run(p, ctx) {
             Ok(PublishOutcome::Published { url }) => {
                 let suffix = url.as_deref().unwrap_or("");
-                println!("    [{kind}] {preview} → {} {suffix}", "published".green());
+                tracing::info!("    [{kind}] {preview} → {} {suffix}", "published".green());
             }
             Ok(PublishOutcome::Skipped { reason }) => {
-                println!("    [{kind}] {preview} → {} ({reason})", "skipped".yellow());
+                tracing::info!("    [{kind}] {preview} → {} ({reason})", "skipped".yellow());
             }
             Ok(PublishOutcome::DryRun) => {
-                println!("    [{kind}] {preview} {}", "(dry-run)".dimmed());
+                tracing::info!("    [{kind}] {preview} {}", "(dry-run)".dimmed());
             }
             Err(e) => {
-                eprintln!("    [{kind}] {} {e:#}", "ERROR".red());
+                tracing::error!("    [{kind}] {} {e:#}", "ERROR".red());
                 return Err(e);
             }
         }


### PR DESCRIPTION
Part of #513 — the `println!`/`eprintln!` → `tracing` migration.

The tracing foundation already exists (`src/logging.rs`: `init_logging` + the
`MessageOnly` human formatter, the `--log-format {human,json}` / `--verbose`
flags, deps under the `cli` feature). This migrates the first, smallest-blast-radius
modules onto it so the pattern is established on real code:

- **`src/publishers/mod.rs`** — the "N publishers", published / skipped / dry-run
  status lines → `tracing::info!`; the publish error → `tracing::error!`.
- **`src/publishers/cargo.rs`** — the transient-retry notice → `tracing::warn!`.
- **`src/hooks/runner.rs`** — the `⊙` dry-run / `▸` running indicators →
  `tracing::info!`; the hook-failed warning → `tracing::warn!`.
- **`src/forge/gitlab.rs`** — the `--draft` unsupported warning → `tracing::warn!`.

Level mapping: always-shown status → `info!`, warnings → `warn!`, errors →
`error!`. The colored `✓ ▸ ⊙ ↻ →` prefixes stay inside the message string, and the
`MessageOnly` formatter renders the message verbatim (via `format_args` Debug — no
quotes, no level/timestamp), so **terminal output is byte-identical** to before.

**Behavioural note:** the human layer writes to **stderr** (as the committed
`logging.rs` already dictates), so these status lines move from stdout → stderr.
That's the intended split — logs on stderr, `--json` *data* stays on stdout
(those `println!(serde_json)` sites are deliberately left untouched). The child
process passthrough in `hooks/runner.rs` (`eprint!` of a failed hook's captured
output) also stays as-is — it relays subprocess bytes, not a ferrflow event.

Verified: `cargo build` clean, **669 lib tests pass**, `cargo fmt --check` +
`cargo clippy` clean.

Remaining stages (follow-up PRs, per the issue's "not one giant PR"): `src/validate/`,
`src/config/`, `src/monorepo/` (has `if verbose && !quiet` gates to fold into
`debug!`), and the `src/` root (~92 sites, the bulk), then the `docs/observability/logs.md`
schema + OTLP.
