### PR TITLE
fix(ci): retry cosign signing and sweep orphaned draft releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -193,13 +193,28 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s nullglob
+          # Retry: Sigstore hiccups ("stream error: INTERNAL_ERROR") killed
+          # this step twice (v5.2.2, v5.3.0) and orphaned their drafts — the
+          # known failure mode here is transient, so give it three shots.
+          sign_with_retry() {
+            local artifact="$1" attempt
+            for attempt in 1 2 3; do
+              if cosign sign-blob --yes \
+                  --output-signature "${artifact}.sig" \
+                  --output-certificate "${artifact}.crt" \
+                  "$artifact"; then
+                return 0
+              fi
+              echo "::warning::cosign signing failed for ${artifact} (attempt ${attempt}/3)"
+              sleep $((attempt * 10))
+            done
+            echo "cosign signing failed for ${artifact} after 3 attempts" >&2
+            return 1
+          }
           for artifact in artifacts/ferrflow-*.tar.gz artifacts/ferrflow-*.zip; do
             [ -f "$artifact" ] || continue
             echo "Signing $artifact"
-            cosign sign-blob --yes \
-              --output-signature "${artifact}.sig" \
-              --output-certificate "${artifact}.crt" \
-              "$artifact"
+            sign_with_retry "$artifact"
           done
 
       - name: Install cyclonedx-cli for SBOM
@@ -228,10 +243,19 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "1"
         run: |
-          cosign sign-blob --yes \
-            --output-signature artifacts/sbom.cdx.json.sig \
-            --output-certificate artifacts/sbom.cdx.json.crt \
-            artifacts/sbom.cdx.json
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if cosign sign-blob --yes \
+                --output-signature artifacts/sbom.cdx.json.sig \
+                --output-certificate artifacts/sbom.cdx.json.crt \
+                artifacts/sbom.cdx.json; then
+              exit 0
+            fi
+            echo "::warning::cosign SBOM signing failed (attempt ${attempt}/3)"
+            sleep $((attempt * 10))
+          done
+          echo "cosign SBOM signing failed after 3 attempts" >&2
+          exit 1
       - name: Wait for draft release to be visible
         # Defense against the race where this workflow (push:tags) fires
         # before `ferrflow release --draft` (running in the CI workflow
@@ -314,6 +338,32 @@ jobs:
         env:
           FERRFLOW_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish any orphaned older draft releases
+        # A transient failure earlier in this job (a cosign hiccup, an
+        # upload error) leaves a fully-cut draft with nothing to ever
+        # publish it — v5.2.2 and v5.3.0 sat orphaned for six weeks (#718):
+        # the ferrflow step above only publishes the draft for the tag
+        # being released. Any draft with a semver tag strictly older than
+        # the current one is such an orphan — its release commit and tag
+        # are on main, only its Publish run died. Publish them (never as
+        # latest) and warn loudly so the underlying failure still gets
+        # looked at.
+        run: |
+          set -euo pipefail
+          TAG="${{ github.ref_name }}"
+          gh release list --limit 200 --json tagName,isDraft \
+            --jq '.[] | select(.isDraft) | .tagName' | while IFS= read -r draft; do
+            [ -n "$draft" ] || continue
+            [ "$draft" = "$TAG" ] && continue
+            case "$draft" in v[0-9]*) ;; *) continue ;; esac
+            newest=$(printf '%s\n%s\n' "$draft" "$TAG" | sort -V | tail -1)
+            [ "$newest" = "$TAG" ] || continue
+            echo "::warning::Publishing orphaned draft release $draft (left behind by a failed Publish run)"
+            gh release edit "$draft" --draft=false --latest=false
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-crate:
     name: Publish crates.io

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,7 +72,8 @@ pub enum Commands {
         #[arg(long)]
         channel: Option<String>,
         /// Create releases as drafts (GitHub only). A subsequent `ferrflow release`
-        /// without --draft will detect and publish existing drafts automatically.
+        /// without --draft detects and publishes the draft for the version being
+        /// released — older drafts left by failed runs are not swept up.
         /// On GitLab this is a no-op — the release is published immediately
         /// (the GitLab releases API has no draft state); a warning is printed.
         #[arg(long)]


### PR DESCRIPTION
Closes #718 — with one correction to that issue's analysis, owned below.

**The issue was wrong about the CLI recovery path being dead.** Reading the Publish workflow again: its "Publish draft release" step runs `./target/release/ferrflow release` on the tag checkout — no bump found, no `--draft`, so it lands exactly in `publish_pending_drafts` and publishes the current tag's draft. That is the designed publisher and it works. What the investigation *did* establish stands: the path is **myopic** (only the current version's draft) and the step never runs at all when the job dies earlier — which is precisely how v5.2.2 and v5.3.0 were orphaned. Corrected on the issue.

Two workflow fixes and one docs truth-up:

**1. Retry cosign signing (both steps: artifacts + SBOM).** The failure that killed both orphaned runs was a transient Sigstore hiccup (`stream error: INTERNAL_ERROR; received from peer`), twice over. Three attempts with 10/20 s backoff; a `::warning::` per failed attempt so flakiness stays visible even when the retry saves the run.

**2. Sweep orphaned older drafts.** After the current draft is published, list all remaining draft releases and publish any with a semver tag strictly older than the tag being released — such a draft is by definition a fully-cut release whose Publish run died after the tag shipped. Published with `--latest=false` so an old version can never steal the `latest` badge (the install-script hazard), and each one emits a `::warning::` so the underlying failure still gets investigated rather than silently papered over. Guards, dry-tested against the real scenario: current tag skipped, newer tags skipped, non-`v*` drafts skipped, and `sort -V` orders prereleases after their stable so an rc draft of the current line is never accidentally published.

**3. `--draft` help text now tells the truth**: a later release publishes the draft *for the version being released*; older orphans are not swept by the CLI (the workflow sweep above is what handles them).

YAML validated against the null-`env` class of failure that broke ci.yml earlier today; the sweep logic was dry-run locally against the exact v5.2.2/v5.3.0-vs-v5.33.0 scenario before shipping.
