### PR TITLE
fix(ci): drop the empty env block left by the telemetry removal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -609,7 +609,6 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Build ferrflow
         run: cargo build --release
-        env:
       # Git identity is configured by the binary itself (see
       # ensure_bot_token in src/bot_token.rs) when FERRFLOW_BOT=true.
       - name: Run ferrflow release


### PR DESCRIPTION
**main is red — no CI runs at all on the #716 merge commit.** The workflow-level failure has zero jobs and the run shows the raw file path instead of the workflow name: GitHub refuses to parse `ci.yml`.

Cause: #716 removed the `FERRFLOW_HMAC_SECRET` env lines and my orphan-block cleanup missed one spot — the release job's "Build ferrflow" step kept a bare `env:` with nothing under it. That is valid YAML (PyYAML parses it as null, which is why my pre-push check passed) but invalid to the Actions schema, which wants a mapping — so the whole workflow is rejected and nothing runs.

This pass removes empty `env:` blocks by indentation analysis rather than regex, then asserts zero remaining null `env` at job and step level across both workflows. `publish.yml` was already clean but is covered by the same check.

Lesson encoded for next time: `yaml.safe_load` success is not workflow validity — the Actions schema is stricter.