### PR TITLE
feat(obs): migrate misc root status output to tracing

### DIFF
--- a/src/bot_token.rs
+++ b/src/bot_token.rs
@@ -192,7 +192,7 @@ pub fn ensure_bot_token() -> Result<()> {
     } else {
         format!(" (expires at {})", issued.expires_at)
     };
-    println!("Authenticated as ferrflow[bot]{repo_note}{expires_note}.");
+    tracing::info!("Authenticated as ferrflow[bot]{repo_note}{expires_note}.");
 
     configure_bot_git_identity();
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -136,7 +136,7 @@ pub fn clear_cwd() -> Result<()> {
     let repo = crate::git::open_repo(&std::env::current_dir()?)?;
     let dir = cache_dir(&repo);
     clear(&repo)?;
-    println!("Cleared FerrFlow cache at {}", dir.display());
+    tracing::info!("Cleared FerrFlow cache at {}", dir.display());
     Ok(())
 }
 

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -36,7 +36,7 @@ pub fn generate_only(config_path: Option<&Path>, dry_run: bool) -> Result<()> {
     let config = Config::load(&root, config_path)?;
 
     if config.packages.is_empty() {
-        println!(
+        tracing::warn!(
             "{}",
             "No packages configured. Run `ferrflow init` to create a ferrflow config.".yellow()
         );
@@ -101,7 +101,7 @@ pub fn generate_only(config_path: Option<&Path>, dry_run: bool) -> Result<()> {
         let changelog_path = match &pkg.changelog {
             Some(rel) => crate::formats::join_within_repo(&root, rel)?,
             None => {
-                println!(
+                tracing::warn!(
                     "{}",
                     format!(
                         "  No changelog configured for '{}', defaulting to CHANGELOG.md.",
@@ -458,7 +458,7 @@ pub fn update_changelog_with(
     let section = build_section_with(new_version, commits, render);
 
     if dry_run {
-        println!(
+        tracing::info!(
             "  [dry-run] Would update {}: {}",
             changelog_path.display(),
             section.trim()
@@ -470,7 +470,7 @@ pub fn update_changelog_with(
     let new_content = splice_section(&existing, &section);
 
     std::fs::write(changelog_path, new_content)?;
-    println!("  ✓ Updated {}", changelog_path.display());
+    tracing::info!("  ✓ Updated {}", changelog_path.display());
     Ok(())
 }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -244,7 +244,7 @@ pub fn sync_cwd(config_path: Option<&Path>) -> Result<()> {
         .unwrap_or_default();
     let manifest = Manifest::new(packages, now_utc_iso8601(), commit);
     write_atomic(&path, &manifest)?;
-    println!(
+    tracing::info!(
         "Wrote {} package version(s) to {}",
         manifest.packages.len(),
         path.display()

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -37,7 +37,7 @@ pub fn run(
         let tag = pkg.tag_for_version(&config.workspace, config.is_monorepo(), &version);
         let package_path = root.join(&pkg.path);
 
-        println!(
+        tracing::info!(
             "{} {} @ {}",
             "publish".bold(),
             pkg.name.cyan(),
@@ -57,7 +57,7 @@ pub fn run(
     }
 
     if ran == 0 {
-        println!(
+        tracing::warn!(
             "{}",
             "No publishers configured on any package — nothing to publish.".yellow()
         );


### PR DESCRIPTION
Part of #513. Second slice of the `src/` root (after #644 — main + timing).

Migrates the misc single-command status output onto `tracing`:

- **`changelog.rs`** — "no packages" / "no changelog configured" → `warn!`; the
  `[dry-run] Would update …` line and `✓ Updated …` → `info!`. (The changelog
  itself is written to a file, never printed, so there's no data output here.)
- **`publish.rs`** — the `publish <pkg> @ <ver>` header → `info!`; "no publishers
  configured" → `warn!`.
- **`cache.rs`** — "Cleared FerrFlow cache" → `info!`.
- **`manifest.rs`** — "Wrote N package version(s)" → `info!`.
- **`bot_token.rs`** — "Authenticated as ferrflow[bot]…" → `info!`.

Colored prefixes stay in the message; output is byte-identical at the default level.

**Deliberately kept as-is** (must show unconditionally, not filterable logs):
- `bot_token.rs`'s `println!("::add-mask::{token}")` — a **GitHub Actions control
  command** that masks the token in CI logs; it has to reach stdout.
- `telemetry.rs`'s first-run `eprintln!("Anonymous telemetry on. …opt out…")` — a
  privacy/transparency disclosure that should always be visible on first run, not
  suppressible under a `RUST_LOG` filter.

Verified: `cargo build` clean, **669 lib tests pass**, `cargo fmt --check` +
`cargo clippy` clean.

Remaining for #513: the final root slice — `query.rs` + `status.rs` (the
`version` / `tag` / `status` commands whose printed **value is scriptable data**
on stdout, alongside `--json`), then the `docs/observability/logs.md` schema.
