### PR TITLE
perf(git): resolve local tag targets in-process instead of spawning rev-list

### DIFF
--- a/src/git/push.rs
+++ b/src/git/push.rs
@@ -10,16 +10,19 @@ use super::repo::Repository;
 use super::retry::retry_transient;
 use super::shell::run_git;
 
-fn local_tag_target_sha(repo: &Repository, tag: &str) -> Result<String> {
-    let workdir = repo
-        .workdir()
-        .ok_or_else(|| anyhow!("Bare repositories are not supported"))?;
-    let out = run_git(
-        workdir,
-        &["rev-list", "-n", "1", &format!("refs/tags/{tag}")],
-    )
-    .with_context(|| format!("could not resolve tag '{tag}' to a commit"))?;
-    Ok(out.trim().to_string())
+// Resolved in-process via gix rather than `git rev-list -n 1` per tag: this
+// runs once per pushed tag, and each process spawn costs 10-20ms on Windows —
+// seconds on a 200-package release. Fully peeling matters: an annotated tag's
+// ref points at the tag object, while the remote comparison below uses the
+// ls-remote `^{}` (commit) form.
+pub(super) fn local_tag_target_sha(repo: &Repository, tag: &str) -> Result<String> {
+    let reference = repo
+        .find_reference(&format!("refs/tags/{tag}"))
+        .with_context(|| format!("could not resolve tag '{tag}' to a commit"))?;
+    let id = reference
+        .into_fully_peeled_id()
+        .with_context(|| format!("could not peel tag '{tag}' to a commit"))?;
+    Ok(id.to_string())
 }
 
 pub(super) fn parse_ls_remote_tags(stdout: &str) -> HashMap<String, String> {

--- a/src/git/tags.rs
+++ b/src/git/tags.rs
@@ -222,6 +222,11 @@ pub(super) fn find_matching_commit(
     orphaned_commit: &gix::Commit<'_>,
     strategy: &OrphanedTagStrategy,
 ) -> Option<ObjectId> {
+    // Warn never recovers a commit; bail before paying for the walk.
+    if matches!(strategy, OrphanedTagStrategy::Warn) {
+        return None;
+    }
+
     let head = repo.head_id().ok()?.detach();
     let walk = repo
         .rev_walk([head])

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -1,5 +1,5 @@
 use super::auth::{configure_git_command, extract_url_password, server_config_url, token_for_url};
-use super::push::{fetch_and_rebase, parse_ls_remote_tags};
+use super::push::{fetch_and_rebase, local_tag_target_sha, parse_ls_remote_tags};
 use super::repo::Repository;
 use super::retry::{is_transient_git_error, retry_transient};
 use super::tags::{find_highest_semver_tag, find_last_tag, is_floating_tag, is_prerelease_tag};
@@ -166,6 +166,47 @@ fn create_lightweight_tag(repo: &Repository, tag_name: &str) {
 fn create_annotated_tag(repo: &Repository, tag_name: &str, message: &str) {
     let workdir = repo.workdir().expect("workdir");
     git(workdir, &["tag", "-a", tag_name, "-m", message]);
+}
+
+// ── local_tag_target_sha — feeds the diverged-tag check in push_tags ──
+//
+// The remote side of that comparison uses ls-remote's dereferenced `^{}`
+// entry, i.e. the commit. If the local side resolves an annotated tag to
+// the tag OBJECT instead of peeling to the commit, every annotated tag
+// looks diverged from a remote it is actually in sync with.
+#[test]
+fn local_tag_target_sha_peels_annotated_tags_to_the_commit() {
+    let (dir, repo) = init_repo();
+    create_commit_in_repo(&repo, dir.path(), "a.txt", "feat: a");
+    create_annotated_tag(&repo, "v1.0.0", "Release 1.0.0");
+
+    let head = git(dir.path(), &["rev-parse", "HEAD"]).trim().to_string();
+    let tag_obj = git(dir.path(), &["rev-parse", "refs/tags/v1.0.0"])
+        .trim()
+        .to_string();
+    assert_ne!(head, tag_obj, "annotated tag must be its own object");
+
+    let sha = local_tag_target_sha(&repo, "v1.0.0").expect("resolves");
+    assert_eq!(sha, head, "must peel to the commit, not the tag object");
+}
+
+#[test]
+fn local_tag_target_sha_resolves_lightweight_tags() {
+    let (dir, repo) = init_repo();
+    create_commit_in_repo(&repo, dir.path(), "a.txt", "feat: a");
+    create_lightweight_tag(&repo, "v1.0.0");
+
+    let head = git(dir.path(), &["rev-parse", "HEAD"]).trim().to_string();
+    let sha = local_tag_target_sha(&repo, "v1.0.0").expect("resolves");
+    assert_eq!(sha, head);
+}
+
+#[test]
+fn local_tag_target_sha_errors_on_a_missing_tag() {
+    let (dir, repo) = init_repo();
+    create_commit_in_repo(&repo, dir.path(), "a.txt", "feat: a");
+    drop(dir);
+    assert!(local_tag_target_sha(&repo, "v9.9.9").is_err());
 }
 
 // -----------------------------------------------------------------------


### PR DESCRIPTION
Part of #504 — items 4 (`rev-list` per tag) and 6 (Warn early-return). Not `Closes`: items 1-3 and 7 remain.

**Item 4.** `local_tag_target_sha` spawned `git rev-list -n 1` once per pushed tag; it now resolves in-process via gix (`find_reference` + `into_fully_peeled_id`). Measured on the `mono-large` fixture: 200 spawns cost **11.6 s on Windows** (~58 ms each); Linux pays 1-2 ms per spawn, so the saving there is the issue's estimated few hundred ms to low seconds on push-heavy releases. The in-process resolve is microseconds.

The subtle part is peeling, and it now has a test that fails without it: the remote side of the diverged-tag check uses ls-remote's dereferenced `^{}` entry (the commit), so the local side must peel annotated tags to the commit too. Resolving to the ref target instead (the tag object) would make **every annotated tag look diverged from a remote it is in sync with** — verified by swapping `into_fully_peeled_id()` for `reference.id()` and watching `local_tag_target_sha_peels_annotated_tags_to_the_commit` fail. Lightweight tags and the missing-tag error path are covered too.

**Item 6.** `find_matching_commit` walked up to 1000 commits before noticing `OrphanedTagStrategy::Warn` (the default) never recovers anything. The strategy check is hoisted above the walk; the match arm stays for exhaustiveness.

**Item 5 was already shipped**: both `collect_dirty_files` call sites (`run/mod.rs:493`, `run/execute.rs:162`) are gated by `resolve_hook(...)` on main. Noted on the issue.

**Deliberately skipped: item 7** (resolve `push_url` once). It threads a parameter through five public functions in `push.rs` plus `fetch.rs` for a 5-15 ms win — the worst gain-to-diff ratio of the list. And a caution on items 1-3: profiling for FerrLabs/Fixtures#143 showed per-package compute is object-I/O-bound (510 ms → 20 ms on `complex` from packing alone), so their estimates likely overstate what's left once the fixtures are packed.

`cargo clippy -D warnings` clean, 882 tests green.
