### PR TITLE
feat(monorepo): linked and fixed package version groups

### DIFF
--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -360,6 +360,26 @@
           "type": "boolean",
           "description": "Snake_case form of `updateLockfiles` — both spellings are accepted. When true, after `ferrflow release` bumps a manifest (Cargo.toml, package.json, pyproject.toml, Gemfile, mix.exs) it refreshes the sibling lockfile (Cargo.lock, package-lock.json / pnpm-lock.yaml / yarn.lock, poetry.lock / uv.lock, Gemfile.lock, mix.lock) with the package manager's offline / lockfile-only mode and stages it in the same release commit. A missing package manager or an unresolvable offline update is warned about, never fatal. Set per-package `updateLockfiles: false` to opt a single package out.",
           "default": false
+        },
+        "linked": {
+          "type": "array",
+          "description": "Groups of packages that share a version line when co-released. When any member of a group has a releasable commit, every member is bumped to the same version (the highest resulting version across the group). Package names stay distinct. Each inner array is one group and must list at least two package names; a package may appear in only one linked/fixed group.",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "fixed": {
+          "type": "array",
+          "description": "Groups of packages locked to an identical version forever. Behaves like `linked`, but is intended for packages that must never diverge; `ferrflow validate` warns when a fixed group's versions have drifted apart. Each inner array is one group and must list at least two package names; a package may appear in only one linked/fixed group.",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         }
       },
       "additionalProperties": false

