### PR TITLE
feat(forge): add Gitea/Forgejo release support

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -239,6 +239,24 @@ The GitLab MR response was missing the `iid` field.
 
 Could not merge the release MR via the GitLab API.
 
+## Gitea API Errors (E3200--E3299)
+
+Covers Gitea, Forgejo, and Codeberg (the API is shared).
+
+### E3201: Failed to create Gitea release
+
+The Gitea Releases API (`POST /api/v1/repos/{owner}/{repo}/releases`) returned an error.
+
+**Fix**: Check that `GITEA_TOKEN` / `FORGEJO_TOKEN` (or `FERRFLOW_TOKEN`) is set and has write access to the repository.
+
+### E3202: Failed to list Gitea releases
+
+The Gitea API returned an error while listing releases to find a draft.
+
+### E3203: Failed to publish Gitea release
+
+Could not clear the draft flag on a Gitea release via the API.
+
 ## Version File Errors (E4000--E4799)
 
 ### TOML (E4101--E4105)

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -9,6 +9,8 @@ pub enum ForgeKind {
     Github,
     #[serde(alias = "GitLab")]
     Gitlab,
+    #[serde(alias = "Gitea", alias = "forgejo", alias = "Forgejo")]
+    Gitea,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]

--- a/src/error_code.rs
+++ b/src/error_code.rs
@@ -141,6 +141,13 @@ pub const GITLAB_MR_MISSING_FIELD: ErrorCode = ErrorCode(3104);
 pub const GITLAB_MERGE_MR: ErrorCode = ErrorCode(3105);
 
 #[allow(dead_code)]
+pub const GITEA_CREATE_RELEASE: ErrorCode = ErrorCode(3201);
+#[allow(dead_code)]
+pub const GITEA_LIST_RELEASES: ErrorCode = ErrorCode(3202);
+#[allow(dead_code)]
+pub const GITEA_PUBLISH_RELEASE: ErrorCode = ErrorCode(3203);
+
+#[allow(dead_code)]
 pub const TOML_READ: ErrorCode = ErrorCode(4101);
 #[allow(dead_code)]
 pub const TOML_PARSE: ErrorCode = ErrorCode(4102);

