### PR TITLE
feat(ci): benchmark a startup floor alongside every shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,6 +507,15 @@ jobs:
           fi
           mkdir -p shard-fixtures
           cp -r "bench-fixtures/$FIXTURE" shard-fixtures/
+          # The floor rides along in every shard, never as a shard of its own:
+          # startup is a property of this runner, and shards land on different
+          # machines, so subtracting one shard's floor from another's total
+          # would measure the hardware gap instead of the work.
+          if [[ ! -d "bench-fixtures/floor" ]]; then
+            echo "::error::generated fixtures contain no 'floor'"
+            exit 1
+          fi
+          cp -r bench-fixtures/floor shard-fixtures/
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24'
@@ -527,7 +536,7 @@ jobs:
           key: bench-npm-cache-${{ hashFiles('.github/workflows/ci.yml', 'benchmarks/fixtures/definitions/*.json') }}
           restore-keys: |
             bench-npm-cache-
-      - uses: FerrLabs/Benchmarks@3d9a4fa078bb94993b8a7f78633aad2a7c740feb # v5 + Fixtures v1.1.1 + sharding + cold-cache benchmark
+      - uses: FerrLabs/Benchmarks@e1237b5e267fe331ea7dd78bbd313c3bf0ff2c72 # v5 + Fixtures v1.1.1 + sharding + cold-cache + startup/work split
         with:
           type: full
           definitions: benchmarks/fixtures/definitions
@@ -567,7 +576,7 @@ jobs:
         with:
           pattern: bench-partial-*
           path: partials/
-      - uses: FerrLabs/Benchmarks@3d9a4fa078bb94993b8a7f78633aad2a7c740feb # v5 + Fixtures v1.1.1 + sharding + cold-cache benchmark
+      - uses: FerrLabs/Benchmarks@e1237b5e267fe331ea7dd78bbd313c3bf0ff2c72 # v5 + Fixtures v1.1.1 + sharding + cold-cache + startup/work split
         with:
           type: full
           definitions: benchmarks/fixtures/definitions

--- a/benchmarks/fixtures/definitions/floor.json
+++ b/benchmarks/fixtures/definitions/floor.json
@@ -1,0 +1,25 @@
+{
+  "meta": {
+    "name": "floor",
+    "description": "Startup floor: 1 package, 1 commit since the last tag. The smallest real job each tool can be given, so its median is the fixed cost of invoking the tool at all.",
+    "default_branch": "main"
+  },
+  "generate": {
+    "packages": 1,
+    "commits": 1
+  },
+  "tool_configs": {
+    "ferrflow": {
+      "ferrflow.json": "{\"package\":[{\"name\":\"myapp\",\"path\":\".\",\"changelog\":\"CHANGELOG.md\",\"versioned_files\":[{\"path\":\"package.json\",\"format\":\"json\"}]}]}"
+    },
+    "changesets": {
+      "package.json": "{\"name\":\"myapp\",\"version\":\"0.1.0\",\"private\":true}",
+      ".changeset/config.json": "{\"$schema\":\"https://unpkg.com/@changesets/config@3.0.0/schema.json\",\"changelog\":\"@changesets/cli/changelog\",\"commit\":false,\"fixed\":[],\"linked\":[],\"access\":\"restricted\",\"baseBranch\":\"main\",\"updateInternalDependencies\":\"patch\",\"ignore\":[]}",
+      ".changeset/initial.md": "---\n\"myapp\": patch\n---\n\nseed changeset so `changesets status` exits 0 on this single-package fixture\n"
+    },
+    "semantic-release": {
+      "package.json": "{\"name\":\"myapp\",\"version\":\"0.1.0\",\"private\":true}",
+      ".releaserc.json": "{\"branches\":[\"main\"],\"plugins\":[\"@semantic-release/commit-analyzer\",\"@semantic-release/release-notes-generator\"]}"
+    }
+  }
+}


### PR DESCRIPTION
Closes #677. 2/3 — picks up FerrLabs/Benchmarks#173; the chart is FerrLabs/FerrFlow-Cloud.

Adds `benchmarks/fixtures/definitions/floor.json`: 1 package, 1 commit since the last tag, with the same `tool_configs` as `single` so every tool runs its **normal** command down its **normal** code path. That median is each tool's fixed cost of being invoked at all — process spawn, runtime boot, module loading, config resolution — and the action subtracts it to publish `work_ms` next to `median_ms`.

**The floor rides along in every shard rather than being a shard of its own.** Startup is a property of the runner, and shards land on different machines — subtracting one shard's floor from another's total would measure the hardware gap instead of the work. It costs one extra tiny fixture per shard (1 commit), which is noise next to `mono-large`.

**`--version` is not the floor**, though it looks like one: it skips the lazy `require`s the real command pulls in, undercounting startup by ~286 ms for `commit-and-tag-version` and billing the difference as their work. That error flatters us, which is why the floor runs the real command.

`median_ms` stays the headline and is untouched — startup is real time the user waits. Same rule as `--jobs 1` vs `ferrflow_parallel` and cold vs `ferrflow_cached`: our nuances go in separate stats, never the score.

Expect the first run after this to add `startup_ms` / `work_ms` to every cell. The site renders them in the third PR; until then the payload just carries them.