### PR TITLE
fix(ci): trust prolific first-party-adjacent publishers in cargo vet

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -3,6 +3,12 @@
 
 [audits]
 
+[[trusted.aho-corasick]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-03-28"
+end = "2027-07-17"
+
 [[trusted.anstream]]
 criteria = "safe-to-deploy"
 user-id = 6743 # Ed Page (epage)
@@ -32,6 +38,30 @@ criteria = "safe-to-deploy"
 user-id = 6743 # Ed Page (epage)
 start = "2023-03-08"
 end = "2027-07-16"
+
+[[trusted.anyhow]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-10-05"
+end = "2027-07-17"
+
+[[trusted.autocfg]]
+criteria = "safe-to-deploy"
+user-id = 539 # Josh Stone (cuviper)
+start = "2019-05-22"
+end = "2027-07-17"
+
+[[trusted.bstr]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-04-02"
+end = "2027-07-17"
+
+[[trusted.byteorder]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-06-09"
+end = "2027-07-17"
 
 [[trusted.clap]]
 criteria = "safe-to-deploy"
@@ -69,11 +99,305 @@ user-id = 6743 # Ed Page (epage)
 start = "2023-04-13"
 end = "2027-07-16"
 
+[[trusted.equivalent]]
+criteria = "safe-to-deploy"
+user-id = 539 # Josh Stone (cuviper)
+start = "2023-02-05"
+end = "2027-07-17"
+
+[[trusted.find-msvc-tools]]
+criteria = "safe-to-deploy"
+user-id = 539 # Josh Stone (cuviper)
+start = "2025-08-29"
+end = "2027-07-17"
+
+[[trusted.gix]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-10"
+end = "2027-07-17"
+
+[[trusted.gix-actor]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-attributes]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-bitmap]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-chunk]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-command]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-commitgraph]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-config]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-config-value]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-date]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-diff]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-discover]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-error]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2026-01-22"
+end = "2027-07-17"
+
+[[trusted.gix-features]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-filter]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-07-01"
+end = "2027-07-17"
+
+[[trusted.gix-fs]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-04-19"
+end = "2027-07-17"
+
+[[trusted.gix-glob]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-hash]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-hashtable]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-index]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-lock]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-object]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-odb]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-pack]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-packetline]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-path]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-protocol]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-quote]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-ref]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-refspec]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-revision]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-revwalk]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-06-10"
+end = "2027-07-17"
+
+[[trusted.gix-sec]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-shallow]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2024-12-22"
+end = "2027-07-17"
+
+[[trusted.gix-tempfile]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-trace]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-06-16"
+end = "2027-07-17"
+
+[[trusted.gix-transport]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-traverse]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-url]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-utils]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-04-19"
+end = "2027-07-17"
+
+[[trusted.gix-validate]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-07-17"
+
+[[trusted.gix-worktree-stream]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-07-22"
+end = "2027-07-17"
+
 [[trusted.is_terminal_polyfill]]
 criteria = "safe-to-deploy"
 user-id = 6743 # Ed Page (epage)
 start = "2024-05-02"
 end = "2027-07-16"
+
+[[trusted.itoa]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-05-02"
+end = "2027-07-17"
+
+[[trusted.jiff]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2024-02-17"
+end = "2027-07-17"
+
+[[trusted.jiff-static]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2025-03-06"
+end = "2027-07-17"
+
+[[trusted.jiff-tzdb]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2024-07-09"
+end = "2027-07-17"
+
+[[trusted.jiff-tzdb-platform]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2024-07-09"
+end = "2027-07-17"
 
 [[trusted.kstring]]
 criteria = "safe-to-deploy"
@@ -81,11 +405,47 @@ user-id = 6743 # Ed Page (epage)
 start = "2020-03-16"
 end = "2027-07-16"
 
+[[trusted.memchr]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-07-07"
+end = "2027-07-17"
+
 [[trusted.once_cell_polyfill]]
 criteria = "safe-to-deploy"
 user-id = 6743 # Ed Page (epage)
 start = "2025-05-22"
 end = "2027-07-16"
+
+[[trusted.proc-macro2]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-04-23"
+end = "2027-07-17"
+
+[[trusted.prodash]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2020-02-16"
+end = "2027-07-17"
+
+[[trusted.quote]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-04-09"
+end = "2027-07-17"
+
+[[trusted.rayon]]
+criteria = "safe-to-deploy"
+user-id = 539 # Josh Stone (cuviper)
+start = "2019-06-13"
+end = "2027-07-17"
+
+[[trusted.rayon-core]]
+criteria = "safe-to-deploy"
+user-id = 539 # Josh Stone (cuviper)
+start = "2019-06-13"
+end = "2027-07-17"
 
 [[trusted.regex]]
 criteria = "safe-to-deploy"
@@ -99,11 +459,77 @@ user-id = 189 # Andrew Gallant (BurntSushi)
 start = "2019-02-25"
 end = "2027-07-17"
 
+[[trusted.regex-syntax]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-03-30"
+end = "2027-07-17"
+
+[[trusted.rustversion]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-07-08"
+end = "2027-07-17"
+
+[[trusted.same-file]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-07-16"
+end = "2027-07-17"
+
+[[trusted.semver]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2021-05-25"
+end = "2027-07-17"
+
+[[trusted.serde]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-03-01"
+end = "2027-07-17"
+
+[[trusted.serde_core]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2025-09-13"
+end = "2027-07-17"
+
+[[trusted.serde_derive]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-03-01"
+end = "2027-07-17"
+
+[[trusted.serde_json]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-02-28"
+end = "2027-07-17"
+
 [[trusted.serde_spanned]]
 criteria = "safe-to-deploy"
 user-id = 6743 # Ed Page (epage)
 start = "2023-01-20"
 end = "2027-07-16"
+
+[[trusted.syn]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-03-01"
+end = "2027-07-17"
+
+[[trusted.thiserror]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-10-09"
+end = "2027-07-17"
+
+[[trusted.thiserror-impl]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-10-09"
+end = "2027-07-17"
 
 [[trusted.toml_datetime]]
 criteria = "safe-to-deploy"
@@ -129,8 +555,92 @@ user-id = 6743 # Ed Page (epage)
 start = "2025-07-08"
 end = "2027-07-15"
 
+[[trusted.ucd-trie]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-07-21"
+end = "2027-07-17"
+
+[[trusted.unicode-ident]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2021-10-02"
+end = "2027-07-17"
+
+[[trusted.walkdir]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-06-09"
+end = "2027-07-17"
+
+[[trusted.winapi-util]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2020-01-11"
+end = "2027-07-17"
+
+[[trusted.windows-core]]
+criteria = "safe-to-deploy"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2021-11-15"
+end = "2027-07-17"
+
+[[trusted.windows-interface]]
+criteria = "safe-to-deploy"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2022-02-18"
+end = "2027-07-17"
+
+[[trusted.windows-link]]
+criteria = "safe-to-deploy"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2024-07-17"
+end = "2027-07-17"
+
+[[trusted.windows-result]]
+criteria = "safe-to-deploy"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2024-02-02"
+end = "2027-07-17"
+
+[[trusted.windows-strings]]
+criteria = "safe-to-deploy"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2024-02-02"
+end = "2027-07-17"
+
+[[trusted.windows-targets]]
+criteria = "safe-to-deploy"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2022-09-09"
+end = "2027-07-17"
+
+[[trusted.windows_aarch64_gnullvm]]
+criteria = "safe-to-deploy"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2022-09-01"
+end = "2027-07-17"
+
+[[trusted.windows_i686_gnullvm]]
+criteria = "safe-to-deploy"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2024-04-02"
+end = "2027-07-17"
+
+[[trusted.windows_x86_64_gnullvm]]
+criteria = "safe-to-deploy"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2022-09-01"
+end = "2027-07-17"
+
 [[trusted.winnow]]
 criteria = "safe-to-deploy"
 user-id = 6743 # Ed Page (epage)
 start = "2023-02-22"
 end = "2027-07-16"
+
+[[trusted.zmij]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2025-12-18"
+end = "2027-07-17"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -13,17 +13,9 @@ url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 [policy.ferrflow]
 audit-as-crates-io = false
 
-[[exemptions.aho-corasick]]
-version = "1.1.4"
-criteria = "safe-to-deploy"
-
 [[exemptions.alloca]]
 version = "0.4.0"
 criteria = "safe-to-run"
-
-[[exemptions.anyhow]]
-version = "1.0.103"
-criteria = "safe-to-deploy"
 
 [[exemptions.arc-swap]]
 version = "1.9.2"
@@ -31,10 +23,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.arrayvec]]
 version = "0.7.8"
-criteria = "safe-to-deploy"
-
-[[exemptions.autocfg]]
-version = "1.5.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.base64]]
@@ -57,16 +45,8 @@ criteria = "safe-to-deploy"
 version = "0.12.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.bstr]]
-version = "1.12.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.bumpalo]]
 version = "3.20.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.byteorder]]
-version = "1.5.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.bytes]]
@@ -221,10 +201,6 @@ criteria = "safe-to-deploy"
 version = "0.8.35"
 criteria = "safe-to-deploy"
 
-[[exemptions.equivalent]]
-version = "1.0.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.errno]]
 version = "0.3.14"
 criteria = "safe-to-deploy"
@@ -275,174 +251,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.getrandom]]
 version = "0.4.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix]]
-version = "0.85.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-actor]]
-version = "0.41.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-attributes]]
-version = "0.33.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-bitmap]]
-version = "0.3.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-chunk]]
-version = "0.7.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-command]]
-version = "0.9.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-commitgraph]]
-version = "0.37.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-config]]
-version = "0.58.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-config-value]]
-version = "0.18.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-date]]
-version = "0.15.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-diff]]
-version = "0.65.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-discover]]
-version = "0.53.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-error]]
-version = "0.2.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-features]]
-version = "0.48.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-filter]]
-version = "0.32.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-fs]]
-version = "0.21.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-glob]]
-version = "0.26.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-hash]]
-version = "0.25.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-hashtable]]
-version = "0.15.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-index]]
-version = "0.53.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-lock]]
-version = "23.0.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-object]]
-version = "0.62.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-odb]]
-version = "0.82.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-pack]]
-version = "0.72.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-packetline]]
-version = "0.21.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-path]]
-version = "0.12.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-protocol]]
-version = "0.63.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-quote]]
-version = "0.7.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-ref]]
-version = "0.65.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-refspec]]
-version = "0.43.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-revision]]
-version = "0.47.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-revwalk]]
-version = "0.33.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-sec]]
-version = "0.14.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-shallow]]
-version = "0.12.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-tempfile]]
-version = "23.0.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-trace]]
-version = "0.1.20"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-transport]]
-version = "0.57.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-traverse]]
-version = "0.59.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-url]]
-version = "0.36.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-utils]]
-version = "0.3.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-validate]]
-version = "0.11.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-worktree-stream]]
-version = "0.34.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.glob-match]]
@@ -529,26 +337,6 @@ criteria = "safe-to-deploy"
 version = "0.13.0"
 criteria = "safe-to-run"
 
-[[exemptions.itoa]]
-version = "1.0.18"
-criteria = "safe-to-deploy"
-
-[[exemptions.jiff]]
-version = "0.2.32"
-criteria = "safe-to-deploy"
-
-[[exemptions.jiff-static]]
-version = "0.2.32"
-criteria = "safe-to-deploy"
-
-[[exemptions.jiff-tzdb]]
-version = "0.1.8"
-criteria = "safe-to-deploy"
-
-[[exemptions.jiff-tzdb-platform]]
-version = "0.1.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.js-sys]]
 version = "0.3.103"
 criteria = "safe-to-deploy"
@@ -591,10 +379,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.maybe-async]]
 version = "0.2.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.memchr]]
-version = "2.8.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.memmap2]]
@@ -657,36 +441,12 @@ criteria = "safe-to-deploy"
 version = "0.1.5"
 criteria = "safe-to-deploy"
 
-[[exemptions.proc-macro2]]
-version = "1.0.106"
-criteria = "safe-to-deploy"
-
-[[exemptions.prodash]]
-version = "31.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.quote]]
-version = "1.0.46"
-criteria = "safe-to-deploy"
-
 [[exemptions.r-efi]]
 version = "6.0.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.rayon]]
-version = "1.12.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.rayon-core]]
-version = "1.13.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.redox_syscall]]
 version = "0.5.18"
-criteria = "safe-to-deploy"
-
-[[exemptions.regex-syntax]]
-version = "0.8.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.ring]]
@@ -709,36 +469,8 @@ criteria = "safe-to-deploy"
 version = "0.103.13"
 criteria = "safe-to-deploy"
 
-[[exemptions.rustversion]]
-version = "1.0.23"
-criteria = "safe-to-deploy"
-
-[[exemptions.same-file]]
-version = "1.0.6"
-criteria = "safe-to-deploy"
-
 [[exemptions.scopeguard]]
 version = "1.2.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.semver]]
-version = "1.0.28"
-criteria = "safe-to-deploy"
-
-[[exemptions.serde]]
-version = "1.0.228"
-criteria = "safe-to-deploy"
-
-[[exemptions.serde_core]]
-version = "1.0.228"
-criteria = "safe-to-deploy"
-
-[[exemptions.serde_derive]]
-version = "1.0.228"
-criteria = "safe-to-deploy"
-
-[[exemptions.serde_json]]
-version = "1.0.150"
 criteria = "safe-to-deploy"
 
 [[exemptions.sha1]]
@@ -785,20 +517,8 @@ criteria = "safe-to-deploy"
 version = "2.6.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.syn]]
-version = "2.0.118"
-criteria = "safe-to-deploy"
-
 [[exemptions.tempfile]]
 version = "3.27.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.thiserror]]
-version = "2.0.18"
-criteria = "safe-to-deploy"
-
-[[exemptions.thiserror-impl]]
-version = "2.0.18"
 criteria = "safe-to-deploy"
 
 [[exemptions.thread_local]]
@@ -853,20 +573,12 @@ criteria = "safe-to-deploy"
 version = "1.20.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.ucd-trie]]
-version = "0.1.7"
-criteria = "safe-to-deploy"
-
 [[exemptions.uluru]]
 version = "3.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.unicode-bom]]
 version = "2.0.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.unicode-ident]]
-version = "1.0.24"
 criteria = "safe-to-deploy"
 
 [[exemptions.unicode-normalization]]
@@ -909,10 +621,6 @@ criteria = "safe-to-deploy"
 version = "0.9.5"
 criteria = "safe-to-deploy"
 
-[[exemptions.walkdir]]
-version = "2.5.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.wasi]]
 version = "0.11.1+wasi-snapshot-preview1"
 criteria = "safe-to-deploy"
@@ -949,36 +657,12 @@ criteria = "safe-to-run"
 version = "0.4.0"
 criteria = "safe-to-run"
 
-[[exemptions.winapi-util]]
-version = "0.1.11"
-criteria = "safe-to-deploy"
-
 [[exemptions.winapi-x86_64-pc-windows-gnu]]
 version = "0.4.0"
 criteria = "safe-to-run"
 
-[[exemptions.windows-core]]
-version = "0.62.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.windows-implement]]
 version = "0.60.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows-interface]]
-version = "0.59.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows-link]]
-version = "0.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows-result]]
-version = "0.4.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows-strings]]
-version = "0.5.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-sys]]
@@ -989,14 +673,6 @@ criteria = "safe-to-deploy"
 version = "0.61.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.windows-targets]]
-version = "0.52.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_aarch64_gnullvm]]
-version = "0.52.6"
-criteria = "safe-to-deploy"
-
 [[exemptions.windows_aarch64_msvc]]
 version = "0.52.6"
 criteria = "safe-to-deploy"
@@ -1005,19 +681,11 @@ criteria = "safe-to-deploy"
 version = "0.52.6"
 criteria = "safe-to-deploy"
 
-[[exemptions.windows_i686_gnullvm]]
-version = "0.52.6"
-criteria = "safe-to-deploy"
-
 [[exemptions.windows_i686_msvc]]
 version = "0.52.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows_x86_64_gnu]]
-version = "0.52.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_x86_64_gnullvm]]
 version = "0.52.6"
 criteria = "safe-to-deploy"
 
@@ -1071,8 +739,4 @@ criteria = "safe-to-deploy"
 
 [[exemptions.zlib-rs]]
 version = "0.6.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.zmij]]
-version = "1.0.22"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,6 +1,13 @@
 
 # cargo-vet imports lock
 
+[[publisher.aho-corasick]]
+version = "1.1.4"
+when = "2025-10-28"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
 [[publisher.anstream]]
 version = "1.0.0"
 when = "2026-02-11"
@@ -35,6 +42,34 @@ when = "2025-11-13"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
+
+[[publisher.anyhow]]
+version = "1.0.103"
+when = "2026-06-25"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.autocfg]]
+version = "1.5.1"
+when = "2026-05-22"
+user-id = 539
+user-login = "cuviper"
+user-name = "Josh Stone"
+
+[[publisher.bstr]]
+version = "1.12.3"
+when = "2026-06-25"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.byteorder]]
+version = "1.5.0"
+when = "2023-10-06"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
 
 [[publisher.clap]]
 version = "4.6.2"
@@ -78,12 +113,348 @@ user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
+[[publisher.equivalent]]
+version = "1.0.2"
+when = "2025-02-14"
+user-id = 539
+user-login = "cuviper"
+user-name = "Josh Stone"
+
+[[publisher.gix]]
+version = "0.85.0"
+when = "2026-06-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-actor]]
+version = "0.41.1"
+when = "2026-05-26"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-attributes]]
+version = "0.33.2"
+when = "2026-06-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-bitmap]]
+version = "0.3.2"
+when = "2026-05-26"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-chunk]]
+version = "0.7.2"
+when = "2026-05-26"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-command]]
+version = "0.9.1"
+when = "2026-05-26"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-commitgraph]]
+version = "0.37.1"
+when = "2026-05-26"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-config]]
+version = "0.58.0"
+when = "2026-06-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-config-value]]
+version = "0.18.1"
+when = "2026-05-26"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-date]]
+version = "0.15.5"
+when = "2026-06-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-diff]]
+version = "0.65.0"
+when = "2026-06-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-discover]]
+version = "0.53.0"
+when = "2026-06-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-error]]
+version = "0.2.4"
+when = "2026-05-26"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-features]]
+version = "0.48.1"
+when = "2026-05-26"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-filter]]
+version = "0.32.0"
+when = "2026-06-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-fs]]
+version = "0.21.2"
+when = "2026-05-26"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-glob]]
+version = "0.26.1"
+when = "2026-05-26"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-hash]]
+version = "0.25.1"
+when = "2026-05-26"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-hashtable]]
+version = "0.15.2"
+when = "2026-06-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-index]]
+version = "0.53.0"
+when = "2026-06-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-lock]]
+version = "23.0.1"
+when = "2026-05-26"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-object]]
+version = "0.62.0"
+when = "2026-06-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-odb]]
+version = "0.82.0"
+when = "2026-06-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-pack]]
+version = "0.72.0"
+when = "2026-06-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-packetline]]
+version = "0.21.5"
+when = "2026-06-16"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-path]]
+version = "0.12.1"
+when = "2026-05-26"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-protocol]]
+version = "0.63.0"
+when = "2026-06-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-quote]]
+version = "0.7.2"
+when = "2026-05-26"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-ref]]
+version = "0.65.0"
+when = "2026-06-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-refspec]]
+version = "0.43.0"
+when = "2026-06-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-revision]]
+version = "0.47.0"
+when = "2026-06-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-revwalk]]
+version = "0.33.0"
+when = "2026-06-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-sec]]
+version = "0.14.1"
+when = "2026-05-26"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-shallow]]
+version = "0.12.1"
+when = "2026-05-26"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-tempfile]]
+version = "23.0.2"
+when = "2026-06-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-trace]]
+version = "0.1.20"
+when = "2026-05-26"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-transport]]
+version = "0.57.2"
+when = "2026-06-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-traverse]]
+version = "0.59.0"
+when = "2026-06-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-url]]
+version = "0.36.1"
+when = "2026-05-26"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-utils]]
+version = "0.3.3"
+when = "2026-05-26"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-validate]]
+version = "0.11.2"
+when = "2026-05-26"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-worktree-stream]]
+version = "0.34.0"
+when = "2026-06-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
 [[publisher.is_terminal_polyfill]]
 version = "1.70.2"
 when = "2025-10-21"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
