### PR TITLE
fix(cli): stop the error printer from burying the message under its code

### DIFF
--- a/src/error_report.rs
+++ b/src/error_report.rs
@@ -1,0 +1,119 @@
+use crate::error_code::ErrorCode;
+
+/// The lines to log for a failed command, one physical line per element.
+///
+/// Walking the chain and emitting a line per cause — rather than a single
+/// `{err:?}` — keeps every cause on its own clean line through the human log
+/// layer, which records the message field with `{:?}` and would otherwise
+/// render anyhow's multi-line Debug with an orphaned `Caused by:` and a blank
+/// line. Both the coded and uncoded paths now format the same way (see #694).
+pub fn error_report_lines(err: &anyhow::Error) -> Vec<String> {
+    // anyhow finds the ErrorCode through the whole chain, but the code is
+    // attached with `.context(code)`, so it also surfaces as a chain link whose
+    // Display is the bare code (`E1001`). Filter that link out by value rather
+    // than by `downcast_ref` on the chain: the context wrapper doesn't downcast
+    // back to ErrorCode on `&dyn Error`, so the naive filter leaves a duplicated
+    // `error[E1001]: E1001` head.
+    let code = err.downcast_ref::<ErrorCode>().copied();
+    let code_str = code.map(|c| c.to_string());
+
+    let causes: Vec<String> = err
+        .chain()
+        .map(|c| c.to_string())
+        .filter(|s| code_str.as_deref() != Some(s.as_str()))
+        .collect();
+
+    let mut lines = Vec::new();
+
+    match code {
+        Some(code) => {
+            let head = causes
+                .first()
+                .map(String::as_str)
+                .unwrap_or("unknown error");
+            lines.push(format!("error[{code}]: {head}"));
+            for cause in causes.iter().skip(1) {
+                lines.push(format!("  {cause}"));
+            }
+            lines.push(String::new());
+            lines.push(format!("  For help: {}", code.doc_url()));
+        }
+        None => {
+            let head = causes
+                .first()
+                .map(String::as_str)
+                .unwrap_or("unknown error");
+            lines.push(format!("Error: {head}"));
+            for cause in causes.iter().skip(1) {
+                lines.push(format!("  Caused by: {cause}"));
+            }
+        }
+    }
+
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error_code::{self, ErrorCodeExt};
+    use anyhow::Context;
+
+    #[test]
+    fn uncoded_error_keeps_every_cause_on_its_own_line() {
+        // The bot-token shape from #694: a context wrapping a specific cause,
+        // with no ErrorCode attached.
+        let err = anyhow::Result::<()>::Err(anyhow::anyhow!(
+            "FerrFlow hosted bot service unavailable (503). Check https://status.ferrlabs.com"
+        ))
+        .context("failed to obtain FerrFlow bot token")
+        .unwrap_err();
+
+        let lines = error_report_lines(&err);
+        assert_eq!(
+            lines,
+            [
+                "Error: failed to obtain FerrFlow bot token",
+                "  Caused by: FerrFlow hosted bot service unavailable (503). Check https://status.ferrlabs.com",
+            ]
+        );
+    }
+
+    #[test]
+    fn a_bare_error_is_a_single_line() {
+        let err = anyhow::anyhow!("something broke");
+        assert_eq!(error_report_lines(&err), ["Error: something broke"]);
+    }
+
+    #[test]
+    fn coded_error_shows_the_code_and_help_url() {
+        let err = anyhow::Result::<()>::Err(anyhow::anyhow!("config file not found"))
+            .error_code(error_code::CONFIG_NOT_FOUND)
+            .unwrap_err();
+
+        let lines = error_report_lines(&err);
+        assert_eq!(lines[0], "error[E1001]: config file not found");
+        assert_eq!(lines[lines.len() - 2], "");
+        assert!(lines.last().unwrap().starts_with("  For help: "));
+        // The ErrorCode itself is a chain link but must not print as a cause.
+        assert!(
+            !lines
+                .iter()
+                .any(|l| l.contains("E1001:") && l.starts_with("  Caused by:"))
+        );
+    }
+
+    // The ErrorCode is stripped from the causes so it never doubles as a
+    // "Caused by:" line.
+    #[test]
+    fn coded_error_with_extra_context_lists_the_real_causes_only() {
+        let err = anyhow::Result::<()>::Err(anyhow::anyhow!("permission denied"))
+            .context("could not read config")
+            .error_code(error_code::CONFIG_NOT_FOUND)
+            .unwrap_err();
+
+        let lines = error_report_lines(&err);
+        assert_eq!(lines[0], "error[E1001]: could not read config");
+        assert_eq!(lines[1], "  permission denied");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod config;
 mod conventional_commits;
 mod diff;
 mod error_code;
+mod error_report;
 mod forge;
 mod formats;
 mod git;
@@ -65,21 +66,8 @@ fn main() {
 
         telemetry::flush();
 
-        if let Some(code) = code {
-            let msgs: Vec<String> = err
-                .chain()
-                .filter(|c| c.downcast_ref::<error_code::ErrorCode>().is_none())
-                .map(|c| c.to_string())
-                .collect();
-
-            tracing::error!("error[{}]: {}", code, msgs[0]);
-            for msg in &msgs[1..] {
-                tracing::error!("  {msg}");
-            }
-            tracing::error!("");
-            tracing::error!("  For help: {}", code.doc_url());
-        } else {
-            tracing::error!("Error: {err:?}");
+        for line in error_report::error_report_lines(&err) {
+            tracing::error!("{line}");
         }
 
         std::process::exit(1);


### PR DESCRIPTION
Closes #694 — but the real bug is bigger than that issue described, and part of my diagnosis there was wrong. Both corrected here.

**What #694 got wrong.** It claimed the bot-token *cause* was dropped from the log. It wasn't: that error is uncoded, so `main` printed it with `{err:?}`, which does include the "Caused by:" body. My `grep Error|fail` while diagnosing the outage filtered the cause line out ("service unavailable" matches neither word), and I mistook a filtered grep for a dropped cause. Verified with a test: `{err:?}` through the human log layer keeps the cause, just as an ugly extra-indented block with an orphaned blank line.

**What's actually broken, on every coded error.** Building the report from `err.chain().filter(|c| c.downcast_ref::<ErrorCode>().is_none())` — the existing code — does not remove the code link, because a `.context(code)` wrapper does not downcast back to `ErrorCode` through `&dyn Error` in this anyhow version. The code's `Display` (`E1017`) survives as the first "cause" and **takes the head slot, pushing the real message out**. On `origin/main`:

```
$ ferrflow init      # ferrflow.json already exists
error[E1017]: E1017
  For help: https://ferrflow.com/docs/reference/errors#e1017
```

The message a user needs — `ferrflow.json already exists` — is gone entirely. This affects any error with a code attached, which is most of them. It very likely made this session's own E2006/E2004 diagnoses harder than they needed to be.

**The fix.** Extract the report into a pure `error_report_lines(&anyhow::Error) -> Vec<String>`, used by both paths, and filter the code link out by value (we already extracted the code via anyhow's chain-aware downcast) instead of by a `downcast_ref` that doesn't fire. After:

```
error[E1017]: ferrflow.json already exists
  For help: https://ferrflow.com/docs/reference/errors#e1017
```

The uncoded path is cleaned up too: one `error!` per chain link (`Error: …` / `  Caused by: …`) instead of one multi-line `{err:?}`, so each cause is its own clean line through the message-only layer — the same shape the coded path already intended.

**Tests.** Four over `error_report_lines`, filesystem-free (the report is a value now, not a side effect): the bot-token uncoded shape, a bare single-line error, a coded error showing message-not-code in the head plus the help URL, and a coded error with extra context listing the real causes. The head-slot assertion (`error[E1001]: config file not found`, not `E1001`) is the regression guard for the bug above — it fails against the old filter.

Verified end to end on the built binary, both before (`E1017: E1017`) and after (`E1017: ferrflow.json already exists`). `cargo clippy -D warnings` clean, 910 tests green.
