### PR TITLE
feat(obs): migrate validate output to tracing

### DIFF
--- a/src/validate/output.rs
+++ b/src/validate/output.rs
@@ -16,15 +16,15 @@ pub(super) fn output_result(result: &ValidationResult, json: bool) -> Result<()>
 }
 
 fn print_text_result(result: &ValidationResult) {
-    println!();
-    println!("{}", "ferrflow validate".bold());
-    println!();
+    tracing::info!("");
+    tracing::info!("{}", "ferrflow validate".bold());
+    tracing::info!("");
 
     if let Some(ref cf) = result.config_file {
-        println!("  {} config parsed ({})", "✓".green(), cf);
+        tracing::info!("  {} config parsed ({})", "✓".green(), cf);
     }
     if result.package_count > 0 {
-        println!(
+        tracing::info!(
             "  {} {} package{} found",
             "✓".green(),
             result.package_count,
@@ -33,20 +33,20 @@ fn print_text_result(result: &ValidationResult) {
     }
 
     for e in &result.errors {
-        println!("  {} {}: {}", "✗".red(), e.path, e.message);
+        tracing::info!("  {} {}: {}", "✗".red(), e.path, e.message);
     }
     for w in &result.warnings {
-        println!("  {} {}: {}", "⚠".yellow(), w.path, w.message);
+        tracing::info!("  {} {}: {}", "⚠".yellow(), w.path, w.message);
     }
     for s in &result.suggestions {
-        println!("  {} {}: {}", "◆".cyan(), s.path, s.message);
+        tracing::info!("  {} {}: {}", "◆".cyan(), s.path, s.message);
     }
 
     if result.errors.is_empty() && result.warnings.is_empty() && result.suggestions.is_empty() {
-        println!("  {} no issues found", "✓".green());
+        tracing::info!("  {} no issues found", "✓".green());
     }
 
-    println!();
+    tracing::info!("");
     let parts: Vec<String> = [
         (result.errors.len(), "error"),
         (result.warnings.len(), "warning"),
@@ -58,9 +58,9 @@ fn print_text_result(result: &ValidationResult) {
     .collect();
 
     if parts.is_empty() {
-        println!("  {}", "all checks passed".green().bold());
+        tracing::info!("  {}", "all checks passed".green().bold());
     } else {
-        println!("  {}", parts.join(", "));
+        tracing::info!("  {}", parts.join(", "));
     }
-    println!();
+    tracing::info!("");
 }


### PR DESCRIPTION
Part of #513 — the `println!`/`eprintln!` → `tracing` migration. Follows #637
(publishers / hooks / gitlab forge).

Migrates `src/validate/output.rs` — the `ferrflow validate` human report — onto
`tracing`. All the report lines (header, `✓`/`✗`/`⚠`/`◆` findings, summary,
blank separators) go through `tracing::info!`; the colored prefixes stay in the
message string, so terminal output is byte-identical.

**One deliberate call:** the whole report is emitted at a **uniform `info!`
level**, not `error!`/`warn!` per symbol. The `✗`/`⚠` lines are *rendered
findings inside a report*, not tool-level log severities — keeping them one level
means the report shows or hides as a cohesive unit under a `RUST_LOG` filter
instead of fragmenting into dangling lines without their header/frame. Validation
still exits 1 on invalid input (unchanged).

`println!("{}", serde_json::to_string_pretty(...))` for `validate --json` is left
untouched — that's machine data on stdout, not a log. As with #637, the human
report now goes to stderr (per `logging.rs`), `--json` data stays on stdout.

Verified: `cargo build` clean, **669 lib tests pass**, `cargo fmt --check` +
`cargo clippy` clean.

Remaining: `src/config/` (careful — interactive `init` prompts + test-only
`eprintln!` that must NOT migrate), `src/monorepo/` (`if verbose && !quiet` gates
to fold into `debug!`), and the `src/` root (~37 sites).