+
+[[publisher.itoa]]
+version = "1.0.18"
+when = "2026-03-20"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.jiff]]
+version = "0.2.32"
+when = "2026-07-09"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.jiff-static]]
+version = "0.2.32"
+when = "2026-07-09"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.jiff-tzdb]]
+version = "0.1.8"
+when = "2026-07-09"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.jiff-tzdb-platform]]
+version = "0.1.3"
+when = "2025-03-23"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
 
 [[publisher.kstring]]
 version = "2.0.2"
@@ -92,12 +463,54 @@ user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
+[[publisher.memchr]]
+version = "2.8.3"
+when = "2026-07-08"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
 [[publisher.once_cell_polyfill]]
 version = "1.70.2"
 when = "2025-10-21"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
+
+[[publisher.proc-macro2]]
+version = "1.0.106"
+when = "2026-01-21"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.prodash]]
+version = "31.0.0"
+when = "2026-01-08"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.quote]]
+version = "1.0.46"
+when = "2026-06-22"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.rayon]]
+version = "1.12.0"
+when = "2026-04-14"
+user-id = 539
+user-login = "cuviper"
+user-name = "Josh Stone"
+
+[[publisher.rayon-core]]
+version = "1.13.0"
+when = "2025-08-12"
+user-id = 539
+user-login = "cuviper"
+user-name = "Josh Stone"
 
 [[publisher.regex]]
 version = "1.13.1"
