### PR TITLE
feat(obs): migrate monorepo run progress lines to tracing

### DIFF
--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -165,12 +165,12 @@ pub(super) fn run_release_logic(
 
     let quiet = json || release_json;
 
-    if verbose && !quiet && !changed_files.is_empty() {
-        println!("Changed files in last commit:");
+    if !quiet && !changed_files.is_empty() {
+        tracing::debug!("Changed files in last commit:");
         for f in &changed_files {
-            println!("  {}", f.dimmed());
+            tracing::debug!("  {}", f.dimmed());
         }
-        println!();
+        tracing::debug!("");
     }
 
     let mut any_bumped = false;
@@ -221,8 +221,8 @@ pub(super) fn run_release_logic(
             PackagePlan::Skipped { recovered, .. } => *recovered,
             PackagePlan::Bump(bump_plan) => bump_plan.recovered,
         };
-        if recovered && verbose && !quiet {
-            println!(
+        if recovered && !quiet {
+            tracing::debug!(
                 "{} {} — recovering missed release",
                 "↻".cyan(),
                 pkg.name.cyan()
@@ -233,8 +233,8 @@ pub(super) fn run_release_logic(
             PackagePlan::Skipped { reason, .. } => {
                 match reason {
                     SkipReason::NotTouched => {
-                        if verbose && !quiet {
-                            println!(
+                        if !quiet {
+                            tracing::debug!(
                                 "{} {} — not touched, skipping",
                                 "○".dimmed(),
                                 pkg.name.dimmed()
@@ -242,8 +242,12 @@ pub(super) fn run_release_logic(
                         }
                     }
                     SkipReason::NoNewCommits => {
-                        if verbose && !quiet {
-                            println!("{} {} — no new commits", "○".dimmed(), pkg.name.dimmed());
+                        if !quiet {
+                            tracing::debug!(
+                                "{} {} — no new commits",
+                                "○".dimmed(),
+                                pkg.name.dimmed()
+                            );
                         }
                     }
                     SkipReason::NoReleasableCommits => {
@@ -256,8 +260,12 @@ pub(super) fn run_release_logic(
                         }
                     }
                     SkipReason::VersionUnchanged => {
-                        if verbose && !quiet {
-                            println!("{} {} — version unchanged", "○".dimmed(), pkg.name.dimmed());
+                        if !quiet {
+                            tracing::debug!(
+                                "{} {} — version unchanged",
+                                "○".dimmed(),
+                                pkg.name.dimmed()
+                            );
                         }
                     }
                 }


### PR DESCRIPTION
Part of #513. Finishes `src/monorepo/run/` after #642 (monorepo report path).

Migrates the verbose-gated progress lines in `run/mod.rs` onto `tracing`:

- The changed-files listing, and the per-package "recovering missed release" /
  "not touched" / "no new commits" / "version unchanged" progress lines were all
  `if verbose && !quiet { println!(…) }`. They become `if !quiet { tracing::debug!(…) }`
  — the `verbose` flag folds into the `debug!` level (handled by the `EnvFilter`
  in `logging.rs`, which sets `ferrflow=debug` under `--verbose`), and the
  `!quiet` (JSON-mode) gate is kept so `--json` / `--release-json` runs stay
  silent. Colored prefixes stay in the message, so output is byte-identical at
  the default level.

`run/drafts.rs` was already on `tracing`; nothing else to do there.

**Intentionally left on stdout** (not migrated): the dry-run diff printer
(`println!("{}", path.bold())` + `print!("{diff}")` + `println!()`). Its content
is a capturable *artifact* — the diff of what a release would change — analogous
to the `--json` data output, not a diagnostic log; it stays on stdout so
`ferrflow release --dry-run --verbose > preview.txt` still captures it. It's
gated by `if dry_run && verbose && !quiet` at the caller (unchanged).

Verified: `cargo build` clean, **669 lib tests pass**, `cargo fmt --check` +
`cargo clippy` clean (`verbose` is still used elsewhere, so no unused-var).

Remaining for #513: the `src/` root (~37 sites, with `--json` data outputs to
preserve), then the `docs/observability/logs.md` schema. `src/config/` stays
excluded (interactive `init` + test-only prints).