--- a/src/forge/gitea.rs
+++ b/src/forge/gitea.rs
@@ -1,0 +1,270 @@
+use anyhow::{Context, Result};
+
+use super::{Forge, MergeRequestResult, ReleaseResult};
+use crate::error_code::{self, ErrorCodeExt};
+
+const PER_PAGE: u32 = 50;
+
+const MAX_PAGES: u32 = 100;
+
+pub struct GiteaForge {
+    pub token: String,
+    pub slug: String,
+    pub api_base: String,
+    pub agent: ureq::Agent,
+}
+
+impl GiteaForge {
+    fn paginated_json_array(&self, base_url: &str, what: &str) -> Result<Vec<serde_json::Value>> {
+        let mut all = Vec::new();
+        for page in 1..=MAX_PAGES {
+            let url = format!("{base_url}?limit={PER_PAGE}&page={page}");
+            let body: serde_json::Value = self
+                .agent
+                .get(&url)
+                .header("Authorization", &format!("token {}", self.token))
+                .header("User-Agent", "ferrflow")
+                .call()
+                .with_context(|| format!("Failed to list {what}"))?
+                .body_mut()
+                .read_json()
+                .with_context(|| format!("Failed to parse {what} response"))?;
+            let page_items = match body.as_array() {
+                Some(arr) if !arr.is_empty() => arr.clone(),
+                _ => return Ok(all),
+            };
+            let len = page_items.len();
+            all.extend(page_items);
+            if (len as u32) < PER_PAGE {
+                return Ok(all);
+            }
+        }
+        Ok(all)
+    }
+}
+
+impl Forge for GiteaForge {
+    fn create_release(
+        &self,
+        tag: &str,
+        body: &str,
+        prerelease: bool,
+        draft: bool,
+        target_commitish: Option<&str>,
+    ) -> Result<ReleaseResult> {
+        let url = format!("{}/repos/{}/releases", self.api_base, self.slug);
+
+        let mut payload = serde_json::json!({
+            "tag_name": tag,
+            "name": tag,
+            "body": body,
+            "draft": draft,
+            "prerelease": prerelease,
+        });
+        if let Some(sha) = target_commitish.filter(|s| !s.is_empty()) {
+            payload["target_commitish"] = serde_json::Value::String(sha.to_string());
+        }
+
+        let response: serde_json::Value = self
+            .agent
+            .post(&url)
+            .header("Authorization", &format!("token {}", self.token))
+            .header("User-Agent", "ferrflow")
+            .send_json(payload)
+            .with_context(|| format!("Failed to create Gitea release for {tag}"))
+            .error_code(error_code::GITEA_CREATE_RELEASE)?
+            .body_mut()
+            .read_json()
+            .unwrap_or(serde_json::Value::Null);
+
+        Ok(ReleaseResult {
+            id: response["id"].as_u64(),
+            url: response["html_url"].as_str().map(str::to_string),
+        })
+    }
+
+    fn find_draft_release(&self, tag: &str) -> Result<Option<u64>> {
+        let base_url = format!("{}/repos/{}/releases", self.api_base, self.slug);
+        let releases = self
+            .paginated_json_array(&base_url, "Gitea releases")
+            .error_code(error_code::GITEA_LIST_RELEASES)?;
+        for release in releases {
+            if release["draft"].as_bool() == Some(true)
+                && release["tag_name"].as_str() == Some(tag)
+                && let Some(id) = release["id"].as_u64()
+            {
+                return Ok(Some(id));
+            }
+        }
+        Ok(None)
+    }
+
+    fn publish_release(&self, release_id: u64) -> Result<()> {
+        let url = format!(
+            "{}/repos/{}/releases/{release_id}",
+            self.api_base, self.slug
+        );
+
+        self.agent
+            .patch(&url)
+            .header("Authorization", &format!("token {}", self.token))
+            .header("User-Agent", "ferrflow")
+            .send_json(serde_json::json!({ "draft": false }))
+            .with_context(|| format!("Failed to publish Gitea release {release_id}"))
+            .error_code(error_code::GITEA_PUBLISH_RELEASE)?;
+
+        Ok(())
+    }
+
+    fn create_merge_request(
+        &self,
+        _head: &str,
+        _base: &str,
+        _title: &str,
+        _body: &str,
+    ) -> Result<MergeRequestResult> {
+        anyhow::bail!(
+            "Pull-request mode is not yet supported on Gitea/Forgejo. \
+             FerrFlow can create releases; PR-based release flow is tracked in FerrLabs/FerrFlow#499."
+        )
+    }
+
+    fn enable_auto_merge(&self, _mr: &MergeRequestResult) -> Result<()> {
+        anyhow::bail!(
+            "Auto-merge is not yet supported on Gitea/Forgejo (PR mode). See FerrLabs/FerrFlow#499."
+        )
+    }
+
+    fn mr_noun(&self) -> &'static str {
+        "PR"
+    }
+
+    fn release_noun(&self) -> &'static str {
+        "Gitea Release"
+    }
+
+    fn find_comment(&self, pr_id: u64, marker: &str) -> Result<Option<u64>> {
+        let base_url = format!(
+            "{}/repos/{}/issues/{}/comments",
+            self.api_base, self.slug, pr_id
+        );
+        let comments = self.paginated_json_array(&base_url, "issue comments")?;
+        for comment in comments {
+            if let Some(body) = comment["body"].as_str()
+                && body.contains(marker)
+                && let Some(id) = comment["id"].as_u64()
+            {
+                return Ok(Some(id));
+            }
+        }
+        Ok(None)
+    }
+
+    fn create_comment(&self, pr_id: u64, body: &str) -> Result<()> {
+        let url = format!(
+            "{}/repos/{}/issues/{}/comments",
+            self.api_base, self.slug, pr_id
+        );
+        self.agent
+            .post(&url)
+            .header("Authorization", &format!("token {}", self.token))
+            .header("User-Agent", "ferrflow")
+            .send_json(serde_json::json!({ "body": body }))
+            .with_context(|| "Failed to create issue comment")?;
+        Ok(())
+    }
+
+    fn update_comment(&self, _pr_id: u64, comment_id: u64, body: &str) -> Result<()> {
+        let url = format!(
+            "{}/repos/{}/issues/comments/{}",
+            self.api_base, self.slug, comment_id
+        );
+        self.agent
+            .patch(&url)
+            .header("Authorization", &format!("token {}", self.token))
+            .header("User-Agent", "ferrflow")
+            .send_json(serde_json::json!({ "body": body }))
+            .with_context(|| "Failed to update issue comment")?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_forge() -> GiteaForge {
+        GiteaForge {
+            token: "test-token".to_string(),
+            slug: "owner/repo".to_string(),
+            api_base: "https://codeberg.org/api/v1".to_string(),
+            agent: ureq::Agent::new_with_defaults(),
+        }
+    }
+
+    #[test]
+    fn release_noun_is_gitea_release() {
+        assert_eq!(make_forge().release_noun(), "Gitea Release");
+    }
+
+    #[test]
+    fn api_base_uses_v1_prefix() {
+        assert_eq!(make_forge().api_base, "https://codeberg.org/api/v1");
+    }
+
+    #[test]
+    fn create_release_payload_structure() {
+        let payload = serde_json::json!({
+            "tag_name": "v1.0.0",
+            "name": "v1.0.0",
+            "body": "Release notes",
+            "draft": true,
+            "prerelease": false,
+        });
+        assert_eq!(payload["tag_name"], "v1.0.0");
+        assert_eq!(payload["draft"], true);
+        assert_eq!(payload["prerelease"], false);
+    }
+
+    #[test]
+    fn find_draft_release_matches_exact_tag() {
+        let releases: serde_json::Value = serde_json::json!([
+            {"id": 10, "tag_name": "v2.0.0", "draft": true},
+            {"id": 20, "tag_name": "v2.0.0-beta.1", "draft": true},
+        ]);
+        let found = releases
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|r| {
+                r["draft"].as_bool() == Some(true) && r["tag_name"].as_str() == Some("v2.0.0")
+            })
+            .and_then(|r| r["id"].as_u64());
+        assert_eq!(found, Some(10));
+    }
+
+    #[test]
+    fn find_draft_release_ignores_published() {
+        let releases: serde_json::Value = serde_json::json!([
+            {"id": 1, "tag_name": "v1.0.0", "draft": false},
+        ]);
+        let found = releases.as_array().unwrap().iter().find(|r| {
+            r["draft"].as_bool() == Some(true) && r["tag_name"].as_str() == Some("v1.0.0")
+        });
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn pr_mode_is_not_supported() {
+        let forge = make_forge();
+        assert!(forge.create_merge_request("h", "b", "t", "body").is_err());
+        assert!(
+            forge
+                .enable_auto_merge(&MergeRequestResult {
+                    id: 1,
+                    auto_merge_key: String::new(),
+                })
+                .is_err()
+        );
+    }
+}

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -1,3 +1,4 @@
+pub mod gitea;
 pub mod github;
 pub mod gitlab;
 