@@ -113,12 +526,89 @@ user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
+[[publisher.regex-syntax]]
+version = "0.8.11"
+when = "2026-06-09"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.rustversion]]
+version = "1.0.23"
+when = "2026-07-07"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.same-file]]
+version = "1.0.6"
+when = "2020-01-11"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.semver]]
+version = "1.0.28"
+when = "2026-04-04"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.serde]]
+version = "1.0.228"
+when = "2025-09-27"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.serde_core]]
+version = "1.0.228"
+when = "2025-09-27"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.serde_derive]]
+version = "1.0.228"
+when = "2025-09-27"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.serde_json]]
+version = "1.0.150"
+when = "2026-05-21"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
 [[publisher.serde_spanned]]
 version = "1.1.1"
 when = "2026-03-31"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
+
+[[publisher.syn]]
+version = "2.0.118"
+when = "2026-06-16"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.thiserror]]
+version = "2.0.18"
+when = "2026-01-18"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.thiserror-impl]]
+version = "2.0.18"
+when = "2026-01-18"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
 
 [[publisher.toml_datetime]]
 version = "1.1.1+spec-1.1.0"
@@ -148,12 +638,110 @@ user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
+[[publisher.ucd-trie]]
+version = "0.1.7"
+when = "2024-09-29"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.unicode-ident]]
+version = "1.0.24"
+when = "2026-02-16"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.walkdir]]
+version = "2.5.0"
+when = "2024-03-01"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.winapi-util]]
+version = "0.1.11"
+when = "2025-09-07"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.windows-core]]
+version = "0.62.2"
+when = "2025-10-06"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows-interface]]
+version = "0.59.3"
+when = "2025-10-06"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows-link]]
+version = "0.2.1"
+when = "2025-10-06"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows-result]]
+version = "0.4.1"
+when = "2025-10-06"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows-strings]]
+version = "0.5.1"
+when = "2025-10-06"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows-targets]]
+version = "0.52.6"
+when = "2024-07-03"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_aarch64_gnullvm]]
+version = "0.52.6"
+when = "2024-07-03"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_i686_gnullvm]]
+version = "0.52.6"
+when = "2024-07-03"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_x86_64_gnullvm]]
+version = "0.52.6"
+when = "2024-07-03"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
 [[publisher.winnow]]
 version = "1.0.3"
 when = "2026-05-14"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
