### PR TITLE
chore(ci): pick up the semantic-release file:// remote fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -536,7 +536,7 @@ jobs:
           key: bench-npm-cache-${{ hashFiles('.github/workflows/ci.yml', 'benchmarks/fixtures/definitions/*.json') }}
           restore-keys: |
             bench-npm-cache-
-      - uses: FerrLabs/Benchmarks@4b589da3decd4d5ff9372b73410b6e516f2e0b02 # v5.5.0 + startup/work split + seeded changesets + semantic-release fix
+      - uses: FerrLabs/Benchmarks@5a4746ea75afca8edcdae739a255af93909ad96f # v5.5.1 + startup/work split + seeded changesets + semantic-release file:// remote
         with:
           type: full
           definitions: benchmarks/fixtures/definitions
@@ -576,7 +576,7 @@ jobs:
         with:
           pattern: bench-partial-*
           path: partials/
-      - uses: FerrLabs/Benchmarks@4b589da3decd4d5ff9372b73410b6e516f2e0b02 # v5.5.0 + startup/work split + seeded changesets + semantic-release fix
+      - uses: FerrLabs/Benchmarks@5a4746ea75afca8edcdae739a255af93909ad96f # v5.5.1 + startup/work split + seeded changesets + semantic-release file:// remote
         with:
           type: full
           definitions: benchmarks/fixtures/definitions


### PR DESCRIPTION
Re-pins the Benchmarks action from `4b589da3` to `5a4746ea` (v5.5.1). SHA-pinned, so FerrLabs/Benchmarks#181 does not reach a run without this.

semantic-release still produced **zero cells** after the previous re-pin (#686). #178 fixed the dangling remote `HEAD`, but a second failure hid behind it: semantic-release feeds `origin` to `new URL()` when generating notes, and the bare `mktemp -d` path throws `TypeError: Invalid URL` on Linux. FerrLabs/Benchmarks#181 addresses the remote as `file://`; `generateNotes` now completes and it resolves a real next version.

I confirmed this against the artifact, not the green tick — the run after #686 was green with semantic-release absent, which is the whole failure mode. Expect it to finally appear in the chart on the next run, as the heaviest competitor.