@@ -65,6 +66,8 @@ pub fn detect_forge_from_url(url: &str) -> Option<ForgeKind> {
         Some(ForgeKind::Github)
     } else if url.contains("gitlab.com") {
         Some(ForgeKind::Gitlab)
+    } else if url.contains("codeberg.org") || url.contains("gitea.io") {
+        Some(ForgeKind::Gitea)
     } else {
         None
     }
@@ -140,7 +143,9 @@ pub fn web_base_url(remote_url: &str) -> Option<String> {
     let host = extract_host(remote_url)?;
     let slug = extract_repo_slug(remote_url)?;
     match kind {
-        ForgeKind::Github | ForgeKind::Gitlab => Some(format!("https://{host}/{slug}")),
+        ForgeKind::Github | ForgeKind::Gitlab | ForgeKind::Gitea => {
+            Some(format!("https://{host}/{slug}"))
+        }
         ForgeKind::Auto => None,
     }
 }
@@ -154,6 +159,14 @@ pub fn resolve_token(kind: ForgeKind) -> Option<String> {
     match kind {
         ForgeKind::Github => std::env::var("GITHUB_TOKEN").ok().filter(|t| !t.is_empty()),
         ForgeKind::Gitlab => std::env::var("GITLAB_TOKEN").ok().filter(|t| !t.is_empty()),
+        ForgeKind::Gitea => std::env::var("GITEA_TOKEN")
+            .ok()
+            .filter(|t| !t.is_empty())
+            .or_else(|| {
+                std::env::var("FORGEJO_TOKEN")
+                    .ok()
+                    .filter(|t| !t.is_empty())
+            }),
         ForgeKind::Auto => None,
     }
 }
