### PR TITLE
fix(wasm): make tracing facade non-optional so the wasm build compiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ workspace = true
 
 [features]
 default = ["cli"]
-cli = ["dep:gix", "dep:gix-traverse", "dep:ureq", "dep:clap", "dep:clap_complete", "dep:colored", "dep:hmac", "dep:mimalloc", "dep:rayon", "dep:tracing", "dep:tracing-subscriber"]
+cli = ["dep:gix", "dep:gix-traverse", "dep:ureq", "dep:clap", "dep:clap_complete", "dep:colored", "dep:hmac", "dep:mimalloc", "dep:rayon", "dep:tracing-subscriber"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -64,10 +64,12 @@ mimalloc = { version = "0.1", default-features = false, optional = true }
 # rayon: data-parallel per-package planning compute (#476). CLI-only —
 # the wasm build does no git/monorepo scanning, so it must not pull rayon.
 rayon = { version = "1", optional = true }
-# tracing: structured logging foundation (#513). CLI-only — the wasm build
-# does no logging. tracing-subscriber provides the human (custom
-# message-only) and JSON fmt layers plus EnvFilter (RUST_LOG / verbose).
-tracing = { version = "0.1", optional = true }
+# tracing: structured logging foundation (#513). The macro facade is
+# always compiled (it no-ops without an installed subscriber) so shared
+# code reachable from the wasm build can emit events. Only the subscriber
+# — human (custom message-only) + JSON fmt layers plus EnvFilter
+# (RUST_LOG / verbose) — is CLI-only; the wasm build installs none.
+tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["std", "fmt", "env-filter", "json"], optional = true }
 # tempfile is used at runtime by the TS config loader to drop the
 # generated wrapper script in a directory we own (security: writing into


### PR DESCRIPTION
Closes #654.

The v5.27.0 `Publish @ferrflow/wasm` job failed to compile — `error[E0433]: cannot find module or crate tracing` in `changelog.rs`. The tracing migration (#513) gated `tracing` behind the `cli` feature, but `changelog.rs` is compiled by the wasm build (`ferrflow-wasm` → lib with `default-features = false`) and emits `tracing::info!`. The default Test job builds with `cli`, so it stayed green and the break only surfaced on the wasm publish.

Fix: the `tracing` macro facade is now a non-optional dependency — it compiles to a no-op without an installed subscriber, which is exactly the tracing contract (libraries emit events unconditionally, the binary installs the subscriber). `tracing-subscriber` (the heavy fmt/EnvFilter impl) stays gated behind `cli`; the wasm build installs no subscriber.

Verified: `cargo build --no-default-features --lib` clean, `cargo check -p ferrflow-wasm` clean, default build + `clippy -D warnings` clean, full suite green (669 + 859 tests).
