### PR TITLE
perf(monorepo): share one decoded commit walk across touched packages

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -9,6 +9,7 @@ use anyhow::Result;
 use chrono::Local;
 use std::path::Path;
 
+#[derive(Clone)]
 pub struct GitLog {
     pub hash: String,
     pub message: String,

--- a/src/git/commit_walk.rs
+++ b/src/git/commit_walk.rs
@@ -1,0 +1,136 @@
+use anyhow::Result;
+use gix::ObjectId;
+use gix::revision::walk::Sorting;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use super::commits::{GitLog, get_commits_since_oid, subject_has_skip_marker};
+use super::repo::Repository;
+
+// A hidden revwalk only visits commits past the stop boundary, so with one
+// or two touched packages it is far cheaper than decoding all of HEAD's
+// ancestry. The shared walk only starts paying for itself once several
+// packages ask, hence the arming threshold.
+const SHARED_WALK_THRESHOLD: usize = 2;
+
+pub struct CommitWalkCache {
+    skip_markers: Vec<String>,
+    calls: AtomicUsize,
+    built: Mutex<Option<Arc<BuiltWalk>>>,
+}
+
+struct BuiltWalk {
+    commits: Vec<DecodedCommit>,
+    pos: HashMap<ObjectId, usize>,
+}
+
+struct DecodedCommit {
+    log: GitLog,
+    skipped: bool,
+    parents: Vec<ObjectId>,
+}
+
+impl CommitWalkCache {
+    pub fn new(skip_markers: Vec<String>) -> Self {
+        Self {
+            skip_markers,
+            calls: AtomicUsize::new(0),
+            built: Mutex::new(None),
+        }
+    }
+
+    // Decodes HEAD's ancestry once and answers every per-package
+    // "commits since <tag commit>" from it: the hidden set of a stop is
+    // recovered with an in-memory parent walk instead of a fresh revwalk
+    // per package. A stop that is not an ancestor of HEAD may still hide
+    // shared history the parent map cannot see, so that case falls back
+    // to the plain hidden revwalk.
+    pub fn commits_since(&self, repo: &Repository, stop: Option<ObjectId>) -> Result<Vec<GitLog>> {
+        let already_built = self
+            .built
+            .lock()
+            .expect("commit walk cache poisoned")
+            .is_some();
+        if !already_built && self.calls.fetch_add(1, Ordering::Relaxed) < SHARED_WALK_THRESHOLD {
+            return get_commits_since_oid(repo, stop, &self.skip_markers);
+        }
+        let built = self.get_or_build(repo)?;
+        let hidden = match stop {
+            None => HashSet::new(),
+            Some(stop) => {
+                let Some(&start) = built.pos.get(&stop) else {
+                    return get_commits_since_oid(repo, Some(stop), &self.skip_markers);
+                };
+                let mut hidden = HashSet::from([start]);
+                let mut queue = VecDeque::from([start]);
+                while let Some(i) = queue.pop_front() {
+                    for parent in &built.commits[i].parents {
+                        if let Some(&pi) = built.pos.get(parent)
+                            && hidden.insert(pi)
+                        {
+                            queue.push_back(pi);
+                        }
+                    }
+                }
+                hidden
+            }
+        };
+        Ok(built
+            .commits
+            .iter()
+            .enumerate()
+            .filter(|(i, c)| !c.skipped && !hidden.contains(i))
+            .map(|(_, c)| c.log.clone())
+            .collect())
+    }
+
+    fn get_or_build(&self, repo: &Repository) -> Result<Arc<BuiltWalk>> {
+        let mut guard = self.built.lock().expect("commit walk cache poisoned");
+        if let Some(built) = guard.as_ref() {
+            return Ok(Arc::clone(built));
+        }
+        let built = Arc::new(build(repo, &self.skip_markers)?);
+        *guard = Some(Arc::clone(&built));
+        Ok(built)
+    }
+}
+
+fn build(repo: &Repository, skip_markers: &[String]) -> Result<BuiltWalk> {
+    let head = repo.head_id()?.detach();
+    let walk = repo
+        .rev_walk([head])
+        .use_commit_graph(true)
+        .sorting(Sorting::BreadthFirst)
+        .all()?;
+
+    let mut commits = Vec::new();
+    let mut pos = HashMap::new();
+    for info in walk {
+        let info = info?;
+        let parents: Vec<ObjectId> = info.parent_ids.iter().copied().collect();
+        let decoded = repo.find_commit(info.id).ok().and_then(|commit| {
+            commit
+                .message_raw()
+                .ok()
+                .map(|raw| String::from_utf8_lossy(raw).into_owned())
+        });
+        let (message, skipped) = match decoded {
+            Some(message) => {
+                let skipped = subject_has_skip_marker(&message, skip_markers);
+                (message, skipped)
+            }
+            None => (String::new(), true),
+        };
+        pos.insert(info.id, commits.len());
+        commits.push(DecodedCommit {
+            log: GitLog {
+                hash: info.id.to_string()[..8].to_string(),
+                message,
+            },
+            skipped,
+            parents,
+        });
+    }
+    Ok(BuiltWalk { commits, pos })
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod commit_walk;
 mod commits;
 mod diff;
 mod fetch;
@@ -12,6 +13,7 @@ mod validate;
 pub use validate::ensure_safe_refname_fragment;
 
 pub use auth::get_remote_url;
+pub use commit_walk::CommitWalkCache;
 #[allow(unused_imports)]
 pub use commits::{
     GitLog, create_branch_and_commit, create_branch_and_commits, create_commit,

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -663,6 +663,87 @@ fn get_changed_files_since_tag_nested_paths_are_full_and_unquoted() {
     assert_eq!(files, vec!["packages/café/index.js".to_string()]);
 }
 
+fn assert_walks_agree(repo: &Repository, cache: &CommitWalkCache, stop: Option<gix::ObjectId>) {
+    let markers = crate::config::default_commit_skip_markers();
+    let direct = get_commits_since_oid(repo, stop, &markers).unwrap();
+    let cached = cache.commits_since(repo, stop).unwrap();
+    let pairs = |logs: &[GitLog]| {
+        logs.iter()
+            .map(|l| (l.hash.clone(), l.message.clone()))
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(pairs(&cached), pairs(&direct), "stop = {stop:?}");
+}
+
+#[test]
+fn commit_walk_cache_matches_direct_walk_on_linear_history() {
+    let (dir, repo) = init_repo();
+    create_commit_in_repo(&repo, dir.path(), "a.txt", "feat: a");
+    let stop = repo.head_id().unwrap().detach();
+    create_commit_in_repo(&repo, dir.path(), "b.txt", "fix: b");
+    create_commit_in_repo(&repo, dir.path(), "c.txt", "feat: c");
+
+    let cache = CommitWalkCache::new(crate::config::default_commit_skip_markers());
+    assert_walks_agree(&repo, &cache, None);
+    assert_walks_agree(&repo, &cache, Some(stop));
+    assert_walks_agree(&repo, &cache, Some(repo.head_id().unwrap().detach()));
+}
+
+#[test]
+fn commit_walk_cache_matches_direct_walk_across_merges() {
+    let (dir, repo) = init_repo();
+    create_commit_in_repo(&repo, dir.path(), "a.txt", "feat: a");
+    let base = repo.head_id().unwrap().detach();
+    git(dir.path(), &["checkout", "-q", "-b", "side"]);
+    create_commit_in_repo(&repo, dir.path(), "b.txt", "feat: b");
+    let side = repo.head_id().unwrap().detach();
+    git(dir.path(), &["checkout", "-q", "-"]);
+    create_commit_in_repo(&repo, dir.path(), "c.txt", "feat: c");
+    git(
+        dir.path(),
+        &["merge", "-q", "--no-ff", "side", "-m", "chore: merge side"],
+    );
+    create_commit_in_repo(&repo, dir.path(), "d.txt", "feat: d");
+
+    let cache = CommitWalkCache::new(crate::config::default_commit_skip_markers());
+    for stop in [None, Some(base), Some(side)] {
+        assert_walks_agree(&repo, &cache, stop);
+    }
+}
+
+#[test]
+fn commit_walk_cache_matches_direct_walk_for_stop_outside_head_ancestry() {
+    let (dir, repo) = init_repo();
+    create_commit_in_repo(&repo, dir.path(), "a.txt", "feat: a");
+    git(dir.path(), &["checkout", "-q", "-b", "orphan"]);
+    create_commit_in_repo(&repo, dir.path(), "b.txt", "feat: b");
+    let orphan = repo.head_id().unwrap().detach();
+    git(dir.path(), &["checkout", "-q", "-"]);
+    create_commit_in_repo(&repo, dir.path(), "c.txt", "feat: c");
+
+    let cache = CommitWalkCache::new(crate::config::default_commit_skip_markers());
+    for _ in 0..3 {
+        assert_walks_agree(&repo, &cache, Some(orphan));
+    }
+}
+
+#[test]
+fn commit_walk_cache_applies_skip_markers() {
+    let (dir, repo) = init_repo();
+    create_commit_in_repo(&repo, dir.path(), "a.txt", "feat: a");
+    let stop = repo.head_id().unwrap().detach();
+    create_commit_in_repo(&repo, dir.path(), "b.txt", "chore: bump [skip ci]");
+    create_commit_in_repo(&repo, dir.path(), "c.txt", "feat: c");
+
+    let cache = CommitWalkCache::new(crate::config::default_commit_skip_markers());
+    for _ in 0..3 {
+        assert_walks_agree(&repo, &cache, Some(stop));
+    }
+    let cached = cache.commits_since(&repo, Some(stop)).unwrap();
+    assert!(cached.iter().all(|l| !l.message.contains("[skip ci]")));
+    assert!(cached.iter().any(|l| l.message.contains("feat: c")));
+}
+
 #[test]
 fn get_changed_files_empty_for_merge_commits() {
     let (dir, repo) = init_repo();

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -190,6 +190,8 @@ pub(super) fn run_release_logic(
 
     let thread_safe_repo = repo.clone().into_sync();
     let changed_files_cache = plan::ChangedFilesCache::default();
+    let commit_walk =
+        crate::git::CommitWalkCache::new(config.workspace.effective_commit_skip_markers());
     let plan_inputs = PlanInputs {
         config,
         root,
@@ -204,6 +206,7 @@ pub(super) fn run_release_logic(
         changed_files: &changed_files,
         short_hash: &short_hash,
         changed_files_cache: &changed_files_cache,
+        commit_walk: &commit_walk,
     };
     let plans: Vec<PackagePlan> = config
         .packages

--- a/src/monorepo/run/plan.rs
+++ b/src/monorepo/run/plan.rs
@@ -7,7 +7,6 @@ use crate::formats::read_version;
 use crate::git::{
     Repository, TagIndex, find_highest_semver_tag_with_cache, get_changed_files_since_oid,
     get_changed_files_since_tag, get_commits_since_last_stable_tag, get_commits_since_last_tag,
-    get_commits_since_oid,
 };
 use crate::prerelease::PrereleaseContext;
 use crate::versioning::compute_next_version;
@@ -106,6 +105,7 @@ pub(super) struct PlanInputs<'a> {
     pub changed_files: &'a [String],
     pub short_hash: &'a str,
     pub changed_files_cache: &'a ChangedFilesCache,
+    pub commit_walk: &'a crate::git::CommitWalkCache,
 }
 
 fn changed_files_since_oid_cached(
@@ -201,7 +201,7 @@ pub(super) fn compute_plan(
     let commits_since_stable = || -> Result<Vec<GitLog>> {
         if let (Some(idx), OrphanedTagStrategy::Warn) = (inputs.tag_index, strategy) {
             let stop = idx.find_last_stable_tag_commit(&tag_search_prefix, strategy);
-            get_commits_since_oid(repo, stop, &skip_markers)
+            inputs.commit_walk.commits_since(repo, stop)
         } else {
             get_commits_since_last_stable_tag(
                 repo,
@@ -215,7 +215,7 @@ pub(super) fn compute_plan(
     let commits_since_any = || -> Result<Vec<GitLog>> {
         if let (Some(idx), OrphanedTagStrategy::Warn) = (inputs.tag_index, strategy) {
             let stop = idx.find_last_tag_commit(&tag_search_prefix, strategy);
-            get_commits_since_oid(repo, stop, &skip_markers)
+            inputs.commit_walk.commits_since(repo, stop)
         } else {
             get_commits_since_last_tag(
                 repo,
@@ -376,6 +376,7 @@ mod tests {
         config: Config,
         root: std::path::PathBuf,
         cache: ChangedFilesCache,
+        commit_walk: crate::git::CommitWalkCache,
     }
 
     fn build_inputs<'a>(
@@ -397,6 +398,7 @@ mod tests {
             forced,
             changed_files,
             short_hash: "deadbee",
+            commit_walk: &fx.commit_walk,
             changed_files_cache: &fx.cache,
         }
     }
@@ -458,12 +460,15 @@ mod tests {
         );
 
         let config = Config::load(&root, Some(&root.join(".ferrflow"))).unwrap();
+        let commit_walk =
+            crate::git::CommitWalkCache::new(config.workspace.effective_commit_skip_markers());
         let fx = Fixture {
             _dir: dir,
             repo,
             config,
             root: root.clone(),
             cache: ChangedFilesCache::default(),
+            commit_walk,
         };
 
         let all_tags = collect_all_tags(&fx.repo);
@@ -511,12 +516,15 @@ mod tests {
         commit_file(&root, "broken/feat.rs", "x", "feat: broken", 1_950_000_200);
 
         let config = Config::load(&root, Some(&root.join(".ferrflow"))).unwrap();
+        let commit_walk =
+            crate::git::CommitWalkCache::new(config.workspace.effective_commit_skip_markers());
         let fx = Fixture {
             _dir: dir,
             repo,
             config,
             root: root.clone(),
             cache: ChangedFilesCache::default(),
+            commit_walk,
         };
 
         let all_tags = collect_all_tags(&fx.repo);


### PR DESCRIPTION
Every touched package ran its own hidden revwalk from HEAD and re-decoded the same commits. With `recoverMissedReleases` marking all 50 packages of the `complex` fixture touched, that was ~50 near-identical walks dominating the run.

### Design

`CommitWalkCache` decodes HEAD's ancestry **once** — hash, message, pre-evaluated skip flag, and the parent ids the walk already yields for free — and answers each per-package "commits since \" from memory: the hidden set of a stop is recovered by walking the recorded parent map (BFS, no object access), then the shared order is emitted minus that set.

Correctness rests on an order argument: a commit outside `ancestry(stop)` can only be discovered through children that are also outside it (if a child is an ancestor of the stop, so is its parent), so a hidden walk yields exactly the full walk's order filtered. That claim is pinned by equivalence tests against `get_commits_since_oid` on linear histories, across merge commits, and for skip markers.

Two guarded escapes keep behaviour identical elsewhere:
- **A stop outside HEAD's ancestry** (orphaned tag) can hide shared history the parent map cannot see — that case falls back to the plain hidden revwalk, tested.
- **An arming threshold (2 calls).** A hidden revwalk only visits commits past the stop boundary, so with one or two touched packages it is far cheaper than decoding all of history — on `mono-large` (10k commits, one touched package with a recent tag) an unconditional shared walk would have turned ~50 ms of walking into ~1.6 s of decoding. The first two queries stay on the direct path; the shared walk only builds once a third package asks. The zero-touched case never builds anything.

### Measured — same machine, same protocol as the baseline, cold cache, `--jobs 1`, n=3

| scenario | before (main, today) | after | |
|---|---|---|---|
| `complex` + `recoverMissedReleases`, 50 touched | 4102–4162 ms | **1103–1698 ms** | **~3.2×** |
| `mono-large`, 1 touched | 2069–2137 ms | 2181–2740 ms | same path by design, within this machine's noise band |

Plan output is byte-identical in both scenarios (all 50 `complex` packages still plan `0.1.0 → 1.0.0` major). Without the threshold the 50-touched case measured 830–956 ms; the ~0.3 s difference is the price of the two guarded direct walks, paid deliberately to protect the common case.

1573 tests pass (4 new equivalence tests), `clippy -D warnings` clean. `GitLog` gains a `Clone` derive.

Closes #691