### PR TITLE
feat(hooks): expand hook points — pre-tag, post-tag, pre-release, on-success, on-error

### DIFF
--- a/docs/configuration/hooks.md
+++ b/docs/configuration/hooks.md
@@ -1,0 +1,92 @@
+# Hooks
+
+Hooks are shell commands FerrFlow runs at fixed points in the release
+lifecycle. Declare them under `workspace.hooks` (applies to every package) or
+under a package's own `hooks` (overrides the workspace value for that package).
+
+```json
+{
+  "workspace": {
+    "hooks": {
+      "preCommit": "cargo test --release",
+      "postTag": "cargo publish --dry-run",
+      "onSuccess": "curl -X POST $DEPLOY_WEBHOOK",
+      "onError": "curl -X POST $SLACK_WEBHOOK -d \"release failed: $FERRFLOW_ERROR_CODE\""
+    }
+  }
+}
+```
+
+## Lifecycle order
+
+Hooks fire in this order during a release:
+
+| Hook | Fires | Scope |
+|------|-------|-------|
+| `preBump` | Before version files are written | per package |
+| `postBump` | After version files are written, before changelog | per package |
+| `preCommit` | After changelog generation, before the git commit | per package |
+| `postCommit` | After the release commit is created, before tagging | per package |
+| `preTag` | After the commit, immediately before `git tag` | per package |
+| `postTag` | After tags are created, before push | per package |
+| `prePublish` | After commit and tag, before push | per package |
+| `postPublish` | After push and forge release creation | per package |
+| `preRelease` | After the release PR is opened, before merge (`releaseCommitMode: pr` only) | once per run |
+| `onSuccess` | After the whole release finishes cleanly | once per run |
+| `onError` | When the release fails at any git op or aborting hook | once per run |
+
+Per-package hooks run once for each package being released, with that
+package's context. Once-per-run hooks (`preRelease`, `onSuccess`, `onError`)
+run a single time for the whole invocation.
+
+`postTag` is the natural place to `cargo publish`: the tag exists locally but
+has not been pushed yet, so if publishing fails you can drop the local tag and
+retry without rewriting remote history.
+
+## Failure handling
+
+`onFailure` is **not** a hook command — it is the strategy for what happens
+when a hook exits non-zero:
+
+- `"abort"` (default): stop the release and surface the error.
+- `"continue"`: log a warning and carry on.
+
+```json
+{ "workspace": { "hooks": { "preBump": "./smoke.sh", "onFailure": "continue" } } }
+```
+
+The reactive hook that *runs* when a release fails is `onError` (distinct from
+the `onFailure` strategy). It fires once, after the failure, and receives the
+failing error code in `FERRFLOW_ERROR_CODE`.
+
+## Context
+
+Every hook runs with these environment variables:
+
+| Variable | Value |
+|----------|-------|
+| `FERRFLOW_PACKAGE` | Package name (empty for once-per-run hooks) |
+| `FERRFLOW_OLD_VERSION` | Version before the bump |
+| `FERRFLOW_NEW_VERSION` | Version after the bump |
+| `FERRFLOW_BUMP_TYPE` | `major` / `minor` / `patch` / prerelease |
+| `FERRFLOW_TAG` | Tag being released (comma-separated list for once-per-run hooks) |
+| `FERRFLOW_PACKAGE_PATH` | Absolute path to the package |
+| `FERRFLOW_CHANNEL` | Prerelease channel, or empty for a stable release |
+| `FERRFLOW_IS_PRERELEASE` | `true` / `false` |
+| `FERRFLOW_DRY_RUN` | `true` when running with `--dry-run` |
+| `FERRFLOW_ERROR_CODE` | Error code (e.g. `E2005`) — set only for `onError` |
+
+For once-per-run hooks (`preRelease`, `onSuccess`, `onError`) the per-package
+variables (`FERRFLOW_PACKAGE`, `FERRFLOW_OLD_VERSION`, …) are empty;
+`FERRFLOW_TAG` holds every released tag joined by commas.
+
+`GITHUB_TOKEN`, `FERRFLOW_TOKEN`, and `GITLAB_TOKEN` are stripped from the hook
+environment so a hook cannot exfiltrate the release token. A hook that needs a
+token must read it from a different variable you inject yourself.
+
+## Dry run
+
+`ferrflow release --dry-run` prints the per-package hooks it *would* run
+(prefixed with `⊙`) without executing them. The once-per-run `onSuccess` /
+`onError` / `preRelease` hooks depend on a real release outcome and are not
+part of the dry-run trace.

