### PR TITLE
perf(ci): raise benchmark runs to 30

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,6 +537,12 @@ jobs:
           binary-dir: bin
           fixtures-dir: shard-fixtures
           shard: true
+          # Sharding put wall-clock back at the slowest fixture (~4.5 min), so
+          # spend the headroom on samples: 30 runs tightens the median's
+          # standard error by ~1.7x over the action's default of 10. The slowest
+          # shard lands around ~9-10 min — still well under the ~19.5 min the
+          # unsharded job used to take.
+          runs: 30
         env:
           FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
       - name: Upload shard results


### PR DESCRIPTION
Closes #671. The follow-up #670 was setting up.

The full benchmark ran 10 timed samples per measurement — the action's default, sized back when all 7 fixtures ran sequentially in one job. Measured on the first sharded run (`c9219e81`): slowest shard **4.5 min**, sum of shards **19.5 min**. Sharding bought back ~15 minutes of wall-clock; this spends part of it on precision.

**30 runs** tightens the median's standard error by **~1.7x** versus 10 (error falls as 1/sqrt(n)). Only the timed portion scales — roughly 2 min of each shard is fixed setup (npm competitor installs, hyperfine, artifact downloads), so the slowest shard should land around **~9-10 min**, still comfortably under the ~19.5 min the unsharded job took.

Set on the FerrFlow shards rather than the action's default, so callers that haven't sharded aren't handed triple the benchmark time.

Worth keeping in mind: more samples tighten variance *within* a run; they don't remove systematic runner-to-runner noise between runs, so the relative `full-regression-threshold` stays the right gate for regressions over time. (And that gate is currently inert — see FerrLabs/Benchmarks#165.)