### PR TITLE
feat(cli): add migrate command to import semantic-release config

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,15 @@ ferrflow init --format toml
 ferrflow init --format dotfile # generates .ferrflow
 ```
 
+Already using semantic-release? `ferrflow migrate` reads your existing config and generates the equivalent `ferrflow.json`:
+
+```bash
+ferrflow migrate                        # auto-detects .releaserc
+ferrflow migrate --from semantic-release
+```
+
+It maps `tagFormat`, `branches`, and the common plugins (`changelog`, `exec`, `github`/`gitlab`) to their FerrFlow equivalents, and prints a summary of what mapped, what was ignored, and what needs manual review — anything without a FerrFlow equivalent is surfaced, never guessed. JSON `.releaserc` is supported today; YAML `.releaserc` and JS `release.config.js` are reported as unsupported rather than mis-parsed.
+
 ### JSON Schema
 
 Add `$schema` to get autocompletion and validation in VS Code, WebStorm, and any JSON-aware editor:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -157,6 +157,26 @@ pub enum Commands {
     /// repair a manifest that diverged from the package files (e.g. after
     /// a crashed release).
     SyncManifest,
+    /// Generate a ferrflow config from another release tool's config
+    Migrate {
+        /// Source tool (auto-detected if omitted)
+        #[arg(long, value_enum)]
+        from: Option<MigrateSourceArg>,
+    },
+}
+
+#[derive(Clone, Copy, clap::ValueEnum)]
+pub enum MigrateSourceArg {
+    #[value(name = "semantic-release")]
+    SemanticRelease,
+}
+
+impl From<MigrateSourceArg> for crate::config::MigrateSource {
+    fn from(arg: MigrateSourceArg) -> Self {
+        match arg {
+            MigrateSourceArg::SemanticRelease => crate::config::MigrateSource::SemanticRelease,
+        }
+    }
 }
 
 #[derive(Subcommand)]
@@ -180,6 +200,7 @@ impl Commands {
             Commands::Completions { .. } => "completions",
             Commands::Cache { .. } => "cache",
             Commands::SyncManifest => "sync-manifest",
+            Commands::Migrate { .. } => "migrate",
         }
     }
 }
@@ -268,6 +289,7 @@ impl Cli {
                 CacheCommand::Clear => crate::cache::clear_cwd(),
             },
             Commands::SyncManifest => crate::manifest::sync_cwd(self.config.as_deref()),
+            Commands::Migrate { from } => crate::config::migrate(from.map(Into::into)),
         }
     }
 }

--- a/src/config/migrate.rs
+++ b/src/config/migrate.rs
@@ -1,0 +1,482 @@
+use anyhow::Result;
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+use crate::error_code::{self, ErrorCodeExt};
+
+use super::Config;
+use super::format::{CONFIG_FORMATS, ConfigFileFormat, format_handler};
+use super::loader_js::{JS_CONFIG_FILENAME, TS_CONFIG_FILENAME};
+use super::package::{FileFormat, PackageConfig, VersionedFile};
+use super::types::{
+    BranchChannelConfig, ChannelValue, ForgeKind, HooksConfig, PrereleaseIdentifier,
+};
+use super::workspace::WorkspaceConfig;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Source {
+    SemanticRelease,
+}
+
+impl Source {
+    fn label(self) -> &'static str {
+        match self {
+            Source::SemanticRelease => "semantic-release",
+        }
+    }
+}
+
+/// A `.releaserc` shape we can parse: JSON (or JSON5) content, whatever the
+/// filename. YAML `.releaserc` and JS `release.config.js` are surfaced as
+/// unsupported rather than mis-parsed.
+const SEMANTIC_RELEASE_JSON_FILES: &[&str] = &[".releaserc", ".releaserc.json"];
+const SEMANTIC_RELEASE_UNSUPPORTED_FILES: &[&str] = &[
+    ".releaserc.yaml",
+    ".releaserc.yml",
+    ".releaserc.js",
+    "release.config.js",
+    "release.config.mjs",
+    ".releaserc.cjs",
+];
+
+pub fn migrate(from: Option<Source>) -> Result<()> {
+    ensure_no_existing_config()?;
+
+    let source = match from {
+        Some(s) => s,
+        None => detect_source()?,
+    };
+
+    match source {
+        Source::SemanticRelease => migrate_semantic_release(),
+    }
+}
+
+fn ensure_no_existing_config() -> Result<()> {
+    for handler in CONFIG_FORMATS {
+        if Path::new(handler.filename()).exists() {
+            return Err(anyhow::anyhow!("{} already exists", handler.filename()))
+                .error_code(error_code::CONFIG_ALREADY_EXISTS);
+        }
+    }
+    for filename in [TS_CONFIG_FILENAME, JS_CONFIG_FILENAME] {
+        if Path::new(filename).exists() {
+            return Err(anyhow::anyhow!("{filename} already exists"))
+                .error_code(error_code::CONFIG_ALREADY_EXISTS);
+        }
+    }
+    Ok(())
+}
+
+fn detect_source() -> Result<Source> {
+    if find_semantic_release_json().is_some() {
+        return Ok(Source::SemanticRelease);
+    }
+    if let Some(f) = SEMANTIC_RELEASE_UNSUPPORTED_FILES
+        .iter()
+        .find(|f| Path::new(f).exists())
+    {
+        return Err(anyhow::anyhow!(
+            "found {f}, but ferrflow can only migrate JSON `.releaserc` for now. \
+             Convert it to `.releaserc.json` (or inline the config as JSON) and rerun."
+        ))
+        .error_code(error_code::CONFIG_INVALID_JSON);
+    }
+    Err(anyhow::anyhow!(
+        "no supported release-tool config found. Looked for {}. \
+         Pass --from to force a source.",
+        SEMANTIC_RELEASE_JSON_FILES.join(", ")
+    ))
+    .error_code(error_code::CONFIG_NOT_FOUND)
+}
+
+fn find_semantic_release_json() -> Option<PathBuf> {
+    SEMANTIC_RELEASE_JSON_FILES
+        .iter()
+        .map(PathBuf::from)
+        .find(|p| p.exists())
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ReleaseRc {
+    #[serde(default, rename = "tagFormat")]
+    tag_format: Option<String>,
+    #[serde(default)]
+    branches: Option<Branches>,
+    #[serde(default, rename = "repositoryUrl")]
+    repository_url: Option<String>,
+    #[serde(default)]
+    plugins: Vec<PluginEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum Branches {
+    One(BranchSpec),
+    Many(Vec<BranchSpec>),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum BranchSpec {
+    Name(String),
+    Object {
+        name: String,
+        #[serde(default)]
+        prerelease: Option<PrereleaseFlag>,
+        #[serde(default)]
+        channel: Option<String>,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum PrereleaseFlag {
+    Bool(bool),
+    Name(String),
+}
+
+/// A plugin is either `"name"` or `["name", { options }]`.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum PluginEntry {
+    Name(String),
+    WithOptions(String, serde_json::Value),
+}
+
+impl PluginEntry {
+    fn name(&self) -> &str {
+        match self {
+            PluginEntry::Name(n) => n,
+            PluginEntry::WithOptions(n, _) => n,
+        }
+    }
+
+    fn options(&self) -> Option<&serde_json::Value> {
+        match self {
+            PluginEntry::Name(_) => None,
+            PluginEntry::WithOptions(_, o) => Some(o),
+        }
+    }
+}
+
+/// Everything the converter wants to say to the user: what it mapped, what it
+/// dropped, and what needs a human. Separated from the write so it can be
+/// asserted in tests without touching the filesystem.
+#[derive(Debug, Default, PartialEq)]
+pub struct MigrationReport {
+    pub mapped: Vec<String>,
+    pub warnings: Vec<String>,
+    pub ignored: Vec<String>,
+}
+
+pub fn build_config_from_releaserc(raw: &str) -> Result<(Config, MigrationReport)> {
+    let rc: ReleaseRc = json5::from_str(raw)
+        .map_err(|e| anyhow::anyhow!("could not parse .releaserc as JSON: {e}"))
+        .error_code(error_code::CONFIG_INVALID_JSON)?;
+
+    let mut report = MigrationReport::default();
+    let mut workspace = WorkspaceConfig::default();
+
+    if let Some(tag_format) = &rc.tag_format {
+        workspace.tag_template = Some(convert_tag_format(tag_format));
+        report
+            .mapped
+            .push(format!("tagFormat → tagTemplate ({})", tag_format));
+    }
+
+    if let Some(branches) = &rc.branches {
+        let converted = convert_branches(branches, &mut report);
+        if !converted.is_empty() {
+            workspace.branches = Some(converted);
+        }
+    }
+
+    if let Some(url) = &rc.repository_url {
+        report.ignored.push(format!(
+            "repositoryUrl ({url}) — ferrflow derives the remote from git"
+        ));
+    }
+
+    let mut changelog: Option<String> = None;
+    let mut hooks = HooksConfig::default();
+    let mut hooks_touched = false;
+
+    for plugin in &rc.plugins {
+        apply_plugin(
+            plugin,
+            &mut workspace,
+            &mut changelog,
+            &mut hooks,
+            &mut hooks_touched,
+            &mut report,
+        );
+    }
+
+    if hooks_touched {
+        workspace.hooks = Some(hooks);
+    }
+
+    let package = PackageConfig {
+        name: default_package_name(),
+        path: ".".to_string(),
+        versioned_files: vec![VersionedFile {
+            path: "package.json".to_string(),
+            format: FileFormat::Json,
+            selector: None,
+        }],
+        changelog: Some(changelog.unwrap_or_else(|| "CHANGELOG.md".to_string())),
+        shared_paths: Vec::new(),
+        depends_on: vec![],
+        versioning: None,
+        tag_template: None,
+        hooks: None,
+        floating_tags: None,
+        publishers: vec![],
+        update_lockfiles: None,
+    };
+
+    report.warnings.push(
+        "semantic-release is single-package; scaffolded one package writing to package.json. \
+         Edit `package` if your layout differs, or add more for a monorepo."
+            .to_string(),
+    );
+
+    Ok((
+        Config {
+            workspace,
+            packages: vec![package],
+        },
+        report,
+    ))
+}
+
+fn default_package_name() -> String {
+    std::fs::read_to_string("package.json")
+        .ok()
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+        .and_then(|v| v.get("name").and_then(|n| n.as_str()).map(str::to_string))
+        .unwrap_or_else(|| "app".to_string())
+}
+
+/// `v${version}` → `v{{version}}`. semantic-release only defines the
+/// `${version}` token; anything else is passed through and flagged.
+fn convert_tag_format(tag_format: &str) -> String {
+    tag_format.replace("${version}", "{{version}}")
+}
+
+fn convert_branches(branches: &Branches, report: &mut MigrationReport) -> Vec<BranchChannelConfig> {
+    let specs: Vec<&BranchSpec> = match branches {
+        Branches::One(b) => vec![b],
+        Branches::Many(bs) => bs.iter().collect(),
+    };
+
+    let mut out = Vec::new();
+    for spec in specs {
+        match spec {
+            BranchSpec::Name(name) => {
+                // A bare non-release branch name in the list is a maintenance
+                // or next branch; semantic-release treats `main`/`master` as
+                // the stable line.
+                let is_stable = name == "main" || name == "master";
+                out.push(BranchChannelConfig {
+                    name: name.clone(),
+                    channel: ChannelValue::Stable(is_stable),
+                    prerelease_identifier: PrereleaseIdentifier::default(),
+                });
+                report
+                    .mapped
+                    .push(format!("branch {name} → {}", channel_desc(is_stable, None)));
+            }
+            BranchSpec::Object {
+                name,
+                prerelease,
+                channel,
+            } => {
+                let (channel_value, desc) = match prerelease {
+                    Some(PrereleaseFlag::Bool(true)) => {
+                        let id = channel.clone().unwrap_or_else(|| name.clone());
+                        (
+                            ChannelValue::Named(id.clone()),
+                            format!("prerelease `{id}`"),
+                        )
+                    }
+                    Some(PrereleaseFlag::Name(id)) => (
+                        ChannelValue::Named(id.clone()),
+                        format!("prerelease `{id}`"),
+                    ),
+                    Some(PrereleaseFlag::Bool(false)) | None => {
+                        let is_stable = name == "main" || name == "master";
+                        (
+                            ChannelValue::Stable(is_stable),
+                            channel_desc(is_stable, channel.as_deref()),
+                        )
+                    }
+                };
+                out.push(BranchChannelConfig {
+                    name: name.clone(),
+                    channel: channel_value,
+                    prerelease_identifier: PrereleaseIdentifier::default(),
+                });
+                report.mapped.push(format!("branch {name} → {desc}"));
+            }
+        }
+    }
+    out
+}
+
+fn channel_desc(is_stable: bool, channel: Option<&str>) -> String {
+    match (is_stable, channel) {
+        (true, _) => "stable".to_string(),
+        (false, Some(c)) => format!("channel `{c}`"),
+        (false, None) => "stable (non-default branch)".to_string(),
+    }
+}
+
+fn apply_plugin(
+    plugin: &PluginEntry,
+    workspace: &mut WorkspaceConfig,
+    changelog: &mut Option<String>,
+    hooks: &mut HooksConfig,
+    hooks_touched: &mut bool,
+    report: &mut MigrationReport,
+) {
+    match plugin.name() {
+        "@semantic-release/commit-analyzer" => {
+            if let Some(opts) = plugin.options()
+                && (opts.get("releaseRules").is_some() || opts.get("preset").is_some())
+            {
+                report.warnings.push(
+                    "commit-analyzer has custom releaseRules/preset — ferrflow's bump rules are \
+                     fixed (feat→minor, fix/perf/refactor→patch, !/BREAKING→major) and can't honour \
+                     them. Review whether the defaults match your intent."
+                        .to_string(),
+                );
+            }
+        }
+        "@semantic-release/release-notes-generator" => {}
+        "@semantic-release/changelog" => {
+            let path = plugin
+                .options()
+                .and_then(|o| o.get("changelogFile"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("CHANGELOG.md")
+                .to_string();
+            *changelog = Some(path.clone());
+            report.mapped.push(format!("changelog plugin → {path}"));
+        }
+        "@semantic-release/github" | "@semantic-release/gitlab" => {
+            workspace.forge = if plugin.name().contains("gitlab") {
+                ForgeKind::Gitlab
+            } else {
+                ForgeKind::Github
+            };
+            report.mapped.push(format!("{} → forge", plugin.name()));
+        }
+        "@semantic-release/git" => {
+            report.mapped.push(
+                "git plugin → (implicit; ferrflow commits the release by default)".to_string(),
+            );
+        }
+        "@semantic-release/exec" => {
+            apply_exec_plugin(plugin, hooks, hooks_touched, report);
+        }
+        "@semantic-release/npm" => {
+            report.warnings.push(
+                "@semantic-release/npm → not mapped. ferrflow has publishers, but the semantics \
+                 differ enough that an automatic map would mislead. Configure `publishers` by hand \
+                 if you publish to npm."
+                    .to_string(),
+            );
+        }
+        other => {
+            report.warnings.push(format!(
+                "plugin {other} has no ferrflow equivalent — review manually"
+            ));
+        }
+    }
+}
+
+fn apply_exec_plugin(
+    plugin: &PluginEntry,
+    hooks: &mut HooksConfig,
+    hooks_touched: &mut bool,
+    report: &mut MigrationReport,
+) {
+    let Some(opts) = plugin.options() else {
+        return;
+    };
+    let get = |key: &str| opts.get(key).and_then(|v| v.as_str()).map(str::to_string);
+
+    for (rc_key, ff_label, slot) in [
+        ("verifyConditionsCmd", "preRelease", &mut hooks.pre_release),
+        ("prepareCmd", "preBump", &mut hooks.pre_bump),
+        ("publishCmd", "postPublish", &mut hooks.post_publish),
+        ("successCmd", "onSuccess", &mut hooks.on_success),
+        ("failCmd", "onError", &mut hooks.on_error),
+    ] {
+        if let Some(cmd) = get(rc_key) {
+            *slot = Some(cmd);
+            *hooks_touched = true;
+            report
+                .mapped
+                .push(format!("exec {rc_key} → hooks.{ff_label}"));
+        }
+    }
+}
+
+fn migrate_semantic_release() -> Result<()> {
+    let path = find_semantic_release_json().ok_or_else(|| {
+        anyhow::anyhow!(
+            "no JSON .releaserc found ({})",
+            SEMANTIC_RELEASE_JSON_FILES.join(", ")
+        )
+    })?;
+    let raw = std::fs::read_to_string(&path)
+        .map_err(|e| anyhow::anyhow!("could not read {}: {e}", path.display()))?;
+
+    let (config, report) = build_config_from_releaserc(&raw)?;
+
+    let handler = format_handler(ConfigFileFormat::Json);
+    let content = handler.serialize(&config)?;
+    let filename = handler.filename();
+    std::fs::write(filename, &content)?;
+
+    print_report(Source::SemanticRelease, &path, filename, &report);
+    Ok(())
+}
+
+fn print_report(source: Source, from: &Path, wrote: &str, report: &MigrationReport) {
+    println!(
+        "Migrated {} config from {} → {wrote}\n",
+        source.label(),
+        from.display()
+    );
+
+    if !report.mapped.is_empty() {
+        println!("Mapped:");
+        for m in &report.mapped {
+            println!("  • {m}");
+        }
+        println!();
+    }
+    if !report.ignored.is_empty() {
+        println!("Ignored:");
+        for i in &report.ignored {
+            println!("  • {i}");
+        }
+        println!();
+    }
+    if !report.warnings.is_empty() {
+        println!("Review manually:");
+        for w in &report.warnings {
+            println!("  ! {w}");
+        }
+        println!();
+    }
+
+    println!("Next: review {wrote}, then `ferrflow validate` and `ferrflow check`.");
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/config/migrate/tests.rs
+++ b/src/config/migrate/tests.rs
@@ -1,0 +1,207 @@
+use super::*;
+use crate::config::types::{ChannelValue, ForgeKind};
+
+fn build(raw: &str) -> (Config, MigrationReport) {
+    build_config_from_releaserc(raw).expect("valid releaserc")
+}
+
+fn branch<'a>(cfg: &'a Config, name: &str) -> &'a BranchChannelConfig {
+    cfg.workspace
+        .branches
+        .as_ref()
+        .expect("branches present")
+        .iter()
+        .find(|b| b.name == name)
+        .unwrap_or_else(|| panic!("branch {name} not converted"))
+}
+
+#[test]
+fn tag_format_version_token_is_rewritten() {
+    let (cfg, report) = build(r#"{"tagFormat": "v${version}"}"#);
+    assert_eq!(cfg.workspace.tag_template.as_deref(), Some("v{{version}}"));
+    assert!(report.mapped.iter().any(|m| m.contains("tagTemplate")));
+}
+
+#[test]
+fn tag_format_with_prefix_and_suffix() {
+    let (cfg, _) = build(r#"{"tagFormat": "release-${version}-stable"}"#);
+    assert_eq!(
+        cfg.workspace.tag_template.as_deref(),
+        Some("release-{{version}}-stable")
+    );
+}
+
+// main/master are the stable line; a prerelease:true branch becomes a channel.
+#[test]
+fn branches_map_stable_and_prerelease() {
+    let (cfg, _) = build(r#"{"branches": ["main", {"name": "beta", "prerelease": true}]}"#);
+    assert!(matches!(
+        branch(&cfg, "main").channel,
+        ChannelValue::Stable(true)
+    ));
+    assert!(matches!(
+        &branch(&cfg, "beta").channel,
+        ChannelValue::Named(c) if c == "beta"
+    ));
+}
+
+// `prerelease` can name the identifier directly, distinct from the branch name.
+#[test]
+fn prerelease_string_names_the_channel() {
+    let (cfg, _) = build(r#"{"branches": [{"name": "next-major", "prerelease": "next"}]}"#);
+    assert!(matches!(
+        &branch(&cfg, "next-major").channel,
+        ChannelValue::Named(c) if c == "next"
+    ));
+}
+
+// prerelease:false is a maintenance branch, not a channel.
+#[test]
+fn prerelease_false_is_not_a_channel() {
+    let (cfg, _) = build(r#"{"branches": [{"name": "1.x", "prerelease": false}]}"#);
+    assert!(matches!(
+        branch(&cfg, "1.x").channel,
+        ChannelValue::Stable(false)
+    ));
+}
+
+#[test]
+fn a_single_branch_string_is_accepted() {
+    let (cfg, _) = build(r#"{"branches": "main"}"#);
+    assert!(matches!(
+        branch(&cfg, "main").channel,
+        ChannelValue::Stable(true)
+    ));
+}
+
+#[test]
+fn changelog_plugin_sets_the_package_changelog() {
+    let (cfg, _) = build(
+        r#"{"plugins": [["@semantic-release/changelog", {"changelogFile": "docs/CHANGES.md"}]]}"#,
+    );
+    assert_eq!(
+        cfg.packages[0].changelog.as_deref(),
+        Some("docs/CHANGES.md")
+    );
+}
+
+#[test]
+fn changelog_plugin_without_options_defaults_the_path() {
+    let (cfg, _) = build(r#"{"plugins": ["@semantic-release/changelog"]}"#);
+    assert_eq!(cfg.packages[0].changelog.as_deref(), Some("CHANGELOG.md"));
+}
+
+#[test]
+fn github_plugin_sets_the_forge() {
+    let (cfg, _) = build(r#"{"plugins": ["@semantic-release/github"]}"#);
+    assert!(matches!(cfg.workspace.forge, ForgeKind::Github));
+}
+
+#[test]
+fn gitlab_plugin_sets_the_forge() {
+    let (cfg, _) = build(r#"{"plugins": ["@semantic-release/gitlab"]}"#);
+    assert!(matches!(cfg.workspace.forge, ForgeKind::Gitlab));
+}
+
+// Every exec command maps to the hook that runs at the equivalent phase.
+#[test]
+fn exec_commands_map_to_hooks() {
+    let (cfg, _) = build(
+        r#"{"plugins": [["@semantic-release/exec", {
+            "prepareCmd": "npm run build",
+            "publishCmd": "npm publish",
+            "successCmd": "echo done",
+            "failCmd": "echo failed",
+            "verifyConditionsCmd": "npm run lint"
+        }]]}"#,
+    );
+    let hooks = cfg.workspace.hooks.as_ref().expect("hooks present");
+    assert_eq!(hooks.pre_bump.as_deref(), Some("npm run build"));
+    assert_eq!(hooks.post_publish.as_deref(), Some("npm publish"));
+    assert_eq!(hooks.on_success.as_deref(), Some("echo done"));
+    assert_eq!(hooks.on_error.as_deref(), Some("echo failed"));
+    assert_eq!(hooks.pre_release.as_deref(), Some("npm run lint"));
+}
+
+// The bump rules are fixed, so custom releaseRules can't be honoured — the user
+// must be told, not silently ignored.
+#[test]
+fn custom_release_rules_warn() {
+    let (_, report) = build(
+        r#"{"plugins": [["@semantic-release/commit-analyzer", {
+            "releaseRules": [{"type": "docs", "release": "patch"}]
+        }]]}"#,
+    );
+    assert!(
+        report.warnings.iter().any(|w| w.contains("releaseRules")),
+        "expected a warning about custom releaseRules, got {:?}",
+        report.warnings
+    );
+}
+
+#[test]
+fn default_commit_analyzer_does_not_warn() {
+    let (_, report) = build(r#"{"plugins": ["@semantic-release/commit-analyzer"]}"#);
+    assert!(
+        !report.warnings.iter().any(|w| w.contains("releaseRules")),
+        "a plain commit-analyzer should not warn about rules"
+    );
+}
+
+// npm publishing semantics differ; a silent map would mislead.
+#[test]
+fn npm_plugin_warns_rather_than_mapping() {
+    let (_, report) = build(r#"{"plugins": ["@semantic-release/npm"]}"#);
+    assert!(report.warnings.iter().any(|w| w.contains("npm")));
+}
+
+#[test]
+fn unknown_plugin_warns() {
+    let (_, report) = build(r#"{"plugins": ["@some/custom-plugin"]}"#);
+    assert!(
+        report
+            .warnings
+            .iter()
+            .any(|w| w.contains("@some/custom-plugin"))
+    );
+}
+
+// repositoryUrl has no field — it must be reported, not dropped in silence.
+#[test]
+fn repository_url_is_reported_as_ignored() {
+    let (cfg, report) = build(r#"{"repositoryUrl": "https://github.com/o/r.git"}"#);
+    assert!(report.ignored.iter().any(|i| i.contains("repositoryUrl")));
+    // and it does not leak into the config anywhere
+    assert!(cfg.workspace.tag_template.is_none());
+}
+
+#[test]
+fn empty_releaserc_still_produces_a_usable_config() {
+    let (cfg, report) = build("{}");
+    assert_eq!(cfg.packages.len(), 1);
+    assert_eq!(cfg.packages[0].path, ".");
+    // the single-package caveat is always surfaced
+    assert!(report.warnings.iter().any(|w| w.contains("single-package")));
+}
+
+#[test]
+fn malformed_json_is_an_error() {
+    assert!(build_config_from_releaserc("{ not json").is_err());
+}
+
+// JSON5 tolerance: real .releaserc files sometimes carry comments/trailing commas.
+#[test]
+fn json5_features_are_tolerated() {
+    let (cfg, _) = build(
+        r#"{
+            // stable only
+            "tagFormat": "v${version}",
+        }"#,
+    );
+    assert_eq!(cfg.workspace.tag_template.as_deref(), Some("v{{version}}"));
+}
+
+#[test]
+fn source_label_is_stable() {
+    assert_eq!(Source::SemanticRelease.label(), "semantic-release");
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,6 +9,7 @@ mod format;
 mod init;
 #[cfg(feature = "cli")]
 mod loader_js;
+mod migrate;
 mod package;
 mod types;
 mod workspace;
@@ -17,6 +18,7 @@ mod workspace;
 pub use format::{ConfigFileFormat, ConfigFormatHandler, format_handler};
 #[cfg(feature = "cli")]
 pub use init::init;
+pub use migrate::{Source as MigrateSource, migrate};
 pub use package::{FileFormat, FloatingTagLevel, PackageConfig, VersionedFile, VersioningStrategy};
 #[allow(unused_imports)]
 pub use types::{


### PR DESCRIPTION
Implements #223, semantic-release first (`.releaserc` JSON). The other sources on that issue (changesets, release-please, standard-version, `release.config.js`) are follow-ups on the same command.

## Why a converter, not a compat-shim

We considered reading `.releaserc` at runtime. Rejected: two config formats with subtly different semantics and ambiguous precedence is the migration-bug factory, and `.releaserc` implies semantic-release to the ecosystem (Renovate and others detect the tool by that file). This generates a real `ferrflow.json` once, loudly, then the old file can go. It never adopts the other tool's schema.

## What it does

`ferrflow migrate` auto-detects `.releaserc`/`.releaserc.json`; `--from semantic-release` forces it. Refuses to overwrite an existing ferrflow config (same guard as `init`).

Mapping:

| `.releaserc` | ferrflow |
|---|---|
| `tagFormat: v${version}` | `tagTemplate: v{{version}}` |
| `branches` | `branches[]` — main/master → stable, `prerelease: true` → channel, a `prerelease` string names the channel, `prerelease: false` → maintenance branch |
| `@semantic-release/changelog` | `package.changelog` (its `changelogFile`, else `CHANGELOG.md`) |
| `@semantic-release/exec` | `hooks` — prepareCmd→preBump, publishCmd→postPublish, successCmd→onSuccess, failCmd→onError, verifyConditionsCmd→preRelease |
| `@semantic-release/github` / `gitlab` | `forge` |
| `@semantic-release/git` | implicit (ferrflow commits by default) |

Surfaced, never guessed:
- `@semantic-release/npm` warns — ferrflow has publishers but the semantics differ enough that an auto-map would mislead.
- Custom `commit-analyzer` `releaseRules`/`preset` warns — ferrflow's bump rules are fixed.
- `repositoryUrl` is reported as ignored (ferrflow derives the remote from git).
- YAML `.releaserc` / JS `release.config.js` are reported as unsupported, not mis-parsed.
- The single-package caveat is always printed.

The report is the product: a converter that silently drops config is worse than none.

## End-to-end

Ran it on a realistic `.releaserc` (tagFormat + prerelease branch + 6 plugins). Output config **passes `ferrflow validate`**. The report listed every mapping, the ignored `repositoryUrl`, and the two manual-review items. Re-running errors with `E1017 already exists`.

## Tests

20 unit tests over `build_config_from_releaserc` (filesystem-free by design — the report is a value, asserted directly): token rewrite, all four branch shapes, changelog with/without options, both forges, every exec hook, the two warn paths, the ignored-not-dropped invariant, empty input, malformed JSON, and JSON5 tolerance (real `.releaserc` files carry comments). `cargo clippy -D warnings` clean, 906 tests green.

Docs updated in the README. Site docs (ferrflow.com) follow in a FerrFlow-Cloud PR, and a changelog entry in the Changelog repo — kept separate per the no-cross-repo-PR rule.