--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -390,6 +390,18 @@
           "type": "string",
           "description": "Run after changelog generation, before git commit."
         },
+        "postCommit": {
+          "type": "string",
+          "description": "Run after the release commit is created, before tagging."
+        },
+        "preTag": {
+          "type": "string",
+          "description": "Run after the release commit, immediately before git tag."
+        },
+        "postTag": {
+          "type": "string",
+          "description": "Run after tags are created, before push."
+        },
         "prePublish": {
           "type": "string",
           "description": "Run after commit and tag, before push."
@@ -397,6 +409,18 @@
         "postPublish": {
           "type": "string",
           "description": "Run after push and release creation."
+        },
+        "preRelease": {
+          "type": "string",
+          "description": "Run after the release pull request is opened (PR mode), before merge."
+        },
+        "onSuccess": {
+          "type": "string",
+          "description": "Run once after the release completes successfully."
+        },
+        "onError": {
+          "type": "string",
+          "description": "Run once when the release fails; receives FERRFLOW_ERROR_CODE."
         },
         "onFailure": {
           "type": "string",

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -21,10 +21,22 @@ pub struct HooksConfig {
     pub post_bump: Option<String>,
     #[serde(alias = "preCommit")]
     pub pre_commit: Option<String>,
+    #[serde(alias = "postCommit")]
+    pub post_commit: Option<String>,
+    #[serde(alias = "preTag")]
+    pub pre_tag: Option<String>,
+    #[serde(alias = "postTag")]
+    pub post_tag: Option<String>,
     #[serde(alias = "prePublish")]
     pub pre_publish: Option<String>,
     #[serde(alias = "postPublish")]
     pub post_publish: Option<String>,
+    #[serde(alias = "preRelease")]
+    pub pre_release: Option<String>,
+    #[serde(alias = "onSuccess")]
+    pub on_success: Option<String>,
+    #[serde(alias = "onError")]
+    pub on_error: Option<String>,
     #[serde(default, alias = "onFailure")]
     pub on_failure: Option<OnFailure>,
 }

--- a/src/error_code.rs
+++ b/src/error_code.rs
@@ -32,6 +32,11 @@ impl<T> ErrorCodeExt<T> for anyhow::Result<T> {
 }
 
 #[allow(dead_code)]
+pub fn code_from_error(err: &anyhow::Error) -> Option<String> {
+    err.downcast_ref::<ErrorCode>().map(ToString::to_string)
+}
+
+#[allow(dead_code)]
 pub const CONFIG_NOT_FOUND: ErrorCode = ErrorCode(1001);
 #[allow(dead_code)]
 pub const CONFIG_PARSE_JSON: ErrorCode = ErrorCode(1002);
@@ -322,5 +327,19 @@ mod tests {
         let err = anyhow::anyhow!("plain error");
         let code = err.downcast_ref::<ErrorCode>().copied();
         assert!(code.is_none());
+    }
+
+    #[test]
+    fn code_from_error_finds_wrapped_code() {
+        let err = anyhow::anyhow!("boom")
+            .context(ErrorCode(2004))
+            .context("while pushing");
+        assert_eq!(code_from_error(&err).as_deref(), Some("E2004"));
+    }
+
+    #[test]
+    fn code_from_error_none_when_absent() {
+        let err = anyhow::anyhow!("plain").context("still plain");
+        assert!(code_from_error(&err).is_none());
     }
 }

--- a/src/hooks/context.rs
+++ b/src/hooks/context.rs
@@ -1,3 +1,6 @@
+use std::path::Path;
+
+#[derive(Clone)]
 pub struct HookContext {
     pub package: String,
     pub old_version: String,
@@ -7,4 +10,21 @@ pub struct HookContext {
     pub dry_run: bool,
     pub package_path: String,
     pub channel: Option<String>,
+    pub error_code: Option<String>,
+}
+
+impl HookContext {
+    pub fn release_summary(root: &Path, tags: &[String], dry_run: bool) -> Self {
+        HookContext {
+            package: String::new(),
+            old_version: String::new(),
+            new_version: String::new(),
+            bump_type: String::new(),
+            tag: tags.join(","),
+            dry_run,
+            package_path: root.to_string_lossy().into_owned(),
+            channel: None,
+            error_code: None,
+        }
+    }
 }

--- a/src/hooks/point.rs
+++ b/src/hooks/point.rs
@@ -1,10 +1,16 @@
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HookPoint {
     PreBump,
     PostBump,
     PreCommit,
+    PostCommit,
+    PreTag,
+    PostTag,
     PrePublish,
     PostPublish,
+    PreRelease,
+    OnSuccess,
+    OnError,
 }
 
 impl HookPoint {
@@ -13,8 +19,14 @@ impl HookPoint {
             Self::PreBump => "pre_bump",
             Self::PostBump => "post_bump",
             Self::PreCommit => "pre_commit",
+            Self::PostCommit => "post_commit",
+            Self::PreTag => "pre_tag",
+            Self::PostTag => "post_tag",
             Self::PrePublish => "pre_publish",
             Self::PostPublish => "post_publish",
+            Self::PreRelease => "pre_release",
+            Self::OnSuccess => "on_success",
+            Self::OnError => "on_error",
         }
     }
 }
@@ -28,7 +40,13 @@ mod tests {
         assert_eq!(HookPoint::PreBump.label(), "pre_bump");
         assert_eq!(HookPoint::PostBump.label(), "post_bump");
         assert_eq!(HookPoint::PreCommit.label(), "pre_commit");
+        assert_eq!(HookPoint::PostCommit.label(), "post_commit");
+        assert_eq!(HookPoint::PreTag.label(), "pre_tag");
+        assert_eq!(HookPoint::PostTag.label(), "post_tag");
         assert_eq!(HookPoint::PrePublish.label(), "pre_publish");
         assert_eq!(HookPoint::PostPublish.label(), "post_publish");
+        assert_eq!(HookPoint::PreRelease.label(), "pre_release");
+        assert_eq!(HookPoint::OnSuccess.label(), "on_success");
+        assert_eq!(HookPoint::OnError.label(), "on_error");
     }
 }

