### PR TITLE
chore(ci): pick up the telemetry-free benchmark runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -536,7 +536,7 @@ jobs:
           key: bench-npm-cache-${{ hashFiles('.github/workflows/ci.yml', 'benchmarks/fixtures/definitions/*.json') }}
           restore-keys: |
             bench-npm-cache-
-      - uses: FerrLabs/Benchmarks@5a4746ea75afca8edcdae739a255af93909ad96f # v5.5.1 + startup/work split + seeded changesets + semantic-release file:// remote
+      - uses: FerrLabs/Benchmarks@e7e235f16c9fe5fcfe510a2c3ee82a6b05f1788b # v5.6.1 + telemetry disabled in runs
         with:
           type: full
           definitions: benchmarks/fixtures/definitions
@@ -576,7 +576,7 @@ jobs:
         with:
           pattern: bench-partial-*
           path: partials/
-      - uses: FerrLabs/Benchmarks@5a4746ea75afca8edcdae739a255af93909ad96f # v5.5.1 + startup/work split + seeded changesets + semantic-release file:// remote
+      - uses: FerrLabs/Benchmarks@e7e235f16c9fe5fcfe510a2c3ee82a6b05f1788b # v5.6.1 + telemetry disabled in runs
         with:
           type: full
           definitions: benchmarks/fixtures/definitions


### PR DESCRIPTION
Re-pins Benchmarks from v5.5.1 to v5.6.1 (`e7e235f1`), carrying FerrLabs/Benchmarks#184: the runner now exports `FERRFLOW_TELEMETRY=0` and `DO_NOT_TRACK=1`.

The `complex` cell was paying ~550 ms of telemetry network wait per timed run — 87% of its published 635 ms — because its generator-written config has a `workspace` object, which flips telemetry on through the default-divergence quirk (FerrLabs/FerrFlow#714), and `telemetry::flush()` blocks exit on 51 HTTPS POSTs (FerrLabs/FerrFlow#713). Every other fixture dodged it, which is why only this cell looked slow.

A/B on the exact CI fixture: telemetry on 1474 ms, off **81 ms**. Expect `complex` ferrflow to land around 80-150 ms on the next run — under commit-and-tag-version (503 ms) — flipping the one remaining losing cell, this time for the right reason: measuring the work instead of our own API latency.