### PR TITLE
fix(release): drop the checkpoint when a failed attempt is cleaned up

### DIFF
--- a/src/monorepo/release.rs
+++ b/src/monorepo/release.rs
@@ -6,6 +6,7 @@ use crate::config::Config;
 use crate::git::{get_repo_root, open_repo};
 use crate::timing::Timing;
 
+use super::run::checkpoint::Checkpoint;
 use super::run::run_release_logic;
 
 const MAX_RELEASE_REGENERATE_ATTEMPTS: usize = 3;
@@ -107,7 +108,7 @@ pub fn release(
                     "{}",
                     format!(
                         "Release attempt {attempt}/{MAX_RELEASE_REGENERATE_ATTEMPTS} \
-                         pushed onto a stale '{}': {e}",
+                         pushed onto a stale '{}': {e:#}",
                         config.workspace.branch,
                     )
                     .yellow()
@@ -151,5 +152,146 @@ fn cleanup_failed_release_attempt(
 
     let target_branch = crate::git::resolve_current_branch(&repo, &config.workspace.branch);
     crate::git::reset_branch_to_remote(&repo, &config.workspace.remote, &target_branch)?;
+
+    // The tags and the release commit this checkpoint recorded are gone, so
+    // it has to go with them. A surviving `TagsCreated` makes the next
+    // attempt skip tag creation and then push tags that were just deleted
+    // (E2006), which also leaves floating tags stranded.
+    Checkpoint::delete(root)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::monorepo::run::checkpoint::Phase;
+    use std::collections::HashSet;
+
+    fn git(dir: &Path, args: &[&str]) -> String {
+        let out = std::process::Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@t.t")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@t.t")
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).to_string()
+    }
+
+    fn commit(dir: &Path, file: &str) {
+        std::fs::write(dir.join(file), file).unwrap();
+        git(dir, &["add", "--", file]);
+        git(dir, &["commit", "-m", &format!("add {file}")]);
+    }
+
+    fn config() -> Config {
+        serde_json::from_str(r#"{"workspace":{"branch":"main","remote":"origin"}}"#).unwrap()
+    }
+
+    // A release attempt that got as far as creating tags, then lost the
+    // push. Mirrors what the regenerate loop hands to the cleanup.
+    fn repo_with_failed_attempt() -> (tempfile::TempDir, std::path::PathBuf, HashSet<String>) {
+        let base = tempfile::tempdir().unwrap();
+
+        let remote = base.path().join("remote.git");
+        std::fs::create_dir_all(&remote).unwrap();
+        git(&remote, &["init", "--bare", "-b", "main"]);
+
+        let local = base.path().join("local");
+        std::fs::create_dir_all(&local).unwrap();
+        git(&local, &["init", "-b", "main"]);
+        git(
+            &local,
+            &["remote", "add", "origin", remote.to_str().unwrap()],
+        );
+        commit(&local, "base.txt");
+        git(&local, &["push", "origin", "main:main"]);
+
+        let pre_attempt_tags: HashSet<String> =
+            crate::git::collect_all_tags(&open_repo(&local).unwrap())
+                .into_iter()
+                .collect();
+
+        commit(&local, "release.txt");
+        git(&local, &["tag", "-a", "v1.1.1", "-m", "Release 1.1.1"]);
+        git(&local, &["tag", "-a", "v1", "-m", "Release 1.1.1"]);
+
+        let head = git(&local, &["rev-parse", "HEAD~1"]).trim().to_string();
+        let mut cp = Checkpoint::new(head, vec!["v1.1.1".to_string()]);
+        cp.advance(Phase::TagsCreated);
+        cp.save(&local).unwrap();
+
+        (base, local, pre_attempt_tags)
+    }
+
+    // The regression behind #662: cleanup deleted the tags but left the
+    // checkpoint at TagsCreated, so the next attempt skipped tag creation
+    // and pushed a v1.1.1 that no longer existed (E2006).
+    #[test]
+    fn cleanup_drops_the_checkpoint_that_recorded_the_deleted_tags() {
+        let (_base, local, pre) = repo_with_failed_attempt();
+        assert!(Checkpoint::load(&local).unwrap().is_some());
+
+        cleanup_failed_release_attempt(&local, &config(), &pre).unwrap();
+
+        assert!(
+            Checkpoint::load(&local).unwrap().is_none(),
+            "a checkpoint surviving the cleanup makes the next attempt skip tag creation"
+        );
+    }
+
+    #[test]
+    fn cleanup_deletes_the_tags_the_failed_attempt_created() {
+        let (_base, local, pre) = repo_with_failed_attempt();
+
+        cleanup_failed_release_attempt(&local, &config(), &pre).unwrap();
+
+        let after: HashSet<String> = crate::git::collect_all_tags(&open_repo(&local).unwrap())
+            .into_iter()
+            .collect();
+        assert!(!after.contains("v1.1.1"), "versioned tag must be gone");
+        assert!(!after.contains("v1"), "floating tag must be gone");
+    }
+
+    // Tags that predate the attempt are not ours to delete.
+    #[test]
+    fn cleanup_keeps_tags_that_existed_before_the_attempt() {
+        let base = tempfile::tempdir().unwrap();
+        let remote = base.path().join("remote.git");
+        std::fs::create_dir_all(&remote).unwrap();
+        git(&remote, &["init", "--bare", "-b", "main"]);
+
+        let local = base.path().join("local");
+        std::fs::create_dir_all(&local).unwrap();
+        git(&local, &["init", "-b", "main"]);
+        git(
+            &local,
+            &["remote", "add", "origin", remote.to_str().unwrap()],
+        );
+        commit(&local, "base.txt");
+        git(&local, &["tag", "-a", "v1.1.0", "-m", "Release 1.1.0"]);
+        git(&local, &["push", "origin", "main:main"]);
+
+        let pre: HashSet<String> = crate::git::collect_all_tags(&open_repo(&local).unwrap())
+            .into_iter()
+            .collect();
+
+        commit(&local, "release.txt");
+        git(&local, &["tag", "-a", "v1.1.1", "-m", "Release 1.1.1"]);
+
+        cleanup_failed_release_attempt(&local, &config(), &pre).unwrap();
+
+        let after: HashSet<String> = crate::git::collect_all_tags(&open_repo(&local).unwrap())
+            .into_iter()
+            .collect();
+        assert!(after.contains("v1.1.0"), "pre-existing tag must survive");
+        assert!(!after.contains("v1.1.1"), "attempt tag must be gone");
+    }
 }

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -21,7 +21,7 @@ use super::types::{CheckCommit, CheckPackage, CheckResult, RunOutput};
 use super::util::{auto_stage_new_files, collect_dirty_files};
 
 mod cascade;
-mod checkpoint;
+pub(super) mod checkpoint;
 mod drafts;
 mod execute;
 mod forced;


### PR DESCRIPTION
Closes #662.

**The issue diagnosed the wrong thing, so this fix is not the one it proposes.** `E2006` is `GIT_PUSH_TAGS`, not `GIT_FLOATING_TAGS` — that is `E2007`:

```rust
pub const GIT_PUSH_TAGS: ErrorCode = ErrorCode(2006);
pub const GIT_FLOATING_TAGS: ErrorCode = ErrorCode(2007);
```

So the failure is not in advancing the floating tag, and it is not a shallow-checkout or missing-fetch problem. Nothing needs `git fetch --tags` and nothing needs `fetch-depth: 0`. The tag it cannot resolve is one we deleted ourselves, moments earlier, in this process.

**What actually happens.** The release regenerate loop, on a rejected push, calls `cleanup_failed_release_attempt`, which deletes every tag the attempt created and resets the branch to the remote tip. It did not touch the checkpoint. So:

1. Attempt 1 creates `v1.1.1` and `v1`, records `Phase::TagsCreated`, then loses the push (`E2004`).
2. Cleanup runs `git tag -d v1.1.1`, `git tag -d v1`, resets the branch — checkpoint still says `TagsCreated`.
3. Attempt 2 sees `TagsCreated` and skips `create_release_tags`, then pushes `v1.1.1` → `could not resolve tag` → `E2006`.

The Fixtures log for run 29351156755 matches step for step: two rebase retries, `E2004`, the reset, `✓ Updated CHANGELOG.md` (attempt 2 rebumping), then `E2006` with no tag-creation line in between.

**This is also why the floating tag is stranded**, which the issue treats as a second symptom. Skipping `create_and_move_floating_tags` leaves `floating_tag_names` empty, so `force_push_tags` is never called — `Fixtures` `v1` sits at `v1.0.5` for exactly the same reason the run went red.

The checkpoint is HEAD-pinned and a mismatch is fatal, which is what makes this reachable at all: it only lands when the remote never moved, i.e. when the push was rejected for a reason other than staleness. The regenerate loop then treats a non-staleness rejection as staleness, resets, and masks the real error with `E2006`.

**The fix.** Cleanup now deletes the checkpoint alongside the tags and the commit it recorded. Undoing the side effects while keeping the record of them is the whole defect. Attempt 2 becomes a genuine fresh attempt: it recreates the tags, and if the push fails again, the *real* error surfaces instead of `E2006`.

Also switches the retry warning from `{e}` to `{e:#}`. `{e}` on an `anyhow::Error` prints only the top context — which, after `.error_code(...)`, is the bare string `E2004`. The underlying git stderr never reached the log, which is a large part of why this was misdiagnosed.

**Tests.** Three, in `monorepo::release::tests`. The load-bearing one asserts no checkpoint survives the cleanup; removing the `Checkpoint::delete` line makes it fail with "a checkpoint surviving the cleanup makes the next attempt skip tag creation" (verified). The other two pin the tag behaviour the cleanup already had: attempt tags are deleted, pre-existing tags are not.

**Left alone deliberately.** `is_push_rejected_error` matches `"push declined due to repository rule"`, so a ruleset rejection deliberately triggers regenerate — which cannot help, since regenerating does not grant permissions. That is a real design question, but a separate one, and `{e:#}` now makes the next occurrence diagnosable rather than guessable.

The stranded tags still need moving by hand once this ships (`Fixtures` `v1` → `v1.1.1`); SHA pins in the Benchmarks chain stay valid either way.