### PR TITLE
perf(build): fat LTO and panic=abort for the release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,9 +91,16 @@ harness = false
 # runner reported as ferrflow_binary_size_mb, overstating the real
 # download by ~3x on /performance.
 strip = "symbols"
-# Thin LTO: cross-crate inlining + dead code elimination. ~30 s extra
-# compile on CI for a measurable runtime win on the commit-walking and
-# git2 plumbing hot paths.
-lto = "thin"
+# Fat LTO: whole-program inlining + dead code elimination. Costs a couple
+# of extra minutes over thin on the one-per-release CI build; combined
+# with panic=abort below it cuts the binary by ~27% (#709).
+lto = "fat"
 # One codegen unit per crate so LTO can see across modules.
 codegen-units = 1
+# A CLI treats every panic as fatal, so the unwinding machinery (landing
+# pads + std unwind tables) is a quarter of the binary bought for
+# nothing. Trade-off: a panic inside a rayon worker aborts the process
+# raw (SIGABRT) instead of propagating as a tidy panic message. Cargo
+# forces unwind back on for test/bench profiles, so the test harness and
+# criterion are unaffected.
+panic = "abort"


### PR DESCRIPTION
Closes #709.

Two lines in `[profile.release]`: `lto = "thin"` → `"fat"`, plus `panic = "abort"`. Unwinding machinery (landing pads + std unwind tables) was a quarter of the binary, bought for nothing in a CLI that treats every panic as fatal.

**Measured, not estimated** (Windows dev build; the release tarballs shrink by the same ratio):

| profile | size |
|---|---|
| before (strip + thin LTO + codegen-units=1) | 10 259 KB |
| after (fat LTO + panic=abort) | **7 439 KB (−27.5%)** |

**Interactions verified rather than assumed:**

- **PGO build** (`scripts/pgo-build.sh`) runs plain `cargo build --release`, layering `-Cprofile-use` on top of `[profile.release]` — its own comment says exactly that — so the shipped x64-linux binary inherits both settings. Fat LTO makes that one-per-release build a couple of minutes slower; the script already has a non-PGO fallback if it fails.
- **Criterion benches build** (`cargo bench --no-run` green, `harness = false`): Cargo forces `panic=unwind` back on for test and bench profiles, so the harness is untouched. Full test suite (dev profile): 890 green.
- **wasm unaffected** — checked; wasm-pack release builds already use abort semantics.
- **Functional smoke test**: the abort+fat binary runs `check --jobs 1` on the 50-package packed fixture correctly.

**The accepted trade-off, stated plainly:** a panic inside a rayon worker (parallel planning, parallel forge releases) now aborts the process raw — SIGABRT, no tidy propagated panic message — instead of unwinding up through rayon's internal `catch_unwind`. For a CLI where any panic is already a bug that ends the run, that costs diagnostics polish, not correctness. Documented in the profile comment.

Side effect on /performance: `ferrflow_binary_size_mb` and the install-footprint table drop by the same ~27% at the next release's benchmark run — a smaller number on a page we advertise, for free.
