### PR TITLE
perf(monorepo): skip per-package tag scan when versioning strategy is set

### DIFF
--- a/src/config/package.rs
+++ b/src/config/package.rs
@@ -61,14 +61,14 @@ impl PackageConfig {
     /// Note: zerover is intentionally excluded from auto-detection because it
     /// is ambiguous with semver (both use `X.Y.Z`). Users must opt-in
     /// explicitly via config.
-    pub fn effective_versioning(
+    pub fn effective_versioning<'t>(
         &self,
         workspace: &WorkspaceConfig,
-        tags: &[&str],
+        tags: impl FnOnce() -> Vec<&'t str>,
     ) -> VersioningStrategy {
         self.versioning
             .or(workspace.versioning)
-            .or_else(|| crate::versioning::detect_strategy_from_tags(tags))
+            .or_else(|| crate::versioning::detect_strategy_from_tags(&tags()))
             .unwrap_or_default()
     }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -218,7 +218,7 @@ fn effective_versioning_inherits_workspace() {
         update_lockfiles: None,
     };
     assert_eq!(
-        pkg.effective_versioning(&ws, &[]),
+        pkg.effective_versioning(&ws, Vec::new),
         VersioningStrategy::Calver
     );
 }
@@ -244,9 +244,34 @@ fn effective_versioning_package_overrides() {
         update_lockfiles: None,
     };
     assert_eq!(
-        pkg.effective_versioning(&ws, &[]),
+        pkg.effective_versioning(&ws, Vec::new),
         VersioningStrategy::Zerover
     );
+}
+
+#[test]
+fn effective_versioning_does_not_read_tags_when_strategy_is_configured() {
+    let ws = WorkspaceConfig {
+        versioning: Some(VersioningStrategy::Calver),
+        ..WorkspaceConfig::default()
+    };
+    let pkg = PackageConfig {
+        name: "a".into(),
+        path: ".".into(),
+        versioned_files: vec![],
+        changelog: None,
+        shared_paths: vec![],
+        depends_on: vec![],
+        versioning: None,
+        tag_template: None,
+        hooks: None,
+        floating_tags: None,
+        publishers: vec![],
+        update_lockfiles: None,
+    };
+    let strategy =
+        pkg.effective_versioning(&ws, || panic!("tags scanned despite configured strategy"));
+    assert_eq!(strategy, VersioningStrategy::Calver);
 }
 
 #[test]
@@ -268,7 +293,7 @@ fn effective_versioning_autodetects_from_tags_when_unset() {
     };
     let tags = vec!["v2024.04.18", "v2024.05.01"];
     assert_eq!(
-        pkg.effective_versioning(&ws, &tags),
+        pkg.effective_versioning(&ws, || tags.clone()),
         VersioningStrategy::Calver
     );
 }
@@ -291,7 +316,7 @@ fn effective_versioning_falls_back_to_semver_without_tags() {
         update_lockfiles: None,
     };
     assert_eq!(
-        pkg.effective_versioning(&ws, &[]),
+        pkg.effective_versioning(&ws, Vec::new),
         VersioningStrategy::Semver
     );
 }

--- a/src/monorepo/run/cascade.rs
+++ b/src/monorepo/run/cascade.rs
@@ -73,10 +73,9 @@ pub(super) fn run_dependency_cascade(
                 continue;
             };
             let pkg_tag_prefix = pkg.tag_prefix(&config.workspace, config.is_monorepo());
-            let strategy = pkg.effective_versioning(
-                &config.workspace,
-                &tags_for_package(all_tags, &pkg_tag_prefix),
-            );
+            let strategy = pkg.effective_versioning(&config.workspace, || {
+                tags_for_package(all_tags, &pkg_tag_prefix)
+            });
             let Ok(new_version) = compute_next_version(&current_version, BumpType::Patch, strategy)
             else {
                 continue;

--- a/src/monorepo/run/plan.rs
+++ b/src/monorepo/run/plan.rs
@@ -168,10 +168,9 @@ pub(super) fn compute_plan(
         });
     }
 
