### PR TITLE
fix(ci): trust epage for toml_edit and toml_writer in cargo vet

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -2,3 +2,15 @@
 # cargo-vet audits file
 
 [audits]
+
+[[trusted.toml_edit]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2021-09-13"
+end = "2027-07-15"
+
+[[trusted.toml_writer]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2025-07-08"
+end = "2027-07-15"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -901,16 +901,8 @@ criteria = "safe-to-deploy"
 version = "1.1.1+spec-1.1.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.toml_edit]]
-version = "0.25.12+spec-1.1.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.toml_parser]]
 version = "1.1.2+spec-1.1.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.toml_writer]]
-version = "1.1.1+spec-1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tracing]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,6 +1,20 @@
 
 # cargo-vet imports lock
 
+[[publisher.toml_edit]]
+version = "0.25.13+spec-1.1.0"
+when = "2026-07-14"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.toml_writer]]
+version = "1.1.2+spec-1.1.0"
+when = "2026-07-14"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
 [[audits.bytecode-alliance.audits.adler2]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
Closes #679. **`main` is red right now** — this is the fix.

#675 bumped `toml_edit` to 0.25.13 at 14:53 and `cargo vet` rejected the unaudited diff, exiting 255. Everything merged since inherits it: #676 and #678 both show `Cargo Security` failing and neither touches Rust dependencies.

Our exemptions are pinned per version:

```toml
[[exemptions.toml_edit]]
version = "0.25.12+spec-1.1.0"
```

So every bump re-breaks the build and needs a hand-edit that Renovate cannot make — the same shape as the `minimumReleaseAge` treadmill: the only PRs needing the exemption are the ones that can't add it.

`cargo vet trust` records the publisher instead of the version, so future bumps are covered. Both crates are published by Ed Page (epage), whom mozilla and bytecode-alliance — the two audit sets we already import — both trust; `cargo vet` suggests this itself in the error. Trusted per crate rather than `--all epage`, so it stays scoped to what we actually depend on.

Drops the two now-redundant exemptions as a side effect. `cargo vet` passes locally on 0.10.0, the version CI installs: `Vetting Succeeded (23 fully audited, 1 partially audited, 286 exempted)`.