@@ -183,6 +196,15 @@ pub fn build_forge(kind: ForgeKind, token: String, slug: String, host: String) -
         ForgeKind::Gitlab => {
             let api_base = format!("https://{host}/api/v4");
             Box::new(gitlab::GitLabForge {
+                token,
+                slug,
+                api_base,
+                agent,
+            })
+        }
+        ForgeKind::Gitea => {
+            let api_base = format!("https://{host}/api/v1");
+            Box::new(gitea::GiteaForge {
                 token,
                 slug,
                 api_base,
@@ -229,6 +251,34 @@ mod tests {
         assert_eq!(
             detect_forge_from_url("git@gitlab.com:owner/repo.git"),
             Some(ForgeKind::Gitlab)
+        );
+    }
+
+    #[test]
+    fn detect_gitea_codeberg() {
+        assert_eq!(
+            detect_forge_from_url("https://codeberg.org/owner/repo.git"),
+            Some(ForgeKind::Gitea)
+        );
+        assert_eq!(
+            detect_forge_from_url("git@codeberg.org:owner/repo.git"),
+            Some(ForgeKind::Gitea)
+        );
+    }
+
+    #[test]
+    fn detect_gitea_io() {
+        assert_eq!(
+            detect_forge_from_url("https://gitea.io/owner/repo.git"),
+            Some(ForgeKind::Gitea)
+        );
+    }
+
+    #[test]
+    fn gitea_web_base_url() {
+        assert_eq!(
+            web_base_url("https://codeberg.org/owner/repo.git").as_deref(),
+            Some("https://codeberg.org/owner/repo")
         );
     }
 
@@ -357,6 +407,36 @@ mod tests {
             std::env::remove_var("GITLAB_TOKEN");
         }
         assert_eq!(result, Some("gl-tok".to_string()));
+    }
+
+    #[test]
+    fn resolve_token_gitea_from_gitea_token() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe {
+            std::env::remove_var("FERRFLOW_TOKEN");
+            std::env::remove_var("FORGEJO_TOKEN");
+            std::env::set_var("GITEA_TOKEN", "gitea-tok");
+        }
+        let result = resolve_token(ForgeKind::Gitea);
+        unsafe {
+            std::env::remove_var("GITEA_TOKEN");
+        }
+        assert_eq!(result, Some("gitea-tok".to_string()));
+    }
+
+    #[test]
+    fn resolve_token_gitea_falls_back_to_forgejo_token() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe {
+            std::env::remove_var("FERRFLOW_TOKEN");
+            std::env::remove_var("GITEA_TOKEN");
+            std::env::set_var("FORGEJO_TOKEN", "forgejo-tok");
+        }
+        let result = resolve_token(ForgeKind::Gitea);
+        unsafe {
+            std::env::remove_var("FORGEJO_TOKEN");
+        }
+        assert_eq!(result, Some("forgejo-tok".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
Part of #499 — Gitea/Forgejo release support. (Bitbucket and Gitea PR-mode parity stay out of scope per the issue.)

Adds a third forge alongside GitHub and GitLab, covering **Gitea, Forgejo, and Codeberg** (shared API):

- **`src/forge/gitea.rs`** — `GiteaForge` modeled on `github.rs`. Gitea's REST API is GitHub-v3-shaped under an `/api/v1` prefix, so release create / find-draft / publish and issue-comment endpoints port almost directly. Differences handled: `Authorization: token <TOKEN>` header, `?limit=&page=` pagination (limit 50).
- **`ForgeKind::Gitea`** added to the enum (config), with `forgejo` / `Forgejo` / `Gitea` serde aliases so `forge = "gitea"` or `forge = "forgejo"` both work.
- **Detection** — `codeberg.org` and `gitea.io` join the hostname allow-list; self-hosted instances work via the explicit `workspace.forge = "gitea"` override.
- **Auth** — `GITEA_TOKEN`, falling back to `FORGEJO_TOKEN` (and `FERRFLOW_TOKEN` as always).
- **`web_base_url`** now renders Gitea commit/compare links.
- Error codes **E3201–E3203** + a Gitea section in `docs/errors.md`.

**Out of scope (per the issue), returned as a clear error on Gitea:** PR-mode
release flow — `create_merge_request` / `enable_auto_merge` bail with a message
pointing at #499, because Gitea's PR + auto-merge API shape differs from GitHub's
and needs its own pass. Release creation (the common case for homelab / Codeberg
users) works end to end.

Verified: `cargo build` clean, **680 lib tests pass** (incl. new Gitea client +
detection + token-resolution tests), `cargo fmt --check` + `cargo clippy -- -D warnings` clean.

Follow-up (cross-repo): ferrflow.com's config reference lists `forge: auto | github | gitlab` — a small FerrFlow-Cloud PR adds `gitea` + the `GITEA_TOKEN` note.
