### PR TITLE
fix(ci): treat ferrflow as first-party in cargo-vet

### DIFF
--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -11,7 +11,7 @@ url = "https://raw.githubusercontent.com/bytecodealliance/wasmtime/main/supply-c
 url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 
 [policy.ferrflow]
-audit-as-crates-io = true
+audit-as-crates-io = false
 
 [[exemptions.aho-corasick]]
 version = "1.1.4"
@@ -279,10 +279,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.fastrand]]
 version = "2.4.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.ferrflow]]
-version = "5.28.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.filetime]]


### PR DESCRIPTION
Closes #665. Unbreaks `Cargo Security` on main.

`cargo vet init` set `[policy.ferrflow] audit-as-crates-io = true`, which makes cargo-vet audit **our own workspace crate** as if it were a third-party crates.io dependency (`ferrflow-wasm` consumes it). The exemption is version-pinned, so every release strands it — v5.29.0 shipped and vetting failed with `ferrflow:5.29.0 missing ["safe-to-deploy"]`. This would recur on **every** release.

- `audit-as-crates-io = false` — ferrflow is a first-party workspace member, not a dependency to audit.
- Dropped the now-unnecessary version-pinned `[[exemptions.ferrflow]]` (via `cargo vet prune`).

Verified locally with cargo-vet 0.10.0 (the CI version) on v5.29.0: `cargo vet` → **Vetting Succeeded (21 fully audited, 1 partially audited, 288 exempted)**.