### PR TITLE
perf(monorepo): memoize the recover-missed-releases diff per tag commit

### DIFF
--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -189,6 +189,7 @@ pub(super) fn run_release_logic(
     let compute_start = std::time::Instant::now();
 
     let thread_safe_repo = repo.clone().into_sync();
+    let changed_files_cache = plan::ChangedFilesCache::default();
     let plan_inputs = PlanInputs {
         config,
         root,
@@ -202,6 +203,7 @@ pub(super) fn run_release_logic(
         forced: &forced,
         changed_files: &changed_files,
         short_hash: &short_hash,
+        changed_files_cache: &changed_files_cache,
     };
     let plans: Vec<PackagePlan> = config
         .packages

--- a/src/monorepo/run/plan.rs
+++ b/src/monorepo/run/plan.rs
@@ -12,8 +12,9 @@ use crate::git::{
 use crate::prerelease::PrereleaseContext;
 use crate::versioning::compute_next_version;
 use gix::ObjectId;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 use super::super::util::{is_package_touched, pick_higher_semver, tags_for_package};
 use super::forced::{Forced, forced_version_for};
@@ -92,6 +93,8 @@ impl PackagePlan {
     }
 }
 
+pub(super) type ChangedFilesCache = Mutex<HashMap<Option<ObjectId>, Arc<Vec<String>>>>;
+
 pub(super) struct PlanInputs<'a> {
     pub config: &'a Config,
     pub root: &'a Path,
@@ -102,6 +105,27 @@ pub(super) struct PlanInputs<'a> {
     pub forced: &'a Option<Forced<'a>>,
     pub changed_files: &'a [String],
     pub short_hash: &'a str,
+    pub changed_files_cache: &'a ChangedFilesCache,
+}
+
+fn changed_files_since_oid_cached(
+    repo: &Repository,
+    last_tag_oid: Option<ObjectId>,
+    cache: &ChangedFilesCache,
+) -> Result<Arc<Vec<String>>> {
+    if let Some(hit) = cache
+        .lock()
+        .expect("changed-files cache poisoned")
+        .get(&last_tag_oid)
+    {
+        return Ok(Arc::clone(hit));
+    }
+    let files = Arc::new(get_changed_files_since_oid(repo, last_tag_oid)?);
+    cache
+        .lock()
+        .expect("changed-files cache poisoned")
+        .insert(last_tag_oid, Arc::clone(&files));
+    Ok(files)
 }
 
 pub(super) fn compute_plan(
@@ -119,14 +143,18 @@ pub(super) fn compute_plan(
 
     if !touched && config.workspace.recover_missed_releases && is_monorepo {
         let strategy = config.workspace.orphaned_tag_strategy;
-        let files_since_tag = if let (Some(idx), OrphanedTagStrategy::Warn) =
-            (inputs.tag_index, strategy)
-        {
-            let last_oid = idx.find_last_tag_commit(&tag_search_prefix, strategy);
-            get_changed_files_since_oid(repo, last_oid)?
-        } else {
-            get_changed_files_since_tag(repo, &tag_search_prefix, strategy, inputs.head_ancestors)?
-        };
+        let files_since_tag =
+            if let (Some(idx), OrphanedTagStrategy::Warn) = (inputs.tag_index, strategy) {
+                let last_oid = idx.find_last_tag_commit(&tag_search_prefix, strategy);
+                changed_files_since_oid_cached(repo, last_oid, inputs.changed_files_cache)?
+            } else {
+                Arc::new(get_changed_files_since_tag(
+                    repo,
+                    &tag_search_prefix,
+                    strategy,
+                    inputs.head_ancestors,
+                )?)
+            };
         if is_package_touched(pkg, &files_since_tag, true) {
             touched = true;
             recovered = true;
@@ -347,6 +375,7 @@ mod tests {
         repo: crate::git::Repository,
         config: Config,
         root: std::path::PathBuf,
+        cache: ChangedFilesCache,
     }
 
     fn build_inputs<'a>(
@@ -368,6 +397,7 @@ mod tests {
             forced,
             changed_files,
             short_hash: "deadbee",
+            changed_files_cache: &fx.cache,
         }
     }
 
@@ -433,6 +463,7 @@ mod tests {
             repo,
             config,
             root: root.clone(),
+            cache: ChangedFilesCache::default(),
         };
 
         let all_tags = collect_all_tags(&fx.repo);
@@ -485,6 +516,7 @@ mod tests {
             repo,
             config,
             root: root.clone(),
+            cache: ChangedFilesCache::default(),
         };
 
         let all_tags = collect_all_tags(&fx.repo);


### PR DESCRIPTION
With `recoverMissedReleases` on, every untouched package called `get_changed_files_since_oid`, which shells out to `git diff --name-only <oid> HEAD` (git/shell.rs:19) — **one subprocess per package**.

The answer depends only on `last_tag_oid` and HEAD. In a monorepo released as a unit, every package's tag points at the same commit: on the `complex` benchmark fixture, **50 tags resolve to 1 distinct commit**. So FerrFlow was spawning ~50 processes to compute the same diff 50 times.

Memoizing by `Option<ObjectId>` collapses that to one call per distinct tag commit. The lock is held only around the map lookup and insert, never across the git call, so `--jobs N` still runs in parallel; a lost race just recomputes once, which is harmless because the function is pure in its inputs.

### Measured — real CI fixture

`complex` (50 packages, 300 commits), generated from `benchmarks/fixtures/definitions/complex.json`, `recoverMissedReleases: true`, `check --jobs 1`, cache cleared before every run, n=3:

| | run 1 | run 2 | run 3 | median |
|---|---|---|---|---|
| before | 5312 ms | 3970 ms | 4038 ms | **4038 ms** |
| after | 3034 ms | 3132 ms | 3033 ms | **3034 ms** |

**−1004 ms, −25%.** Identical output (50 packages planned), 875 tests pass, `clippy --all-targets -D warnings` clean.

### Scope, honestly

This does **not** move the published benchmark: `complex.json` does not enable `recoverMissedReleases`, so the feature is not exercised there. It is a win for real users who turn it on.

The magnitude is also machine-dependent: it was measured on Windows, where process spawn costs 20–40 ms against roughly 2–8 ms on the Linux CI runner. The *shape* of the win (P spawns → 1) holds everywhere; the absolute number will be smaller on CI.

Deliberately not attempted here: replacing the subprocess with an in-process gix tree diff. That would drop the last spawn too, but `git diff --name-only` applies rename detection by default, and the result feeds `is_package_touched` — so getting it wrong silently changes which packages get released. Worth doing separately, with that semantics pinned down first.

Closes #684