### PR TITLE
chore(ci): pick up seeded changesets and the semantic-release fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -536,7 +536,7 @@ jobs:
           key: bench-npm-cache-${{ hashFiles('.github/workflows/ci.yml', 'benchmarks/fixtures/definitions/*.json') }}
           restore-keys: |
             bench-npm-cache-
-      - uses: FerrLabs/Benchmarks@e1237b5e267fe331ea7dd78bbd313c3bf0ff2c72 # v5 + Fixtures v1.1.1 + sharding + cold-cache + startup/work split
+      - uses: FerrLabs/Benchmarks@4b589da3decd4d5ff9372b73410b6e516f2e0b02 # v5.5.0 + startup/work split + seeded changesets + semantic-release fix
         with:
           type: full
           definitions: benchmarks/fixtures/definitions
@@ -576,7 +576,7 @@ jobs:
         with:
           pattern: bench-partial-*
           path: partials/
-      - uses: FerrLabs/Benchmarks@e1237b5e267fe331ea7dd78bbd313c3bf0ff2c72 # v5 + Fixtures v1.1.1 + sharding + cold-cache + startup/work split
+      - uses: FerrLabs/Benchmarks@4b589da3decd4d5ff9372b73410b6e516f2e0b02 # v5.5.0 + startup/work split + seeded changesets + semantic-release fix
         with:
           type: full
           definitions: benchmarks/fixtures/definitions


### PR DESCRIPTION
Re-pins the Benchmarks action from `e1237b5e` to `4b589da3` (v5.5.0). Without this the two fixes below sit on Benchmarks `main` and never reach a run — the action is SHA-pinned.

**FerrLabs/Benchmarks#178 — semantic-release runs again.** It produced zero cells and was silently absent from the perf page. `git init --bare` points `HEAD` at `refs/heads/master` while the fixtures are on `main`, so semantic-release's early `git fetch --tags origin` died with `fatal: couldn't find remote ref HEAD` and every fixture reported `SKIP: command failed`. Expect it to appear in the chart on the next run, as the heaviest competitor by some margin (~3.7s on `single` locally, ~1.6s of it work).

**FerrLabs/Benchmarks#176 — changesets gets real input.** Six of seven fixtures gave it no `.changeset/*.md`, so `changesets status` printed "NO packages to be bumped" and we published the result as a benchmark. It now gets the changesets a maintainer would have written for the same history — 200 on `mono-large`, at the levels FerrFlow derives from the same commits.

Worth being clear: #176 does **not** move the numbers. A/B on the real fixture put it at -35ms, i.e. noise — reading 200 changeset files is free, and changesets never reads the 10k commits by design. What changes is what the number means: `733 ms` was changesets doing nothing; now it is changesets planning a real 200-package release.