### PR TITLE
feat(obs): migrate status command output to tracing

### DIFF
--- a/src/status.rs
+++ b/src/status.rs
@@ -31,7 +31,7 @@ pub fn run(
     let config = timing.stage("load config", || Config::load(&root, config_path))?;
 
     if config.packages.is_empty() {
-        println!(
+        tracing::warn!(
             "{}",
             "No packages configured. Run `ferrflow init` to create a ferrflow config.".yellow()
         );
@@ -104,7 +104,7 @@ fn print_text(statuses: &[PackageStatus]) {
             Some(tag) => format!("(tag: {})", tag),
             None => "(no tag)".to_string(),
         };
-        println!(
+        tracing::info!(
             "{} {:<20} v{}   {}",
             dot,
             s.name,


### PR DESCRIPTION
Part of #513. Final `src/` root slice — completes the code migration.

- **`status.rs`** — the "no packages configured" warning → `warn!`; the per-package
  human status line (`● pkg  v1.2.3  (tag: …)`) → `info!`. The `--output json`
  path (`print_json`) is left untouched (machine data on stdout).
- **`query.rs`** — **nothing to migrate.** Every print there is machine output:
  the `--json` serializations, the bare `version` / `tag` value (`V=$(ferrflow version)`),
  and the tab-separated `name<TAB>version` / `name<TAB>tag` tables. All stay on
  stdout as scriptable data.

Colored prefixes stay in the message; output is byte-identical at the default level.

Verified: `cargo build` clean, **669 lib tests pass**, `cargo fmt --check` +
`cargo clippy` clean.

**This finishes the log-output migration for #513.** Every remaining `println!` /
`eprintln!` in `src/` is an intentional keep, in one of these categories:
- machine data on stdout (`--json` outputs, `query.rs` values/tables),
- interactive UX (`config/init.rs` prompts),
- a GitHub Actions control command (`bot_token.rs` `::add-mask::`),
- a first-run transparency disclosure (`telemetry.rs`),
- a capturable artifact (`monorepo/run` dry-run diff),
- test-only diagnostics (`config/tests.rs`).

Left for #513: the `docs/observability/logs.md` schema doc (documenting the JSON
log event shape) to close the issue's acceptance.