--- a/src/hooks/resolve.rs
+++ b/src/hooks/resolve.rs
@@ -12,8 +12,14 @@ pub fn resolve_hook(
             HookPoint::PreBump => h.pre_bump.as_ref(),
             HookPoint::PostBump => h.post_bump.as_ref(),
             HookPoint::PreCommit => h.pre_commit.as_ref(),
+            HookPoint::PostCommit => h.post_commit.as_ref(),
+            HookPoint::PreTag => h.pre_tag.as_ref(),
+            HookPoint::PostTag => h.post_tag.as_ref(),
             HookPoint::PrePublish => h.pre_publish.as_ref(),
             HookPoint::PostPublish => h.post_publish.as_ref(),
+            HookPoint::PreRelease => h.pre_release.as_ref(),
+            HookPoint::OnSuccess => h.on_success.as_ref(),
+            HookPoint::OnError => h.on_error.as_ref(),
         }
     }
 
@@ -125,29 +131,34 @@ mod tests {
             pre_bump: Some("a".into()),
             post_bump: Some("b".into()),
             pre_commit: Some("c".into()),
+            post_commit: Some("f".into()),
+            pre_tag: Some("g".into()),
+            post_tag: Some("h".into()),
             pre_publish: Some("d".into()),
             post_publish: Some("e".into()),
+            pre_release: Some("i".into()),
+            on_success: Some("j".into()),
+            on_error: Some("k".into()),
             on_failure: None,
         };
-        assert_eq!(
-            resolve_hook(Some(&hooks), None, HookPoint::PreBump).as_deref(),
-            Some("a")
-        );
-        assert_eq!(
-            resolve_hook(Some(&hooks), None, HookPoint::PostBump).as_deref(),
-            Some("b")
-        );
-        assert_eq!(
-            resolve_hook(Some(&hooks), None, HookPoint::PreCommit).as_deref(),
-            Some("c")
-        );
-        assert_eq!(
-            resolve_hook(Some(&hooks), None, HookPoint::PrePublish).as_deref(),
-            Some("d")
-        );
-        assert_eq!(
-            resolve_hook(Some(&hooks), None, HookPoint::PostPublish).as_deref(),
-            Some("e")
-        );
+        for (point, expected) in [
+            (HookPoint::PreBump, "a"),
+            (HookPoint::PostBump, "b"),
+            (HookPoint::PreCommit, "c"),
+            (HookPoint::PostCommit, "f"),
+            (HookPoint::PreTag, "g"),
+            (HookPoint::PostTag, "h"),
+            (HookPoint::PrePublish, "d"),
+            (HookPoint::PostPublish, "e"),
+            (HookPoint::PreRelease, "i"),
+            (HookPoint::OnSuccess, "j"),
+            (HookPoint::OnError, "k"),
+        ] {
+            assert_eq!(
+                resolve_hook(Some(&hooks), None, point).as_deref(),
+                Some(expected),
+                "hook point {point:?}"
+            );
+        }
     }
 }

