### PR TITLE
chore(ci): bump Benchmarks pin to pull Fixtures v1.1.1 (graph mode)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,7 +478,7 @@ jobs:
           key: bench-npm-cache-${{ hashFiles('.github/workflows/ci.yml', 'benchmarks/fixtures/definitions/*.json') }}
           restore-keys: |
             bench-npm-cache-
-      - uses: FerrLabs/Benchmarks@90ce64396c762ad04a8a89a86a5739c664e0d50f # v5
+      - uses: FerrLabs/Benchmarks@39918d084f48dc4e1ce63fe7c353088e10b03958 # v5 + Fixtures v1.1.1 (graph mode)
         with:
           type: full
           definitions: benchmarks/fixtures/definitions


### PR DESCRIPTION
Closes #663. Completes the unblock for #630.

The competitive benchmark runs `FerrLabs/Benchmarks`, which internally pins `FerrLabs/Fixtures`. That pin was v1.0.5 — no `generate.graph` — so the new `complex` dependency-graph fixture would be generated flat. FerrLabs/Benchmarks#159 bumped it to Fixtures v1.1.1; this re-pins FerrFlow's Benchmarks action to that commit so the benchmark actually generates `complex` with the dependency DAG (10 cores → 40-leaf cascade).

Pinned to the merge commit rather than a version tag because the floating-tag release issue (#662) left `Benchmarks@v5` stuck on the old commit. Once #662 is fixed and the tags advance cleanly, Renovate can normalize this back to a tag.