+
+[[publisher.zmij]]
+version = "1.0.22"
+when = "2026-07-12"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
 
 [[audits.bytecode-alliance.audits.adler2]]
 who = "Alex Crichton <alex@alexcrichton.com>"


### PR DESCRIPTION
Implements #706 option B (option A — `Cargo Security` as a required check — is already live on the `main` ruleset).

Three outages in eight days (#679, #696, #704) came from Renovate bumping a crate whose publisher we hadn't trusted yet. Option A stops those from reaching `main`, but leaves the PR blocked until someone trusts the publisher by hand. B shrinks how often that happens by trusting the prolific publishers up front.

**Not a guess — driven by `cargo vet suggest`.** It only recommends `trust X` when the audit sets we already import (mozilla + bytecode-alliance) trust X, so every publisher here is one two independent third parties already vouch for. Ranked by how many of our exempted crates each covers:

| Publisher | Who | Crates |
|---|---|---|
| Byron | Sebastian Thiel — gitoxide/`gix`, our git core | 43 |
| dtolnay | David Tolnay — serde, syn, anyhow, thiserror | 15 |
| BurntSushi | Andrew Gallant — regex, aho-corasick, memchr, bstr | 13 |
| kennykerr | Kenny Kerr — Microsoft `windows-*` | 9 |
| cuviper | Josh Stone — num, autocfg, equivalent | 5 |

`trust --all` skips any crate with multiple historical publishers (semver, indexmap, windows-sys, flate2, lazy_static) — the safe default. `semver` is a direct dependency and now maintained solely by dtolnay, so it's trusted per-crate; the rest are transitive and stable, left exempt.

Effect: **266 → 182 exemptions**, and the five publishers most likely to bump (gix, serde, regex, windows, num) no longer break the build on a version bump. `cargo vet` passes on 0.10.0 (CI's version): `Vetting Succeeded (127 fully audited, 1 partially audited, 182 exempted)`.

**On the security trade-off, stated plainly.** Trusting a publisher means we stop re-auditing their future releases — if one of these accounts is compromised, we're exposed until RustSec flags it. This is deliberately scoped to a handful of long-established maintainers that mozilla and bytecode-alliance already trust; it is not a blanket `trust everyone`. The 182 remaining exemptions still get the normal treatment.
