### PR TITLE
fix(cli): exchange the bot token before spawning threads

### DIFF
--- a/src/bot_token.rs
+++ b/src/bot_token.rs
@@ -174,7 +174,10 @@ pub fn ensure_bot_token() -> Result<()> {
         .issue()
         .context("failed to obtain FerrFlow bot token")?;
 
-    // SAFETY: set_var is marked unsafe in edition 2024. This is single-threaded
+    // SAFETY: set_var mutates the process environment, which is UB (#710) if
+    // another thread is concurrently reading or writing it. main() calls this
+    // before concurrency::init spawns the rayon pool, so no other thread is
+    // alive at this point. The EXCHANGED guard above keeps it one-shot.
     unsafe {
         std::env::set_var("GITHUB_TOKEN", &issued.token);
         std::env::set_var("FERRFLOW_TOKEN", &issued.token);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -187,6 +187,10 @@ pub enum CacheCommand {
 }
 
 impl Commands {
+    pub fn needs_bot_token(&self) -> bool {
+        matches!(self, Commands::Release { .. } | Commands::Check { .. })
+    }
+
     #[cfg(test)]
     pub fn name(&self) -> &'static str {
         match self {
@@ -300,6 +304,19 @@ impl Cli {
 mod tests {
     use super::*;
     use clap::Parser;
+
+    #[test]
+    fn only_push_capable_commands_need_the_bot_token() {
+        let needs = |args: &[&str]| Cli::parse_from(args).command.needs_bot_token();
+        assert!(needs(&["ferrflow", "release"]));
+        assert!(needs(&["ferrflow", "check"]));
+        assert!(!needs(&["ferrflow", "status"]));
+        assert!(!needs(&["ferrflow", "version"]));
+        assert!(!needs(&["ferrflow", "tag"]));
+        assert!(!needs(&["ferrflow", "validate"]));
+        assert!(!needs(&["ferrflow", "changelog"]));
+        assert!(!needs(&["ferrflow", "init"]));
+    }
 
     fn parse(args: &[&str]) -> Cli {
         Cli::try_parse_from(args).unwrap()

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,20 @@ fn main() {
     let cli = Cli::parse();
 
     logging::init_logging(cli.verbose, cli.log_format);
+
+    // Exchange the bot token here, while the process is still single-threaded:
+    // it writes GITHUB_TOKEN/FERRFLOW_TOKEN with set_var, and the next line
+    // (concurrency::init) spawns the rayon pool on --jobs. set_var racing a
+    // live worker is UB (#710), so it must run before any thread exists.
+    if cli.command.needs_bot_token()
+        && let Err(err) = bot_token::ensure_bot_token()
+    {
+        for line in error_report::error_report_lines(&err) {
+            tracing::error!("{line}");
+        }
+        std::process::exit(1);
+    }
+
     concurrency::init(cli.jobs);
 
     let result = cli.run();

--- a/src/monorepo/check.rs
+++ b/src/monorepo/check.rs
@@ -19,7 +19,6 @@ pub fn check(
     comment: bool,
     timing: &mut Timing,
 ) -> Result<()> {
-    crate::bot_token::ensure_bot_token()?;
     let repo = timing.stage("open_repo", || open_repo(&std::env::current_dir()?))?;
     let root = get_repo_root(&repo)?;
     let config = timing.stage("load config", || Config::load(&root, config_path))?;

--- a/src/monorepo/release.rs
+++ b/src/monorepo/release.rs
@@ -24,7 +24,6 @@ pub fn release(
     force_unlock: bool,
     timing: &mut Timing,
 ) -> Result<()> {
-    crate::bot_token::ensure_bot_token()?;
     let repo = timing.stage("open_repo", || open_repo(&std::env::current_dir()?))?;
     let root = get_repo_root(&repo)?;
     let config = timing.stage("load config", || Config::load(&root, config_path))?;


### PR DESCRIPTION
Closes #710.

`ensure_bot_token()` writes `GITHUB_TOKEN`/`FERRFLOW_TOKEN` via `std::env::set_var`, which in edition 2024 is UB whenever another thread touches the environment concurrently. The old call sites (`monorepo::check`, `monorepo::release`) ran *after* `concurrency::init(cli.jobs)` had already built the global rayon pool, so on `--jobs` the `set_var` raced live worker threads (and, before its removal, the telemetry thread). The `// SAFETY: … single-threaded` comment was simply wrong.

Fix: hoist the exchange into `main()`, before `concurrency::init` spawns anything. At that point the process is genuinely single-threaded, so `set_var` is sound by construction.

- New `Commands::needs_bot_token()` scopes the exchange to the push-capable commands (`release`, `check`) — read-only/local commands no longer depend on the bot service being reachable, which is a behavioural improvement over the previous "call it inside check/release" placement.
- Removed the scattered `ensure_bot_token()?` calls from `check.rs`/`release.rs`.
- Corrected the SAFETY comment to state the real invariant (runs before any thread exists; `EXCHANGED` keeps it one-shot).

Out of scope: the token is still exported into the environment and thus inherited by every child process (git push, hooks, publishers). Narrowing that to least-privilege is a larger, riskier change (could break user hooks that rely on the env) and is tracked separately.