### PR TITLE
refactor(monorepo): compute the per-package versioning strategy once

### DIFF
--- a/src/monorepo/run/plan.rs
+++ b/src/monorepo/run/plan.rs
@@ -251,25 +251,20 @@ pub(super) fn compute_plan(
             });
         }
 
-        let strategy = pkg.effective_versioning(
-            &config.workspace,
-            &tags_for_package(inputs.all_tags, &tag_search_prefix),
-        );
-
         let bump = commits
             .iter()
             .map(|c| determine_bump(&c.message))
             .max()
             .unwrap_or(BumpType::None);
 
-        if bump == BumpType::None && !is_date_or_seq(strategy) {
+        if bump == BumpType::None && !is_date_or_seq(pkg_strategy) {
             return Ok(PackagePlan::Skipped {
                 reason: SkipReason::NoReleasableCommits,
                 recovered,
             });
         }
 
-        let base_version = compute_next_version(&current_version, bump, strategy)?;
+        let base_version = compute_next_version(&current_version, bump, pkg_strategy)?;
 
         let (new_version, is_prerelease) = if prerelease {
             let tag_prefix = pkg.tag_prefix(&config.workspace, is_monorepo);
@@ -300,12 +295,8 @@ pub(super) fn compute_plan(
     let strategy_label = if forced_ver_for_pkg.is_some() {
         "forced".to_string()
     } else {
-        let strategy = pkg.effective_versioning(
-            &config.workspace,
-            &tags_for_package(inputs.all_tags, &tag_search_prefix),
-        );
-        if is_date_or_seq(strategy) {
-            format!("{strategy:?}").to_lowercase()
+        if is_date_or_seq(pkg_strategy) {
+            format!("{pkg_strategy:?}").to_lowercase()
         } else {
             bump.to_string()
         }


### PR DESCRIPTION
Part of #504, item 1 — but framed as the refactor it actually is, not the perf win the issue estimated.

`plan_package` computed `pkg.effective_versioning(&workspace, &tags_for_package(all_tags, prefix))` **three times** per package with identical arguments (lines ~171, ~254, ~303). `effective_versioning` is pure and `VersioningStrategy` is `Copy`, so the second and third calls were dead recomputation, each re-scanning `all_tags` and allocating a `Vec`. Now computed once and reused.

**Honest measurement.** On `mono-large` (200 pkg × 10k commits, packed), `check --jobs 1`, 15 runs:

```
origin/main : 105.6 ms (±59.4)
this        : 108.1 ms (±11.2)
```

The delta is noise — the baseline's own stddev is ±59 ms. This confirms the audit behind FerrLabs/Fixtures#143: the per-package hot path is object-I/O-bound, not CPU-bound, so removing CPU recomputation does not move the wall clock. The win here is the code: one computation instead of three, less allocation, DRY. `refactor`, not `perf`, because there is no measurable speedup to claim.

**Deliberately not doing #504 items 2 and 3.** Same reason. The profiling shows the CPU these target is dwarfed by object I/O:
- Item 2 (`is_package_touched` "quadratic") — pre-sorting `changed_files` for a binary search adds complexity for a gain that only exists when `changed_files` is large, which the common HEAD-diff case is not. Under KISS/YAGNI, not worth the added machinery without a measurable gain.
- Item 3 (cache parsed semver in `TagIndexEntry`) — the version depends on the per-call prefix, so a build-time parse needs a fragile `@`/`v` heuristic that misses custom prefixes; and the `continue` on `!starts_with(prefix)` already skips before the parse, so each tag is parsed for its own package only, not the 200k re-parses the item estimates. The real cost in that function is the per-package full scan, which this item does not address.

I will note this reasoning on #504 so the remaining items are a decision, not an open TODO. 94 monorepo tests green, clippy clean.