### PR TITLE
feat(obs): migrate monorepo report output to tracing

### DIFF
--- a/src/monorepo/check.rs
+++ b/src/monorepo/check.rs
@@ -26,8 +26,8 @@ pub fn check(
     let config = timing.stage("load config", || Config::load(&root, config_path))?;
 
     if !json {
-        println!("{}", "FerrFlow — Check (dry run)".bold().blue());
-        println!();
+        tracing::info!("{}", "FerrFlow — Check (dry run)".bold().blue());
+        tracing::info!("");
     }
 
     let variant = if json { "json" } else { "text" };
@@ -86,6 +86,6 @@ fn print_cached(hit: &CachedRun) {
         return;
     }
     for line in &hit.text_lines {
-        println!("{line}");
+        tracing::info!("{line}");
     }
 }

--- a/src/monorepo/release.rs
+++ b/src/monorepo/release.rs
@@ -35,11 +35,11 @@ pub fn release(
 
     if !json {
         if dry_run {
-            println!("{}", "FerrFlow — Release (dry run)".bold().blue());
+            tracing::info!("{}", "FerrFlow — Release (dry run)".bold().blue());
         } else {
-            println!("{}", "FerrFlow — Release".bold().green());
+            tracing::info!("{}", "FerrFlow — Release".bold().green());
         }
-        println!();
+        tracing::info!("");
     }
 
     let single_shot = dry_run
@@ -102,7 +102,7 @@ pub fn release(
                 if attempt < MAX_RELEASE_REGENERATE_ATTEMPTS
                     && crate::git::is_push_rejected_error(&e) =>
             {
-                eprintln!();
+                tracing::warn!("");
                 tracing::warn!(
                     "{}",
                     format!(

--- a/src/monorepo/types.rs
+++ b/src/monorepo/types.rs
@@ -34,7 +34,7 @@ impl RunOutput {
             return;
         }
         for line in &self.text_lines {
-            println!("{line}");
+            tracing::info!("{line}");
         }
     }
 }


### PR DESCRIPTION
Part of #513. Follows #637 (publishers/hooks/forge) and #641 (validate).

Migrates the monorepo **report-output path** onto `tracing`:

- `RunOutput::print()` (`types.rs`) and `print_cached` (`check.rs`) — the captured
  human report (`text_lines`) is now replayed through `tracing::info!`; the
  `println!("{json}")` sibling is **left untouched** (machine data on stdout).
- The `check` / `release` command headers (gated `if !json`) → `tracing::info!`.
- The stray blank-line `eprintln!()` before the stale-push `warn!` in `release.rs`
  → `warn!("")`, so it groups with the warning it precedes.

Colored prefixes stay in the message string, so terminal output is byte-identical;
as with the earlier stages the human report moves to stderr while `--json` data
stays on stdout.

Verified: `cargo build` clean, **669 lib tests pass**, `cargo fmt --check` +
`cargo clippy` clean.

**Deferred to the next monorepo sub-stage** (they need per-site gate rewrites and
raw-diff handling, so they don't belong in this mechanical pass): the
`if verbose && !quiet { println!(…) }` progress lines in `src/monorepo/run/mod.rs`
(changed-files list, "recovering" / "not touched" / "no new commits" / "version
unchanged") — these fold into `debug!` with the `!quiet` (JSON-mode) gate kept —
and the dry-run diff printer (`println!(path)` + `print!(diff)`), whose raw diff
passthrough needs its own treatment.

Also noted: **`src/config/` is intentionally excluded** from this migration —
`init.rs` is an interactive command (prompts + confirmations must show
unconditionally, not behind a log filter) and `config/tests.rs` is test-only
`eprintln!` (no subscriber in tests). Remaining after monorepo: the `src/` root
(~37 sites, with `--json` outputs to preserve).
