### PR TITLE
chore(ci): pick up packed fixtures from Fixtures v1.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Generate fixtures
         if: steps.fixture-cache.outputs.cache-hit != 'true'
-        uses: FerrLabs/Fixtures@7db03266c337749bef6f0d5c1e956b112b337b9c # v1
+        uses: FerrLabs/Fixtures@dbe382d75ee6631dd87f937d7d29358b1c58c73e # v1.2.0 (packed repos)
         with:
           definitions: tests/fixtures/definitions
 
@@ -457,7 +457,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Generate benchmark fixtures
-        uses: FerrLabs/Fixtures@3d9971a22666f2d5d262d5a308920af191e16a4a # v1.1.1
+        uses: FerrLabs/Fixtures@dbe382d75ee6631dd87f937d7d29358b1c58c73e # v1.2.0 (packed repos)
         with:
           definitions: benchmarks/fixtures/definitions
           generated-dir: bench-fixtures


### PR DESCRIPTION
Re-pins both Fixtures uses (test fixtures + bench fixtures) from v1/v1.1.1 to v1.2.0 (`dbe382d7`), which carries FerrLabs/Fixtures#144: generated repos are now repacked with a commit-graph instead of shipping fully loose.

Why it matters here (FerrLabs/Fixtures#143): `mono-large` shipped 40 470 loose objects — a shape a real clone can never have — and the benchmark taxed history-reading tools ~100× over for it. Measured on the same machine, `ferrflow check` on `mono-large` goes 30 018 ms loose → 106 ms packed; `complex` goes 566 → 54 ms. It also finally lets the `use_commit_graph(true)` walks from #596 actually find a commit-graph in CI.

**Expect the perf-page numbers to move substantially on the next run — honestly, and for every tool.** Packing also speeds up the competitors that shell out to git; the point is that everyone now gets measured on a repo shaped like a repo. The `complex` cell where ferrflow currently trails commit-and-tag-version is the one to watch.

Note: the Benchmarks action still pins Fixtures v1.1.1 internally, but only for its non-sharded fallback path — our sharded flow generates fixtures with the pin in this file, so this PR is what changes the actual runs. The internal pin can follow in a routine Benchmarks bump.