### PR TITLE
fix(ci): benchmark ferrflow cold and warm up three times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -527,7 +527,7 @@ jobs:
           key: bench-npm-cache-${{ hashFiles('.github/workflows/ci.yml', 'benchmarks/fixtures/definitions/*.json') }}
           restore-keys: |
             bench-npm-cache-
-      - uses: FerrLabs/Benchmarks@ba4238c7dfaab33a62aba9490cbe152ec8382e1a # v5 + Fixtures v1.1.1 (graph mode) + sharding
+      - uses: FerrLabs/Benchmarks@3d9a4fa078bb94993b8a7f78633aad2a7c740feb # v5 + Fixtures v1.1.1 + sharding + cold-cache benchmark
         with:
           type: full
           definitions: benchmarks/fixtures/definitions
@@ -537,12 +537,14 @@ jobs:
           binary-dir: bin
           fixtures-dir: shard-fixtures
           shard: true
-          # Sharding put wall-clock back at the slowest fixture (~4.5 min), so
-          # spend the headroom on samples: 30 runs tightens the median's
-          # standard error by ~1.7x over the action's default of 10. The slowest
-          # shard lands around ~9-10 min — still well under the ~19.5 min the
-          # unsharded job used to take.
+          # Sharding put wall-clock back at the slowest fixture, so spend the
+          # headroom on samples: 30 runs tightens the median's standard error
+          # by ~1.7x over the action's default of 10.
           runs: 30
+          # The action defaults to 2. Three is what the published methodology
+          # has always claimed, and the extra pass is cheap now that each shard
+          # only carries one fixture.
+          warmup: 3
         env:
           FERRFLOW_HMAC_SECRET: ${{ secrets.FERRFLOW_HMAC_SECRET }}
       - name: Upload shard results
@@ -565,7 +567,7 @@ jobs:
         with:
           pattern: bench-partial-*
           path: partials/
-      - uses: FerrLabs/Benchmarks@ba4238c7dfaab33a62aba9490cbe152ec8382e1a # v5 + Fixtures v1.1.1 (graph mode) + sharding
+      - uses: FerrLabs/Benchmarks@3d9a4fa078bb94993b8a7f78633aad2a7c740feb # v5 + Fixtures v1.1.1 + sharding + cold-cache benchmark
         with:
           type: full
           definitions: benchmarks/fixtures/definitions


### PR DESCRIPTION
Closes #673. Picks up FerrLabs/Benchmarks#170 and FerrLabs/Benchmarks#167.

**The published head-to-head was measuring our cache.** `ferrflow check` memoises under `.git/ferrflow-cache` (5 min TTL, keyed by HEAD+tags+config) and returns early on a hit; hyperfine got no `--prepare` and the fixture never changes, so the warmup primed it and every timed run read it back. The tell is on the live page: ferrflow flat at ~3-5 ms from `1 x 100` to `200 x 10k` — work doesn't stay flat across a 100x bigger history. No competitor has such a cache.

Re-pinning to `3d9a4fa0` brings in:
- **Cold headline** — the cache is dropped before each timed run, so `benchmarks` is comparable across tools. The warm number is still published, as the separate `ferrflow_cached` stat (same rule as `--jobs 1` vs `ferrflow_parallel`).
- **A working regression check** (FerrLabs/Benchmarks#167) — the baseline artifact was never actually found, so `full-regression-threshold` has been inert.
- **`warmup`/`runs` emitted in the results**, so the site can stop hardcoding them.

**`warmup: 3`** — the site's methodology has always said "3 warmup runs"; the action defaults to 2. Rather than correct the page down, take the extra pass: it's cheap now that each shard carries one fixture, and it matches what we've published all along.

**Expect the ferrflow numbers to jump on the next run.** That's the fix working — FerrFlow still wins, by a margin that survives someone re-running the benchmark themselves.