### PR TITLE
fix(wasm): gate the migrate module behind the cli feature

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,6 +9,7 @@ mod format;
 mod init;
 #[cfg(feature = "cli")]
 mod loader_js;
+#[cfg(feature = "cli")]
 mod migrate;
 mod package;
 mod types;
@@ -18,6 +19,7 @@ mod workspace;
 pub use format::{ConfigFileFormat, ConfigFormatHandler, format_handler};
 #[cfg(feature = "cli")]
 pub use init::init;
+#[cfg(feature = "cli")]
 pub use migrate::{Source as MigrateSource, migrate};
 pub use package::{FileFormat, FloatingTagLevel, PackageConfig, VersionedFile, VersioningStrategy};
 #[allow(unused_imports)]


### PR DESCRIPTION
Closes #701. **main's wasm build is broken** — the v5.32.0 release job fails on it.

#699 added `config::migrate`, which imports `super::loader_js` (cli-only) but was not itself `#[cfg(feature = "cli")]`. The wasm crate builds the lib without `cli`, compiles `migrate.rs`, and dies on `error[E0432]: unresolved import super::loader_js`.

Gates `mod migrate` and its `pub use` behind `cli`, exactly like `init` and `loader_js` next to it. `migrate` is a CLI command, so it has no business in the wasm lib anyway.

Reproduced the CI failure locally with `cargo check --no-default-features --lib` (the wasm feature set) — fails before, clean after — and confirmed `cargo check -p ferrflow-wasm` builds. CLI build and the 20 migrate tests stay green.

Same shape as the tracing/wasm gate in #655.