### PR TITLE
fix(ci): trust all BurntSushi crates in cargo vet

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -87,6 +87,18 @@ user-id = 6743 # Ed Page (epage)
 start = "2025-05-22"
 end = "2027-07-16"
 
+[[trusted.regex]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-02-27"
+end = "2027-07-17"
+
+[[trusted.regex-automata]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-02-25"
+end = "2027-07-17"
+
 [[trusted.serde_spanned]]
 criteria = "safe-to-deploy"
 user-id = 6743 # Ed Page (epage)

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -685,14 +685,6 @@ criteria = "safe-to-deploy"
 version = "0.5.18"
 criteria = "safe-to-deploy"
 
-[[exemptions.regex]]
-version = "1.13.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.regex-automata]]
-version = "0.4.15"
-criteria = "safe-to-deploy"
-
 [[exemptions.regex-syntax]]
 version = "0.8.11"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -99,6 +99,20 @@ user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
+[[publisher.regex]]
+version = "1.13.1"
+when = "2026-07-15"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.regex-automata]]
+version = "0.4.16"
+when = "2026-07-15"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
 [[publisher.serde_spanned]]
 version = "1.1.1"
 when = "2026-03-31"


### PR DESCRIPTION
Closes #704. **main is red on `Cargo Security`** since Renovate bumped `regex` to 1.13.1 (#698).

`cargo vet trust --all BurntSushi` — Andrew Gallant publishes `regex`, `regex-automata`, `aho-corasick`, `bstr`, `memchr`, `walkdir`, and more that we depend on transitively, so trusting the crate individually just schedules the next outage (this is the third). mozilla and bytecode-alliance — the two audit sets we import — both trust him; `cargo vet` suggests exactly this in the failure.

Drops 8 lines of now-redundant per-version exemptions. `cargo vet` passes locally on 0.10.0 (CI's version): `Vetting Succeeded (43 fully audited, 1 partially audited, 266 exempted)`.

The recurring pattern is tracked separately — this just unblocks main.