### PR TITLE
feat(bench): add complex dependency-graph benchmark fixture

### DIFF
--- a/benchmarks/fixtures/definitions/complex.json
+++ b/benchmarks/fixtures/definitions/complex.json
@@ -1,0 +1,30 @@
+{
+  "meta": {
+    "name": "complex",
+    "description": "50 packages wired as a dependency DAG (core spine + leaves). Only ferrflow is given the dependency graph (via dependsOn in ferrflow.json); the competitors run over the same packages without inter-package edges, so this fixture measures ferrflow's version-cascade path specifically.",
+    "default_branch": "main"
+  },
+  "generate": {
+    "packages": 50,
+    "commits": 300,
+    "seed": 20250714,
+    "graph": true
+  },
+  "tool_configs": {
+    "ferrflow": {},
+    "changesets": {
+      "package.json": "{\"name\":\"root\",\"private\":true,\"workspaces\":[\"packages/*\"]}",
+      ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.0.0/schema.json\",\"changelog\":\"@changesets/cli/changelog\",\"commit\":false,\"fixed\":[],\"linked\":[],\"access\":\"restricted\",\"baseBranch\":\"main\",\"updateInternalDependencies\":\"patch\",\"ignore\":[]}"
+    },
+    "semantic-release": {
+      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true}",
+      ".releaserc.json": "{\"branches\":[\"main\"],\"plugins\":[\"@semantic-release/commit-analyzer\",\"@semantic-release/release-notes-generator\"]}"
+    },
+    "standard-version": {
+      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true}"
+    },
+    "commit-and-tag-version": {
+      "package.json": "{\"name\":\"root\",\"version\":\"0.1.0\",\"private\":true}"
+    }
+  }
+}


### PR DESCRIPTION
Part of #630. Adds `benchmarks/fixtures/definitions/complex.json` — 50 packages wired as a dependency DAG (core spine + leaves), 300 commits concentrated on the cores.

This is the one scenario where ferrflow does real graph work a flat 'bump everything' tool doesn't: the cores change and the cascade patch-bumps their dependents. **Verified end-to-end** with the graph generator (FerrLabs/Fixtures#137 + #139): `ferrflow check` → 50 released = **10 cores (direct) + 40 leaves (pure cascade, 0 direct commits)**.

Only ferrflow is given the dependency graph (via `dependsOn` in the generated `ferrflow.json`); the competitor tool_configs mirror the other `mono-*` fixtures without inter-package edges (their package.json declare no workspace deps), so `complex` measures ferrflow's version-cascade path specifically — the gap is documented in the fixture description rather than faked, per the issue.

Requires the Fixtures action to include graph mode (`@v1` picks it up once Fixtures cuts the release carrying #137/#139). The site `FIXTURE_LABELS` entry lands in a companion FerrFlow-Cloud PR.