### PR TITLE
refactor(git): compute changed files with an in-process gix tree diff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,6 +652,7 @@ dependencies = [
  "colored",
  "criterion",
  "gix",
+ "gix-diff",
  "gix-traverse",
  "glob-match",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ workspace = true
 
 [features]
 default = ["cli"]
-cli = ["dep:gix", "dep:gix-traverse", "dep:ureq", "dep:clap", "dep:clap_complete", "dep:colored", "dep:hmac", "dep:mimalloc", "dep:rayon", "dep:tracing-subscriber"]
+cli = ["dep:gix", "dep:gix-traverse", "dep:gix-diff", "dep:ureq", "dep:clap", "dep:clap_complete", "dep:colored", "dep:hmac", "dep:mimalloc", "dep:rayon", "dep:tracing-subscriber"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -53,6 +53,7 @@ clap_complete = { version = "4", optional = true }
 colored = { version = "3", optional = true }
 gix = { version = "0.85", default-features = false, features = ["sha1", "max-performance-safe", "revision"], optional = true }
 gix-traverse = { version = "0.59", optional = true }
+gix-diff = { version = "0.65", default-features = false, optional = true }
 ureq = { version = "3", features = ["json"], optional = true }
 sha2 = "0.11.0"
 hex = "0.4.3"

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -1,52 +1,33 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use gix::ObjectId;
+use gix::objs::TreeRefIter;
+use gix_diff::tree::recorder::Change;
 use std::collections::HashSet;
 
 use crate::config::OrphanedTagStrategy;
 
 use super::repo::Repository;
-use super::shell::run_git;
 use super::tags::find_last_tag_commit;
 
 pub fn get_changed_files(repo: &Repository) -> Result<Vec<String>> {
-    let workdir = match repo.workdir() {
-        Some(p) => p,
-        None => return Ok(vec![]),
-    };
+    if repo.workdir().is_none() {
+        return Ok(vec![]);
+    }
     let head = match repo.head_id() {
         Ok(id) => id.detach(),
         Err(_) => return Ok(vec![]),
     };
 
-    let has_parent = repo
+    let mut parents: Vec<ObjectId> = repo
         .find_commit(head)
-        .ok()
-        .and_then(|c| c.parent_ids().next())
-        .is_some();
-
-    let args: Vec<String> = if has_parent {
-        vec![
-            "diff-tree".into(),
-            "--no-commit-id".into(),
-            "--name-only".into(),
-            "-r".into(),
-            head.to_string(),
-        ]
-    } else {
-        vec![
-            "ls-tree".into(),
-            "-r".into(),
-            "--name-only".into(),
-            head.to_string(),
-        ]
-    };
-    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-    let out = run_git(workdir, &arg_refs)?;
-    Ok(out
-        .lines()
-        .filter(|l| !l.is_empty())
-        .map(String::from)
-        .collect())
+        .map(|c| c.parent_ids().map(|id| id.detach()).collect())
+        .unwrap_or_default();
+    // `git diff-tree` prints nothing for merge commits unless -m/-c is given;
+    // the previous shell-out inherited that, so an empty list is the contract.
+    if parents.len() > 1 {
+        return Ok(vec![]);
+    }
+    changed_paths_between(repo, parents.pop(), head)
 }
 
 pub fn get_changed_files_since_tag(
@@ -63,35 +44,68 @@ pub fn get_changed_files_since_oid(
     repo: &Repository,
     last_tag_oid: Option<ObjectId>,
 ) -> Result<Vec<String>> {
-    let workdir = match repo.workdir() {
-        Some(p) => p,
-        None => return Ok(vec![]),
-    };
+    if repo.workdir().is_none() {
+        return Ok(vec![]);
+    }
     let head = match repo.head_id() {
         Ok(id) => id.detach(),
         Err(_) => return Ok(vec![]),
     };
+    changed_paths_between(repo, last_tag_oid, head)
+}
 
-    let head_str = head.to_string();
-    let args: Vec<String> = match last_tag_oid {
-        Some(tag_oid) => vec![
-            "diff".into(),
-            "--name-only".into(),
-            tag_oid.to_string(),
-            head_str,
-        ],
-        None => vec![
-            "ls-tree".into(),
-            "-r".into(),
-            "--name-only".into(),
-            head_str,
-        ],
-    };
-    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-    let out = run_git(workdir, &arg_refs)?;
-    Ok(out
-        .lines()
-        .filter(|l| !l.is_empty())
-        .map(String::from)
-        .collect())
+fn changed_paths_between(
+    repo: &Repository,
+    from: Option<ObjectId>,
+    to: ObjectId,
+) -> Result<Vec<String>> {
+    let to_tree = tree_bytes(repo, to)?;
+    let from_tree = from.map(|oid| tree_bytes(repo, oid)).transpose()?;
+
+    let hash_kind = repo.object_hash();
+    let mut recorder = gix_diff::tree::Recorder::default();
+    gix_diff::tree(
+        TreeRefIter::from_bytes(from_tree.as_deref().unwrap_or_default(), hash_kind),
+        TreeRefIter::from_bytes(&to_tree, hash_kind),
+        gix_diff::tree::State::default(),
+        &repo.objects,
+        &mut recorder,
+    )
+    .with_context(|| format!("tree diff failed for {to}"))?;
+
+    let mut paths: Vec<String> = recorder
+        .records
+        .into_iter()
+        .filter_map(|change| {
+            let (mode, path) = match change {
+                Change::Addition {
+                    entry_mode, path, ..
+                } => (entry_mode, path),
+                Change::Deletion {
+                    entry_mode, path, ..
+                } => (entry_mode, path),
+                Change::Modification {
+                    entry_mode, path, ..
+                } => (entry_mode, path),
+            };
+            (!mode.is_tree()).then(|| path.to_string())
+        })
+        .collect();
+    paths.sort_unstable();
+    paths.dedup();
+    Ok(paths)
+}
+
+fn tree_bytes(repo: &Repository, commit: ObjectId) -> Result<Vec<u8>> {
+    let tree_id = repo
+        .find_commit(commit)
+        .with_context(|| format!("commit {commit} not found"))?
+        .tree_id()
+        .with_context(|| format!("no tree for commit {commit}"))?
+        .detach();
+    Ok(repo
+        .find_object(tree_id)
+        .with_context(|| format!("tree {tree_id} not found"))?
+        .detach()
+        .data)
 }

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -623,6 +623,64 @@ fn get_changed_files_since_tag_only_new() {
 }
 
 #[test]
+fn get_changed_files_since_tag_lists_deletions() {
+    let (dir, repo) = init_repo();
+    create_commit_in_repo(&repo, dir.path(), "a.txt", "first");
+    create_commit_in_repo(&repo, dir.path(), "b.txt", "second");
+    create_lightweight_tag(&repo, "v1.0.0");
+    git(dir.path(), &["rm", "-q", "--", "a.txt"]);
+    git(dir.path(), &["commit", "-m", "remove a"]);
+
+    let files = get_changed_files_since_tag(&repo, "v", OrphanedTagStrategy::Warn, None).unwrap();
+    assert!(files.contains(&"a.txt".to_string()));
+    assert!(!files.contains(&"b.txt".to_string()));
+}
+
+#[test]
+fn get_changed_files_since_tag_lists_both_sides_of_a_rename() {
+    let (dir, repo) = init_repo();
+    create_commit_in_repo(&repo, dir.path(), "old.txt", "first");
+    create_lightweight_tag(&repo, "v1.0.0");
+    git(dir.path(), &["mv", "old.txt", "new.txt"]);
+    git(dir.path(), &["commit", "-m", "rename"]);
+
+    let files = get_changed_files_since_tag(&repo, "v", OrphanedTagStrategy::Warn, None).unwrap();
+    assert!(files.contains(&"old.txt".to_string()));
+    assert!(files.contains(&"new.txt".to_string()));
+}
+
+#[test]
+fn get_changed_files_since_tag_nested_paths_are_full_and_unquoted() {
+    let (dir, repo) = init_repo();
+    create_commit_in_repo(&repo, dir.path(), "a.txt", "first");
+    create_lightweight_tag(&repo, "v1.0.0");
+    std::fs::create_dir_all(dir.path().join("packages/café")).unwrap();
+    std::fs::write(dir.path().join("packages/café/index.js"), "x").unwrap();
+    git(dir.path(), &["add", "--", "packages"]);
+    git(dir.path(), &["commit", "-m", "add nested"]);
+
+    let files = get_changed_files_since_tag(&repo, "v", OrphanedTagStrategy::Warn, None).unwrap();
+    assert_eq!(files, vec!["packages/café/index.js".to_string()]);
+}
+
+#[test]
+fn get_changed_files_empty_for_merge_commits() {
+    let (dir, repo) = init_repo();
+    create_commit_in_repo(&repo, dir.path(), "a.txt", "first");
+    git(dir.path(), &["checkout", "-q", "-b", "side"]);
+    create_commit_in_repo(&repo, dir.path(), "b.txt", "second");
+    git(dir.path(), &["checkout", "-q", "-"]);
+    create_commit_in_repo(&repo, dir.path(), "c.txt", "third");
+    git(
+        dir.path(),
+        &["merge", "-q", "--no-ff", "side", "-m", "merge side"],
+    );
+
+    let files = get_changed_files(&repo).unwrap();
+    assert!(files.is_empty());
+}
+
+#[test]
 fn walks_stay_correct_with_commit_graph_present() {
     let (dir, repo) = init_repo();
     create_commit_in_repo(&repo, dir.path(), "a.txt", "feat: first");


### PR DESCRIPTION
Replaces the per-package `git diff --name-only` / `git diff-tree` / `git ls-tree` subprocesses in `get_changed_files` and `get_changed_files_since_oid` with an in-process `gix-diff` tree walk (`gix_diff::tree` + `Recorder`). `gix-diff` was already in the dependency graph; it is now a direct dependency with default features off — no blob/content machinery, this is a structural tree diff only.

### Why — and an honest note on performance

**This is a correctness and robustness change first, not the perf win the analysis projected.** The original profiling attributed ~40 ms per spawn to this path (~80% of its cost) and predicted a collapse. My A/B today, same machine, same `complex` fixture with `recoverMissedReleases`, cold cache, `--jobs 1`, n=3: **4162 ms → 4102 ms (~1.5%)**. Process spawn cost is wildly environment-dependent on Windows (2–40 ms depending on AV pressure) — the earlier measurement caught the expensive regime, today's the cheap one. What actually dominates this path in both versions is the per-touched-package commit walk, which is a separate, known finding. In-process still removes the spawn-cost lottery and the runtime dependency on a `git` binary; the win on Linux CI remains to be measured there.

### What it fixes outright

- **`core.quotePath` bug.** `git diff --name-only` escapes non-ASCII paths (`"caf\303\251.txt"`), so such paths could never match `is_package_touched` — a package whose changed files include accented names was silently never recovered. The gix walk returns raw paths. Covered by a new test asserting `packages/café/index.js` comes back verbatim.
- **Rename inconsistency.** `git diff` porcelain applies rename detection (a cross-package rename listed only its destination); `git diff-tree` plumbing, used by the sibling function, does not. Both functions now share plumbing semantics: a rename lists **both** paths, so the source package of a cross-package move counts as touched too. New test pins this.

### Semantics deliberately preserved

- Merge commits: `git diff-tree` prints nothing for merges without `-m`/`-c`; `get_changed_files` keeps returning an empty list (verified against real git before implementing, and pinned by a new test).
- `None` tag oid still yields the full file list — now as a diff against the empty tree, one code path instead of an `ls-tree` special case.
- Bare repositories still return an empty list.

1565 tests pass (5 new: deletion listing, rename both-sides, unquoted nested non-ASCII path, merge-commit emptiness, plus the existing suite), `clippy -D warnings` clean.

Closes #688