--- a/src/config/groups.rs
+++ b/src/config/groups.rs
@@ -1,0 +1,135 @@
+use std::collections::HashSet;
+
+use super::Config;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GroupKind {
+    Linked,
+    Fixed,
+}
+
+impl GroupKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            GroupKind::Linked => "linked",
+            GroupKind::Fixed => "fixed",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PackageGroup {
+    pub kind: GroupKind,
+    pub members: Vec<String>,
+}
+
+impl Config {
+    pub fn package_groups(&self) -> Vec<PackageGroup> {
+        let linked = self.workspace.linked.iter().map(|m| PackageGroup {
+            kind: GroupKind::Linked,
+            members: m.clone(),
+        });
+        let fixed = self.workspace.fixed.iter().map(|m| PackageGroup {
+            kind: GroupKind::Fixed,
+            members: m.clone(),
+        });
+        linked.chain(fixed).collect()
+    }
+
+    pub fn validate_groups(&self) -> Result<(), Vec<String>> {
+        let groups = self.package_groups();
+        if groups.is_empty() {
+            return Ok(());
+        }
+
+        let known: HashSet<&str> = self.packages.iter().map(|p| p.name.as_str()).collect();
+        let mut errors = Vec::new();
+        let mut assigned: HashSet<&str> = HashSet::new();
+
+        for group in &groups {
+            let kind = group.kind.label();
+            if group.members.len() < 2 {
+                errors.push(format!(
+                    "{kind} group {:?} must list at least two packages",
+                    group.members
+                ));
+            }
+            let mut seen_in_group: HashSet<&str> = HashSet::new();
+            for member in &group.members {
+                if !known.contains(member.as_str()) {
+                    errors.push(format!(
+                        "package '{member}' in a {kind} group is not defined in package[]"
+                    ));
+                }
+                if !seen_in_group.insert(member.as_str()) {
+                    errors.push(format!(
+                        "package '{member}' is listed twice in the same {kind} group"
+                    ));
+                    continue;
+                }
+                if !assigned.insert(member.as_str()) {
+                    errors.push(format!(
+                        "package '{member}' appears in more than one linked/fixed group"
+                    ));
+                }
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::Config;
+
+    fn config(packages: &[&str], linked: &str, fixed: &str) -> Config {
+        let pkgs: Vec<String> = packages
+            .iter()
+            .map(|n| format!(r#"{{"name":"{n}","path":"{n}"}}"#))
+            .collect();
+        serde_json::from_str(&format!(
+            r#"{{"workspace":{{"linked":{linked},"fixed":{fixed}}},"package":[{}]}}"#,
+            pkgs.join(",")
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn valid_groups_pass() {
+        let c = config(&["a", "b", "c"], r#"[["a","b"]]"#, r#"[["c","a"]]"#);
+        // a is in linked and fixed → not allowed
+        assert!(c.validate_groups().is_err());
+
+        let c = config(&["a", "b", "c"], r#"[["a","b"]]"#, "[]");
+        assert!(c.validate_groups().is_ok());
+    }
+
+    #[test]
+    fn member_missing_from_packages_is_an_error() {
+        let c = config(&["a"], r#"[["a","ghost"]]"#, "[]");
+        let err = c.validate_groups().unwrap_err();
+        assert!(
+            err.iter()
+                .any(|e| e.contains("ghost") && e.contains("not defined"))
+        );
+    }
+
+    #[test]
+    fn member_in_two_groups_is_an_error() {
+        let c = config(&["a", "b", "c"], r#"[["a","b"]]"#, r#"[["a","c"]]"#);
+        let err = c.validate_groups().unwrap_err();
+        assert!(err.iter().any(|e| e.contains("more than one")));
+    }
+
+    #[test]
+    fn singleton_group_is_an_error() {
+        let c = config(&["a", "b"], r#"[["a"]]"#, "[]");
+        let err = c.validate_groups().unwrap_err();
+        assert!(err.iter().any(|e| e.contains("at least two")));
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use crate::error_code::{self, ErrorCodeExt};
 
 mod format;
+mod groups;
 #[cfg(feature = "cli")]
 mod init;
 #[cfg(feature = "cli")]
@@ -17,6 +18,8 @@ mod workspace;
 
 #[allow(unused_imports)]
 pub use format::{ConfigFileFormat, ConfigFormatHandler, format_handler};
+#[allow(unused_imports)]
+pub use groups::{GroupKind, PackageGroup};
 #[cfg(feature = "cli")]
 pub use init::init;
 #[cfg(feature = "cli")]

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -81,6 +81,18 @@ pub struct WorkspaceConfig {
     /// `package.updateLockfiles = false` to opt a single package out.
     #[serde(default, alias = "updateLockfiles")]
     pub update_lockfiles: bool,
+    /// Packages that share a version line when co-released. When any
+    /// member of a group has a releasable commit, every member is bumped
+    /// to the same version (the highest resulting version across the
+    /// group). Names stay distinct. Each inner array is one group.
+    #[serde(default)]
+    pub linked: Vec<Vec<String>>,
+    /// Packages locked to an identical version forever. Behaves like
+    /// [`linked`](Self::linked) but is intended for packages that must
+    /// never diverge; `ferrflow validate` warns when their versions have
+    /// drifted apart. Each inner array is one group.
+    #[serde(default)]
+    pub fixed: Vec<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]

--- a/src/monorepo/run/groups.rs
+++ b/src/monorepo/run/groups.rs
@@ -1,0 +1,225 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::config::Config;
+use crate::conventional_commits::BumpType;
+use crate::formats::read_version;
+
+use super::super::util::pick_higher_semver;
+use super::plan::{PackageBump, PackagePlan};
+
+pub(super) fn apply_groups(config: &Config, root: &Path, plans: &mut [Option<PackagePlan>]) {
+    let groups = config.package_groups();
+    if groups.is_empty() {
+        return;
+    }
+
+    let index_of: HashMap<&str, usize> = config
+        .packages
+        .iter()
+        .enumerate()
+        .map(|(i, p)| (p.name.as_str(), i))
+        .collect();
+    let is_monorepo = config.is_monorepo();
+
+    for group in &groups {
+        let member_idxs: Vec<usize> = group
+            .members
+            .iter()
+            .filter_map(|name| index_of.get(name.as_str()).copied())
+            .collect();
+
+        let Some((target_version, target_is_prerelease)) = group_target(plans, &member_idxs) else {
+            continue;
+        };
+
+        for idx in member_idxs {
+            let pkg = &config.packages[idx];
+            let target_tag = pkg.tag_for_version(&config.workspace, is_monorepo, &target_version);
+
+            match plans[idx].take() {
+                Some(PackagePlan::Bump(mut bump)) => {
+                    if bump.new_version != target_version {
+                        bump.new_version = target_version.clone();
+                        bump.tag = target_tag;
+                        bump.is_prerelease = target_is_prerelease;
+                    }
+                    plans[idx] = Some(PackagePlan::Bump(bump));
+                }
+                _ => {
+                    let current = pkg
+                        .versioned_files
+                        .first()
+                        .and_then(|vf| read_version(vf, root).ok())
+                        .unwrap_or_else(|| target_version.clone());
+                    plans[idx] = Some(PackagePlan::Bump(Box::new(PackageBump {
+                        recovered: false,
+                        current_version: current,
+                        new_version: target_version.clone(),
+                        is_prerelease: target_is_prerelease,
+                        last_tag: None,
+                        commits: Vec::new(),
+                        bump: BumpType::None,
+                        strategy_label: group.kind.label().to_string(),
+                        tag: target_tag,
+                    })));
+                }
+            }
+        }
+    }
+}
+
+fn group_target(plans: &[Option<PackagePlan>], member_idxs: &[usize]) -> Option<(String, bool)> {
+    let mut best: Option<(String, bool)> = None;
+    for &idx in member_idxs {
+        let Some(Some(PackagePlan::Bump(bump))) = plans.get(idx) else {
+            continue;
+        };
+        best = match best {
+            None => Some((bump.new_version.clone(), bump.is_prerelease)),
+            Some((current, _))
+                if pick_higher_semver(&current, &bump.new_version) == bump.new_version =>
+            {
+                Some((bump.new_version.clone(), bump.is_prerelease))
+            }
+            keep => keep,
+        };
+    }
+    best
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::plan::SkipReason;
+    use super::*;
+    use crate::changelog::GitLog;
+
+    fn write_pkg(root: &Path, name: &str, version: &str) {
+        std::fs::create_dir_all(root.join(name)).unwrap();
+        std::fs::write(
+            root.join(name).join("Cargo.toml"),
+            format!("[package]\nname = \"{name}\"\nversion = \"{version}\"\n"),
+        )
+        .unwrap();
+    }
+
+    fn config(root: &Path, names: &[&str], linked: &str, fixed: &str) -> Config {
+        for n in names {
+            write_pkg(root, n, "1.0.0");
+        }
+        let packages: Vec<String> = names
+            .iter()
+            .map(|n| {
+                format!(
+                    r#"{{"name":"{n}","path":"{n}","versionedFiles":[{{"path":"{n}/Cargo.toml","format":"toml"}}]}}"#
+                )
+            })
+            .collect();
+        serde_json::from_str(&format!(
+            r#"{{"workspace":{{"linked":{linked},"fixed":{fixed}}},"package":[{}]}}"#,
+            packages.join(",")
+        ))
+        .unwrap()
+    }
+
+    fn bump(current: &str, new: &str, tag: &str, bump: BumpType) -> Option<PackagePlan> {
+        Some(PackagePlan::Bump(Box::new(PackageBump {
+            recovered: false,
+            current_version: current.to_string(),
+            new_version: new.to_string(),
+            is_prerelease: false,
+            last_tag: None,
+            commits: vec![GitLog {
+                hash: "abc1234".to_string(),
+                message: "feat: x".to_string(),
+            }],
+            bump,
+            strategy_label: bump.to_string(),
+            tag: tag.to_string(),
+        })))
+    }
+
+    fn as_bump(plan: &Option<PackagePlan>) -> &PackageBump {
+        match plan {
+            Some(PackagePlan::Bump(b)) => b,
+            _ => panic!("expected a bump plan, got a skip"),
+        }
+    }
+
+    #[test]
+    fn linked_pulls_an_unchanged_member_to_the_same_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let config = config(root, &["a", "b"], r#"[["a","b"]]"#, "[]");
+
+        let mut plans = vec![
+            bump("1.0.0", "1.1.0", "a@v1.1.0", BumpType::Minor),
+            Some(PackagePlan::Skipped {
+                reason: SkipReason::NotTouched,
+                recovered: false,
+            }),
+        ];
+        apply_groups(&config, root, &mut plans);
+
+        let a = as_bump(&plans[0]);
+        let b = as_bump(&plans[1]);
+        assert_eq!(a.new_version, "1.1.0");
+        assert_eq!(b.new_version, "1.1.0", "unchanged member follows the group");
+        assert_eq!(b.tag, "b@v1.1.0");
+        assert_eq!(
+            b.current_version, "1.0.0",
+            "current read from the version file"
+        );
+        assert!(b.commits.is_empty(), "no commits of its own");
+    }
+
+    #[test]
+    fn fixed_aligns_every_member_to_the_highest_bump() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let config = config(root, &["a", "b", "c"], "[]", r#"[["a","b","c"]]"#);
+
+        let mut plans = vec![
+            bump("1.0.0", "1.1.0", "a@v1.1.0", BumpType::Minor),
+            bump("1.0.0", "1.0.1", "b@v1.0.1", BumpType::Patch),
+            Some(PackagePlan::Skipped {
+                reason: SkipReason::NoNewCommits,
+                recovered: false,
+            }),
+        ];
+        apply_groups(&config, root, &mut plans);
+
+        for (idx, name) in ["a", "b", "c"].iter().enumerate() {
+            let plan = as_bump(&plans[idx]);
+            assert_eq!(
+                plan.new_version, "1.1.0",
+                "{name} must land on the max bump"
+            );
+            assert_eq!(plan.tag, format!("{name}@v1.1.0"));
+        }
+        // The patch member was raised to the group minor.
+        assert_eq!(as_bump(&plans[1]).new_version, "1.1.0");
+    }
+
+    #[test]
+    fn group_with_no_releasable_member_is_left_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let config = config(root, &["a", "b"], r#"[["a","b"]]"#, "[]");
+
+        let mut plans = vec![
+            Some(PackagePlan::Skipped {
+                reason: SkipReason::NotTouched,
+                recovered: false,
+            }),
+            Some(PackagePlan::Skipped {
+                reason: SkipReason::NotTouched,
+                recovered: false,
+            }),
+        ];
+        apply_groups(&config, root, &mut plans);
+
+        assert!(matches!(plans[0], Some(PackagePlan::Skipped { .. })));
+        assert!(matches!(plans[1], Some(PackagePlan::Skipped { .. })));
+    }
+}

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -25,6 +25,7 @@ mod drafts;
 mod execute;
 mod forced;
 mod graph;
+mod groups;
 mod lock;
 mod plan;
 mod release_json;
@@ -83,6 +84,13 @@ pub(super) fn run_release_logic(
             ],
         };
         return finish(dry_run, out);
+    }
+
+    if let Err(errors) = config.validate_groups() {
+        return Err(anyhow::anyhow!(
+            "invalid linked/fixed groups:\n  - {}",
+            errors.join("\n  - ")
+        ));
     }
 
     let release_order = graph::release_order(&config.packages).map_err(graph::Cycle::into_error)?;
@@ -217,6 +225,7 @@ pub(super) fn run_release_logic(
         .collect::<Result<Vec<_>>>()?;
 
     let mut plans: Vec<Option<PackagePlan>> = plans.into_iter().map(Some).collect();
+    groups::apply_groups(config, root, &mut plans);
     for &pkg_idx in &release_order {
         let pkg = &config.packages[pkg_idx];
         let plan = plans[pkg_idx]

--- a/src/validate/checks.rs
+++ b/src/validate/checks.rs
@@ -254,6 +254,55 @@ pub(super) fn check_shared_paths(config: &Config, source: &dyn FileSource) -> Ve
     entries
 }
 
+pub(super) fn check_groups(config: &Config, versions: &PackageVersionMap) -> Vec<ValidationEntry> {
+    let mut entries = Vec::new();
+
+    if let Err(errors) = config.validate_groups() {
+        for message in errors {
+            entries.push(ValidationEntry {
+                level: ValidationLevel::Error,
+                path: "(config)".to_string(),
+                message,
+            });
+        }
+        return entries;
+    }
+
+    for group in config.package_groups() {
+        if group.kind != crate::config::GroupKind::Fixed {
+            continue;
+        }
+        let member_versions: Vec<(&String, &String)> = group
+            .members
+            .iter()
+            .filter_map(|name| {
+                versions
+                    .get(name)
+                    .and_then(|f| f.first())
+                    .map(|(_, v)| (name, v))
+            })
+            .collect();
+        if let Some((_, first)) = member_versions.first()
+            && member_versions.iter().any(|(_, v)| v != first)
+        {
+            let listed = member_versions
+                .iter()
+                .map(|(name, v)| format!("{name}={v}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            entries.push(ValidationEntry {
+                level: ValidationLevel::Warning,
+                path: "(config)".to_string(),
+                message: format!(
+                    "fixed group has drifted versions ({listed}); the next release will realign them"
+                ),
+            });
+        }
+    }
+
+    entries
+}
+
 pub(super) fn check_suggestions(config: &Config) -> Vec<ValidationEntry> {
     let mut entries = Vec::new();
     for pkg in &config.packages {

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -17,9 +17,9 @@ pub use source::{
 };
 
 use checks::{
-    check_changelog_paths, check_duplicate_names, check_duplicate_paths, check_package_paths,
-    check_shared_paths, check_suggestions, check_tag_templates, check_version_consistency,
-    check_versioned_files, check_versioned_files_exist,
+    check_changelog_paths, check_duplicate_names, check_duplicate_paths, check_groups,
+    check_package_paths, check_shared_paths, check_suggestions, check_tag_templates,
+    check_version_consistency, check_versioned_files, check_versioned_files_exist,
 };
 use output::output_result;
 
@@ -87,6 +87,7 @@ pub fn run(
     entries.extend(check_version_consistency(&versions));
     entries.extend(check_changelog_paths(&config, source.as_ref()));
     entries.extend(check_shared_paths(&config, source.as_ref()));
+    entries.extend(check_groups(&config, &versions));
     entries.extend(check_suggestions(&config));
 
     let mut result = ValidationResult::from_entries(entries);


### PR DESCRIPTION
Closes #494.

Adds `workspace.linked` and `workspace.fixed` — package groups that move in lockstep, the way changesets `linked`/`fixed` and lerna `mode: "fixed"` do. Until now the only cross-package coupling was `dependsOn`, which cascades a bump but doesn't share the version.

## Config

```toml
[workspace]
linked = [["react", "react-dom"]]
fixed  = [["@scope/a", "@scope/b", "@scope/c"]]
```

Each inner array is one group. `linked` and `fixed` both take a list of groups.

## Behaviour

After per-package bumps are computed (in parallel), `run/groups.rs::apply_groups` post-processes the plans:

- A group is **active** when at least one member has a releasable commit.
- The group's **target version** is the highest resulting version across its active members (so `feat` on one member + `fix` on another → everyone lands on the minor). This reuses each member's already-computed `new_version` rather than recomputing bumps, so prerelease suffixes and calver/sequential strategies come along for free.
- Every member is aligned to that version: members that bumped less are raised, and members with no commits of their own are pulled into the release at the shared version (tagged, changelog gets a version header like a dependency cascade). Package names stay distinct.

`linked` vs `fixed`: same release-time alignment, different intent. `fixed` is for packages that must never diverge — `ferrflow validate` additionally **warns** when a fixed group's on-disk versions have already drifted apart (the next release realigns them). `linked` is the looser "share a version line when co-released".

The alignment runs inside the normal `check`/`release` pipeline, so `ferrflow check` previews the co-released members too. The dependency cascade runs after grouping, so a `dependsOn` a grouped package still cascades correctly.

## Validation

`Config::validate_groups()` hard-errors the release (and surfaces as `ferrflow validate` errors) when:
- a member isn't defined in `package[]`,
- a member appears in more than one linked/fixed group (covers "in both linked and fixed"),
- a member is listed twice in one group,
- a group has fewer than two members.

## Tests

- `run/groups.rs`: linked pulls an unchanged member to the group version (current read from its version file); fixed raises a patch member and an untouched member to the group minor; a group with no releasable member is left untouched.
- `config/groups.rs`: each validation rule.
- Verified end-to-end with `ferrflow check` on scratch repos: linked `[a,b]` with a `feat` on `a` → both `1.0.0 → 1.1.0` (`b` labelled `linked`); fixed `[a,b,c]` → all three realign to the max bump; a package in both groups aborts with a clear error before any side effect.

Schema updated (`schema/ferrflow.json`). The site schema copy + config-reference docs (EN/FR) and the changelog entry land in their own repos (FerrFlow-Cloud, Changelog) per the cross-repo rule.

Follow-up (not in scope): independent-release `linked` (only changed members published, versions kept aligned upward) — the canonical changesets nuance — is deferred; #494's test plan specifies all members co-release, which is what this implements.