### PR TITLE
feat(obs): migrate main error printer and timing breakdown to tracing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -72,14 +72,14 @@ fn main() {
                 .map(|c| c.to_string())
                 .collect();
 
-            eprintln!("error[{}]: {}", code, msgs[0]);
+            tracing::error!("error[{}]: {}", code, msgs[0]);
             for msg in &msgs[1..] {
-                eprintln!("  {msg}");
+                tracing::error!("  {msg}");
             }
-            eprintln!();
-            eprintln!("  For help: {}", code.doc_url());
+            tracing::error!("");
+            tracing::error!("  For help: {}", code.doc_url());
         } else {
-            eprintln!("Error: {err:?}");
+            tracing::error!("Error: {err:?}");
         }
 
         std::process::exit(1);

--- a/src/timing.rs
+++ b/src/timing.rs
@@ -65,21 +65,21 @@ impl Timing {
             .max()
             .unwrap_or(0);
 
-        eprintln!();
-        eprintln!("Timing breakdown:");
+        tracing::info!("");
+        tracing::info!("Timing breakdown:");
         for stage in &self.stages {
             match stage {
                 Stage::Measured(name, d) => {
-                    eprintln!("  {name:<label_width$}  {:>6} ms", d.as_millis());
+                    tracing::info!("  {name:<label_width$}  {:>6} ms", d.as_millis());
                 }
                 Stage::Skipped(name, reason) => {
-                    eprintln!("  {name:<label_width$}  — ({reason})");
+                    tracing::info!("  {name:<label_width$}  — ({reason})");
                 }
             }
         }
         let rule = "─".repeat(label_width + 12);
-        eprintln!("  {rule}");
-        eprintln!(
+        tracing::info!("  {rule}");
+        tracing::info!(
             "  {:<label_width$}  {:>6} ms",
             "total",
             self.total().as_millis()


### PR DESCRIPTION
Part of #513. First slice of the `src/` root (splitting it 3 ways — this is the
two clearest, self-contained diagnostic units; the misc status files and the
data-value commands follow).

- **`main.rs`** — the top-level error printer (`error[code]: …`, the indented
  cause chain, the "For help" URL, and the `Error: {err:?}` fallback) → `tracing::error!`.
  The subscriber is already initialized earlier in `main`, and the `exit(1)` is
  unchanged. Bonus: under `--log-format json` these now come out as structured
  JSON error events (exactly the CI-ingestion goal of #513) instead of raw text.
- **`timing.rs`** — the `--timing` breakdown (already on stderr) → uniform
  `tracing::info!`, keeping the block cohesive under a `RUST_LOG` filter.

Output is byte-identical at the default level (colored prefixes / alignment stay
in the message strings).

Verified: `cargo build` clean, **669 lib tests pass**, `cargo fmt --check` +
`cargo clippy` clean.

**Next slices of the root** (deliberately separate for correct classification):
- Misc status files: `changelog.rs`, `publish.rs`, `cache.rs`, `manifest.rs`,
  `telemetry.rs`, `bot_token.rs` — note `bot_token.rs`'s `println!("::add-mask::…")`
  is a **GitHub Actions control command** and must stay on stdout, not migrate.
- `query.rs` + `status.rs` — the `version` / `tag` / `status` commands print their
  **value to stdout** (scriptable: `V=$(ferrflow version)`) + `--json` data. Those
  data outputs must stay on stdout; only the surrounding decoration migrates.
