### PR TITLE
perf(monorepo): reuse the tag index ancestor set instead of walking twice

### DIFF
--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -142,18 +142,16 @@ pub(super) fn run_release_logic(
         .unwrap_or_default();
 
     let all_tags = collect_all_tags(&repo);
-    // Build the HEAD ancestor set once so the per-package find_*_tag calls
-    // below can skip their per-tag graph_descendant_of walk. On dense
-    // monorepos (mono-large: 200 pkg × 10k commits) this is the
-    // difference between 1.8 s and a couple hundred ms for the tag-bound
-    // commands.
-    let head_ancestors = crate::git::build_head_ancestors(&repo).ok();
     // Pre-collect all tags + their commit OIDs in one tag_foreach scan
     // so the per-package find_*_tag / get_*_since_tag calls below don't
     // each repeat that scan. Coupled with the ancestor set, the per-pkg
     // lookups collapse from O(tags) callbacks + O(commits) walk to O(1)
     // hash hits.
     let tag_index = timing.stage("build TagIndex", || crate::git::TagIndex::build(&repo).ok());
+    let fallback_ancestors = match &tag_index {
+        Some(_) => None,
+        None => crate::git::build_head_ancestors(&repo).ok(),
+    };
 
     let target_branch = if prerelease_ctx.is_prerelease() {
         current_branch.clone()
@@ -195,7 +193,10 @@ pub(super) fn run_release_logic(
         config,
         root,
         tag_index: tag_index.as_ref(),
-        head_ancestors: head_ancestors.as_ref(),
+        head_ancestors: tag_index
+            .as_ref()
+            .map(|idx| &idx.ancestors)
+            .or(fallback_ancestors.as_ref()),
         all_tags: &all_tags,
         prerelease_ctx: &prerelease_ctx,
         forced: &forced,


### PR DESCRIPTION
`run_release_logic` walked HEAD's full ancestry twice, and threw the first walk away.

`build_head_ancestors` (mod.rs:150) and `TagIndex::build` run the byte-identical revwalk, and `TagIndex` already exposes the result as `pub ancestors`. On top of that, all four reads of `inputs.head_ancestors` (plan.rs:128/160/183/197) live in the `else` of `if let (Some(idx), OrphanedTagStrategy::Warn) = (inputs.tag_index, strategy)` — and `Warn` is `#[default]` while `TagIndex::build` normally succeeds. So in the default configuration the first walk was **dead work**: nothing read it.

`src/query.rs:229` already does `Some(&idx.ancestors)`; this path simply missed the same reuse.

Now the index is built first and its ancestor set is passed through; the standalone walk only runs as a fallback when the index is unavailable (which is also the only case where the `else` branches can fire).

### Measured — A/B on the real CI fixture

`mono-large` (200 packages × 10k commits), generated from `benchmarks/fixtures/definitions/mono-large.json` with the `Fixtures` generator and the same `ferrflow.json` the benchmark harness writes. `check --jobs 1`, cache cleared before every run, same binary/machine, n=3:

| | run 1 | run 2 | run 3 | median |
|---|---|---|---|---|
| before | 2722 ms | 2568 ms | 2551 ms | **2568 ms** |
| after | 2069 ms | 2078 ms | 2137 ms | **2078 ms** |

**−490 ms, −19%.**

This is not a benchmark-only win. The cache key is `head + tags_hash + config_hash` (cache.rs:42-56), so every push invalidates it — a one-run-per-push CI job is always cold. Cold numbers are the real numbers.

875 tests pass, `clippy -D warnings` clean. No observable behaviour change: the ancestor set is identical, only its provenance changes.

Closes #682