--- a/src/hooks/runner.rs
+++ b/src/hooks/runner.rs
@@ -52,7 +52,11 @@ pub fn run_hook(
         .env("FERRFLOW_DRY_RUN", ctx.dry_run.to_string())
         .env("FERRFLOW_PACKAGE_PATH", &ctx.package_path)
         .env("FERRFLOW_CHANNEL", ctx.channel.as_deref().unwrap_or(""))
-        .env("FERRFLOW_IS_PRERELEASE", ctx.channel.is_some().to_string());
+        .env("FERRFLOW_IS_PRERELEASE", ctx.channel.is_some().to_string())
+        .env(
+            "FERRFLOW_ERROR_CODE",
+            ctx.error_code.as_deref().unwrap_or(""),
+        );
 
     if verbose {
         let status = cmd

--- a/src/monorepo/run/execute.rs
+++ b/src/monorepo/run/execute.rs
@@ -103,6 +103,8 @@ pub(super) fn execute_release(plan: &mut ReleasePlan<'_>) -> Result<()> {
         } else if plan.verbose {
             tracing::info!("  ↻ Resumed: skipping commit (already done)");
         }
+        run_package_hooks(plan, HookPoint::PostCommit)?;
+        run_package_hooks(plan, HookPoint::PreTag)?;
         if !checkpoint_is_done(plan, Phase::TagsCreated) {
             create_release_tags(plan)?;
             create_and_move_floating_tags(plan, &mut floating_tag_names)?;
@@ -110,9 +112,10 @@ pub(super) fn execute_release(plan: &mut ReleasePlan<'_>) -> Result<()> {
         } else if plan.verbose {
             tracing::info!("  ↻ Resumed: skipping tag creation (already done)");
         }
+        run_package_hooks(plan, HookPoint::PostTag)?;
     }
 
-    run_pre_publish_hooks(plan)?;
+    run_package_hooks(plan, HookPoint::PrePublish)?;
 
     if !plan.dry_run {
         if !checkpoint_is_done(plan, Phase::ReleasesCreated) {
@@ -260,6 +263,7 @@ fn run_commit_or_pr(
                             forge_instance.mr_noun(),
                             mr.id.to_string().cyan()
                         ));
+                        run_release_summary_hook(plan, HookPoint::PreRelease)?;
                         if plan.config.workspace.auto_merge_releases {
                             match forge_instance.enable_auto_merge(&mr) {
                                 Ok(()) => {
@@ -371,15 +375,15 @@ fn create_and_move_floating_tags(
     Ok(())
 }
 
-fn run_pre_publish_hooks(plan: &mut ReleasePlan<'_>) -> Result<()> {
+fn run_package_hooks(plan: &ReleasePlan<'_>, point: HookPoint) -> Result<()> {
     for (ctx, pkg_idx) in plan.hook_contexts {
         let pkg = &plan.config.packages[*pkg_idx];
         let ws_hooks = plan.config.workspace.hooks.as_ref();
         let pkg_hooks = pkg.hooks.as_ref();
         let on_failure = resolve_on_failure(pkg_hooks, ws_hooks);
-        if let Some(cmd) = resolve_hook(pkg_hooks, ws_hooks, HookPoint::PrePublish) {
+        if let Some(cmd) = resolve_hook(pkg_hooks, ws_hooks, point) {
             run_hook(
-                HookPoint::PrePublish,
+                point,
                 &cmd,
                 ctx,
                 on_failure,
@@ -388,6 +392,29 @@ fn run_pre_publish_hooks(plan: &mut ReleasePlan<'_>) -> Result<()> {
                 plan.root,
             )?;
         }
+    }
+    Ok(())
+}
+
+fn run_release_summary_hook(plan: &ReleasePlan<'_>, point: HookPoint) -> Result<()> {
+    let ws_hooks = plan.config.workspace.hooks.as_ref();
+    if let Some(cmd) = resolve_hook(None, ws_hooks, point) {
+        let on_failure = resolve_on_failure(None, ws_hooks);
+        let tags: Vec<String> = plan
+            .tags_to_create
+            .iter()
+            .map(|(t, _, _, _, _, _, _)| t.clone())
+            .collect();
+        let ctx = HookContext::release_summary(plan.root, &tags, plan.dry_run);
+        run_hook(
+            point,
+            &cmd,
+            &ctx,
+            on_failure,
+            plan.dry_run,
+            plan.verbose,
+            plan.root,
+        )?;
     }
     Ok(())
 }
@@ -648,6 +675,9 @@ pub(super) fn print_dry_run_hooks(plan: &ReleasePlan<'_>) -> Result<()> {
         let on_failure = resolve_on_failure(pkg_hooks, ws_hooks);
         for point in [
             HookPoint::PreCommit,
+            HookPoint::PostCommit,
+            HookPoint::PreTag,
+            HookPoint::PostTag,
             HookPoint::PrePublish,
             HookPoint::PostPublish,
         ] {

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use crate::changelog::{
     ChangelogRender, GitLog, build_section_with, compute_changelog_update, update_changelog_with,
 };
-use crate::config::{Config, PackageConfig};
+use crate::config::{Config, OnFailure, PackageConfig};
 use crate::conventional_commits::BumpType;
 use crate::diff::unified_diff;
 use crate::formats::{get_handler, render_new_version, write_version};
@@ -395,6 +395,7 @@ pub(super) fn run_release_logic(
                 .to_string_lossy()
                 .into_owned(),
             channel: prerelease_ctx.channel.clone(),
+            error_code: None,
         };
 
         let ws_hooks = config.workspace.hooks.as_ref();
@@ -655,12 +656,50 @@ pub(super) fn run_release_logic(
         let release_start = std::time::Instant::now();
         let release_result = execute_release(&mut plan);
         timing.record("release commit phase", release_start.elapsed());
-        release_result?;
-        // Release finished cleanly — drop the checkpoint so the next
-        // run starts from scratch instead of trying to resume a
-        // finished release.
-        if !dry_run {
-            Checkpoint::delete(root)?;
+
+        let released_tags: Vec<String> = tags_to_create
+            .iter()
+            .map(|(t, _, _, _, _, _, _)| t.clone())
+            .collect();
+        let ws_hooks = config.workspace.hooks.as_ref();
+        match release_result {
+            Ok(()) => {
+                // Release finished cleanly — drop the checkpoint so the
+                // next run starts from scratch instead of trying to
+                // resume a finished release.
+                if !dry_run {
+                    Checkpoint::delete(root)?;
+                }
+                if let Some(cmd) = resolve_hook(None, ws_hooks, HookPoint::OnSuccess) {
+                    let ctx = HookContext::release_summary(root, &released_tags, dry_run);
+                    let on_failure = resolve_on_failure(None, ws_hooks);
+                    run_hook(
+                        HookPoint::OnSuccess,
+                        &cmd,
+                        &ctx,
+                        on_failure,
+                        dry_run,
+                        verbose,
+                        root,
+                    )?;
+                }
+            }
+            Err(err) => {
+                if let Some(cmd) = resolve_hook(None, ws_hooks, HookPoint::OnError) {
+                    let mut ctx = HookContext::release_summary(root, &released_tags, dry_run);
+                    ctx.error_code = crate::error_code::code_from_error(&err);
+                    let _ = run_hook(
+                        HookPoint::OnError,
+                        &cmd,
+                        &ctx,
+                        OnFailure::Continue,
+                        dry_run,
+                        verbose,
+                        root,
+                    );
+                }
+                return Err(err);
+            }
         }
     } else if dry_run && any_bumped {
         let plan = ReleasePlan {

--- a/tests/fixtures/definitions/hooks-ordering.json
+++ b/tests/fixtures/definitions/hooks-ordering.json
@@ -1,10 +1,10 @@
 {
   "meta": {
     "name": "hooks-ordering",
-    "description": "All five hook points are defined to verify lifecycle ordering"
+    "description": "All lifecycle hook points fire without breaking a commit-mode release"
   },
   "config": {
-    "content": "{\n  \"workspace\": {\n    \"hooks\": {\n      \"preBump\": \"echo pre-bump\",\n      \"postBump\": \"echo post-bump\",\n      \"preCommit\": \"echo pre-commit\",\n      \"prePublish\": \"echo pre-publish\",\n      \"postPublish\": \"echo post-publish\"\n    }\n  },\n  \"package\": [\n    {\"name\": \"app\", \"path\": \".\", \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
+    "content": "{\n  \"workspace\": {\n    \"hooks\": {\n      \"preBump\": \"echo pre-bump\",\n      \"postBump\": \"echo post-bump\",\n      \"preCommit\": \"echo pre-commit\",\n      \"postCommit\": \"echo post-commit\",\n      \"preTag\": \"echo pre-tag\",\n      \"postTag\": \"echo post-tag\",\n      \"prePublish\": \"echo pre-publish\",\n      \"postPublish\": \"echo post-publish\",\n      \"onSuccess\": \"echo on-success\"\n    }\n  },\n  \"package\": [\n    {\"name\": \"app\", \"path\": \".\", \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
   },
   "packages": [
     { "name": "app", "path": ".", "initial_version": "1.0.0", "tag": "v1.0.0" }

--- a/tests/fixtures/definitions/hooks-pre-tag-abort.json
+++ b/tests/fixtures/definitions/hooks-pre-tag-abort.json
@@ -1,0 +1,25 @@
+{
+  "meta": {
+    "name": "hooks-pre-tag-abort",
+    "description": "A failing pre_tag hook aborts before the tag is created (commit already made)"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\n    \"hooks\": {\n      \"preTag\": \"./hooks/fail.sh\",\n      \"onFailure\": \"abort\"\n    }\n  },\n  \"package\": [\n    {\"name\": \"app\", \"path\": \".\", \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
+  },
+  "packages": [
+    { "name": "app", "path": ".", "initial_version": "1.0.0", "tag": "v1.0.0" }
+  ],
+  "hooks": [
+    {
+      "path": "hooks/fail.sh",
+      "content": "#!/usr/bin/env bash\nexit 1\n"
+    }
+  ],
+  "commits": [
+    { "message": "feat: trigger bump", "files": ["src/main.rs"] }
+  ],
+  "expect": {
+    "check_contains": ["app"],
+    "check_not_contains": ["Nothing to release"]
+  }
+}


### PR DESCRIPTION
Closes #500.

Expands the release-lifecycle hook points from 5 to 11. New points slot into the existing `execute_release` flow at their natural boundaries.

## New hook points

| Point | Fires | Scope |
|-------|-------|-------|
| `postCommit` | after the release commit, before tagging | per package |
| `preTag` | after the commit, immediately before `git tag` | per package |
| `postTag` | after tags are created, before push | per package |
| `preRelease` | after the release PR opens, before merge (`releaseCommitMode: pr`) | once per run |
| `onSuccess` | after the whole release finishes cleanly | once per run |
| `onError` | when the release fails at a git op or aborting hook | once per run |

`postTag` is the natural `cargo publish` slot — the tag exists locally but isn't pushed, so a failed publish is recoverable by dropping the local tag.

## Naming note

The issue proposed `OnFailure`, but `onFailure` is already the abort/continue **strategy** key in `hooks`. The reactive hook is therefore exposed as `onError` to avoid the collision, and it receives the failing code in `FERRFLOW_ERROR_CODE` (surfaced from the anyhow chain via a new `error_code::code_from_error` helper). `onFailure` (strategy) is unchanged — fully backward compatible.

## Context

`onError` adds `FERRFLOW_ERROR_CODE` to the hook environment (e.g. `E2005`). Once-per-run hooks get an empty `FERRFLOW_PACKAGE` and a comma-joined `FERRFLOW_TAG`. Token stripping (`GITHUB_TOKEN`/`FERRFLOW_TOKEN`/`GITLAB_TOKEN`) is unchanged.

## Tests

- `resolve_all_hook_points` extended to all 11 points; `hook_point_labels` covers the new labels.
- `code_from_error` unit tests — this caught a real bug: a naive `err.chain()` + `std::downcast_ref` misses anyhow context wrappers, so the error code would not have reached `onError` hooks; fixed to use anyhow's chain-searching `downcast_ref`.
- Integration fixtures: `hooks-ordering` now exercises the full set; new `hooks-pre-tag-abort` covers a failing `pre_tag` aborting before the tag is created.

Full suite green (872 tests), `clippy -D warnings` + `fmt` clean, wasm build clean.

## Docs

`docs/configuration/hooks.md` (new) documents all 11 points, ordering, the `onFailure` strategy vs `onError` hook distinction, and the context env vars. Schema (`schema/ferrflow.json`) updated. The ferrflow.com config reference + served schema copy land in a companion FerrFlow-Cloud PR.