-    let pkg_strategy = pkg.effective_versioning(
-        &config.workspace,
-        &tags_for_package(inputs.all_tags, &tag_search_prefix),
-    );
+    let pkg_strategy = pkg.effective_versioning(&config.workspace, || {
+        tags_for_package(inputs.all_tags, &tag_search_prefix)
+    });
 
     let file_version = pkg
         .versioned_files


### PR DESCRIPTION
Closes #504.

Auditing #504 against current `main` — the codebase has moved a long way since the list was written (gix migration, `TagIndex`, the `plan.rs` extraction + rayon parallelization from #476, gix-based push). Most of the listed items already landed as part of those refactors. This PR ships the one remaining meaningful piece and documents the rest.

## This PR

**Item 1 residual — don't build the per-package tag slice when the strategy is already known.** After the `plan.rs` refactor, `pkg.effective_versioning(...)` is now computed exactly once per package (the "called 3–4×" redundancy is gone). But the tag slice it takes was still built *eagerly*: `effective_versioning` only uses `tags` for the `detect_strategy_from_tags` fallback — i.e. only when neither the package nor the workspace sets `versioning` — yet `tags_for_package(all_tags, prefix)` (a full scan of every tag + a `Vec` allocation) ran for every package regardless, then got thrown away whenever the strategy was configured.

Made the argument a `FnOnce() -> Vec<&str>` so the scan runs only when auto-detection actually needs it. For a repo with `versioning` set, this drops the per-package tag scan + allocation entirely (200 pkg × N tags of wasted iteration → zero). Guarded by a test that passes a closure which panics if invoked while a strategy is configured.

## Already done by intervening refactors (checked on the issue)

- **Cache `pkg_strategy` + `pkg_tags`** — `compute_plan` (`plan.rs`) computes `pkg_strategy` once and reuses it; the 3–4× redundant `effective_versioning`/`tags_for_package` calls no longer exist. (This PR removes the last wasted work in that item.)
- **Replace per-tag `git rev-list -n 1` in push_tags** — done: `push.rs::local_tag_target_sha` peels the tag in-process via gix (`find_reference` + `into_fully_peeled_id`), no per-tag process spawn. The code comment already states the exact rationale from this item.
- **Skip `collect_dirty_files` when no hook** — done: both call sites (`run/mod.rs` post-bump, `run/execute.rs::run_pre_commit_hooks`) are inside `if let Some(cmd) = resolve_hook(...)`, so `git status` only shells out when a hook exists for that context.
- **Move `OrphanedTagStrategy::Warn` early-return in `find_matching_commit`** — done: `tags.rs` bails on `Warn` before the 1000-commit walk.

## Intentionally not pursued (left unchecked, with reasons)

- **`is_package_touched` quadratic** — the scan is only over the *last commit's* changed files in the common path (a handful), so it's below the noise floor there; it's only sizeable in the `recover_missed_releases` path against a large diff. Pre-sorting + `binary_search` adds prefix-range subtlety and risk for a rarely-hot path. Not worth the complexity now.
- **Cache parsed semver in `TagIndexEntry`** — no longer cleanly applicable: `find_highest_semver_tag` parses only *after* the `starts_with(prefix)` filter, so it parses ~the handful of tags matching each package's prefix, not all of them — the "200k re-parses" premise doesn't hold. And a build-time cache can't pre-parse anyway, since the version string depends on the per-package prefix that isn't known at `TagIndex::build`.
- **Resolve `push_url` once** — the premise ("gix re-opens remotes on each call") doesn't match this code: `get_remote_url` is a cheap in-memory gix config read, and it runs ~once per top-level git operation (~5 per release), not per package. Threading it through five function signatures trades real complexity for ~0ms.

Net: the two big wins in the original estimate (the push `rev-list` seconds, and the redundant per-package compute) were already in place; this PR removes the last bit of wasted per-package scanning. No behaviour change — pure internal optimization, so no changelog/site entry.