### PR TITLE
feat(cli): add doctor diagnostic subcommand

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,6 +5,7 @@ use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::Shell;
 
 use crate::config::ConfigFileFormat;
+use crate::doctor::DoctorFormat;
 use crate::logging::LogFormat;
 use crate::status::OutputFormat;
 use crate::timing::Timing;
@@ -164,6 +165,15 @@ pub enum Commands {
         #[arg(long, value_enum)]
         from: Option<MigrateSourceArg>,
     },
+    /// Run read-only diagnostics on the repo, config, and forge setup
+    Doctor {
+        /// Output format
+        #[arg(long, value_enum, default_value = "human")]
+        format: DoctorFormat,
+        /// Also probe the forge API (rate limit / auth). Requires a token.
+        #[arg(long)]
+        online: bool,
+    },
 }
 
 #[derive(Clone, Copy, clap::ValueEnum)]
@@ -207,6 +217,7 @@ impl Commands {
             Commands::Cache { .. } => "cache",
             Commands::SyncManifest => "sync-manifest",
             Commands::Migrate { .. } => "migrate",
+            Commands::Doctor { .. } => "doctor",
         }
     }
 }
@@ -296,6 +307,9 @@ impl Cli {
             },
             Commands::SyncManifest => crate::manifest::sync_cwd(self.config.as_deref()),
             Commands::Migrate { from } => crate::config::migrate(from.map(Into::into)),
+            Commands::Doctor { format, online } => {
+                crate::doctor::run(self.config.as_deref(), format, online)
+            }
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -246,6 +246,10 @@ impl Config {
         self.packages.len() > 1
     }
 
+    pub fn discovered_config_paths(repo_root: &Path) -> Vec<PathBuf> {
+        Self::discover(repo_root)
+    }
+
     pub fn has_release_side_effects(&self) -> bool {
         self.workspace.hooks.is_some()
             || self

--- a/src/doctor/checks.rs
+++ b/src/doctor/checks.rs
@@ -1,0 +1,409 @@
+use std::path::Path;
+use std::process::Command;
+
+use crate::config::{Config, ForgeKind};
+use crate::formats::read_version;
+use crate::git::{Repository, collect_all_tags, get_remote_url};
+use crate::validate::ValidationLevel;
+
+use super::report::{Check, Section, Status};
+
+fn remote_name(config: Option<&Config>) -> &str {
+    config
+        .map(|c| c.workspace.remote.as_str())
+        .filter(|remote| !remote.is_empty())
+        .unwrap_or("origin")
+}
+
+pub(super) fn repo_section(
+    repo: Option<&Repository>,
+    config: Option<&Config>,
+    root: &Path,
+) -> Section {
+    let mut checks = Vec::new();
+    let Some(repo) = repo else {
+        checks.push(Check::error(
+            "git repository",
+            Some("not a git repository — run `git init` in the project root".into()),
+        ));
+        return Section::new("Repo", checks);
+    };
+    checks.push(Check::ok("git repository", None));
+
+    match repo.head_id() {
+        Ok(id) => checks.push(Check::ok(
+            "commit history",
+            Some(format!("HEAD at {}", &id.to_string()[..7])),
+        )),
+        Err(_) => checks.push(Check::error(
+            "commit history",
+            Some("no commits yet — make an initial commit before releasing".into()),
+        )),
+    }
+
+    match dirty_count(root) {
+        Some(0) => checks.push(Check::ok("working tree clean", None)),
+        Some(n) => checks.push(Check::warn(
+            "working tree clean",
+            Some(format!(
+                "{n} uncommitted change{}; a release refuses a dirty tree",
+                if n == 1 { "" } else { "s" }
+            )),
+        )),
+        None => checks.push(Check::info(
+            "working tree clean",
+            Some("could not read `git status`".into()),
+        )),
+    }
+
+    let remote = remote_name(config);
+    match get_remote_url(repo, remote) {
+        Some(url) => checks.push(Check::ok(
+            "remote configured",
+            Some(format!("{remote} → {}", redact_url(&url))),
+        )),
+        None => checks.push(Check::warn(
+            "remote configured",
+            Some(format!(
+                "no '{remote}' remote — releases push tags and commits there"
+            )),
+        )),
+    }
+
+    let tag_count = collect_all_tags(repo).len();
+    if tag_count > 0 {
+        checks.push(Check::ok(
+            "tags present",
+            Some(format!(
+                "{tag_count} local tag{}",
+                if tag_count == 1 { "" } else { "s" }
+            )),
+        ));
+    } else {
+        checks.push(Check::info(
+            "tags present",
+            Some("no tags yet — the first release creates them".into()),
+        ));
+    }
+
+    Section::new("Repo", checks)
+}
+
+pub(super) fn config_section(
+    config: Option<&Config>,
+    config_error: Option<&str>,
+    discovered: &[std::path::PathBuf],
+    root: &Path,
+) -> Section {
+    let mut checks = Vec::new();
+
+    match discovered.len() {
+        0 => checks.push(Check::warn(
+            "config file",
+            Some(
+                "none found — run `ferrflow init` (otherwise FerrFlow auto-detects version files)"
+                    .into(),
+            ),
+        )),
+        1 => checks.push(Check::ok("config file", Some(filename(&discovered[0])))),
+        _ => {
+            let list = discovered
+                .iter()
+                .map(|p| filename(p))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let winner = filename(&discovered[0]);
+            checks.push(Check::warn(
+                "config file",
+                Some(format!(
+                    "multiple found ({list}); '{winner}' takes precedence"
+                )),
+            ));
+        }
+    }
+
+    if let Some(err) = config_error {
+        checks.push(Check::error("config parses", Some(err.to_string())));
+        return Section::new("Config", checks);
+    }
+
+    let Some(config) = config else {
+        return Section::new("Config", checks);
+    };
+
+    checks.push(Check::ok(
+        "config parses",
+        Some(format!(
+            "{} package{}",
+            config.packages.len(),
+            if config.packages.len() == 1 { "" } else { "s" }
+        )),
+    ));
+
+    for entry in crate::validate::local_entries(config, root) {
+        let status = match entry.level {
+            ValidationLevel::Error => Status::Error,
+            ValidationLevel::Warning => Status::Warn,
+            ValidationLevel::Suggestion => Status::Info,
+        };
+        checks.push(Check::new(entry.path, status, Some(entry.message)));
+    }
+
+    Section::new("Config", checks)
+}
+
+pub(super) fn versioning_section(config: Option<&Config>, root: &Path) -> Section {
+    let mut checks = Vec::new();
+    let Some(config) = config else {
+        checks.push(Check::info(
+            "strategy",
+            Some("skipped — no parsed config".into()),
+        ));
+        return Section::new("Versioning", checks);
+    };
+    if config.packages.is_empty() {
+        checks.push(Check::info(
+            "strategy",
+            Some("no packages configured".into()),
+        ));
+        return Section::new("Versioning", checks);
+    }
+
+    match config.workspace.versioning {
+        Some(strategy) => checks.push(Check::info(
+            "strategy",
+            Some(format!(
+                "declared: {}",
+                format!("{strategy:?}").to_lowercase()
+            )),
+        )),
+        None => checks.push(Check::info(
+            "strategy",
+            Some("auto-detected from tags (semver by default)".into()),
+        )),
+    }
+
+    // On-disk versions only — the tag walk that computes last-tag / next
+    // version lives in `ferrflow status` / `check`, and its orphaned-tag
+    // warnings would drown out a diagnostic report.
+    for pkg in &config.packages {
+        let version = pkg
+            .versioned_files
+            .first()
+            .and_then(|vf| read_version(vf, root).ok())
+            .unwrap_or_else(|| "unknown".to_string());
+        checks.push(Check::ok(pkg.name.clone(), Some(format!("v{version}"))));
+    }
+
+    checks.push(Check::info(
+        "next versions",
+        Some("run `ferrflow check` to preview the next version for each package".into()),
+    ));
+
+    Section::new("Versioning", checks)
+}
+
+pub(super) fn forge_section(
+    repo: Option<&Repository>,
+    config: Option<&Config>,
+    online: bool,
+) -> Section {
+    let mut checks = Vec::new();
+
+    let remote = remote_name(config);
+    let url = repo.and_then(|r| get_remote_url(r, remote));
+    let configured = config.map(|c| c.workspace.forge).unwrap_or(ForgeKind::Auto);
+    let detected = url.as_deref().and_then(crate::forge::detect_forge_from_url);
+    let forge = match configured {
+        ForgeKind::Auto => detected,
+        explicit => Some(explicit),
+    };
+
+    match forge {
+        Some(kind) => {
+            let source = if configured == ForgeKind::Auto {
+                "from remote URL"
+            } else {
+                "from config"
+            };
+            checks.push(Check::ok(
+                "forge",
+                Some(format!("{} ({source})", forge_label(kind))),
+            ));
+        }
+        None => checks.push(Check::warn(
+            "forge",
+            Some("could not detect the forge from the remote URL — set workspace.forge".into()),
+        )),
+    }
+
+    let (var, present) = token_env(forge);
+    if present {
+        checks.push(Check::ok("auth token", Some(format!("{var} is set"))));
+    } else {
+        checks.push(Check::warn(
+            "auth token",
+            Some("no token in env (FERRFLOW_TOKEN / GITHUB_TOKEN / GITLAB_TOKEN) — API pushes and releases will fail".into()),
+        ));
+    }
+
+    if online {
+        checks.push(online_check(forge));
+    }
+
+    Section::new("Forge", checks)
+}
+
+pub(super) fn ci_section(root: &Path) -> Section {
+    let mut checks = Vec::new();
+
+    let gh_workflows = root.join(".github").join("workflows");
+    let gitlab = root.join(".gitlab-ci.yml");
+    let forgejo = root.join(".forgejo").join("workflows");
+
+    if gh_workflows.is_dir() {
+        checks.push(Check::ok("workflows", Some(".github/workflows/".into())));
+        checks.push(ferrflow_action_check(&gh_workflows));
+    } else if gitlab.is_file() {
+        checks.push(Check::ok("workflows", Some(".gitlab-ci.yml".into())));
+    } else if forgejo.is_dir() {
+        checks.push(Check::ok("workflows", Some(".forgejo/workflows/".into())));
+    } else {
+        checks.push(Check::info(
+            "workflows",
+            Some("no CI workflows detected".into()),
+        ));
+    }
+
+    Section::new("CI", checks)
+}
+
+fn ferrflow_action_check(workflows: &Path) -> Check {
+    let Ok(entries) = std::fs::read_dir(workflows) else {
+        return Check::info(
+            "FerrFlow action",
+            Some("could not read workflows directory".into()),
+        );
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let is_yaml = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e == "yml" || e == "yaml");
+        if !is_yaml {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        for token in content.split_whitespace() {
+            let reference = token.trim_matches(|c| c == '"' || c == '\'');
+            for prefix in ["FerrLabs/FerrFlow@", "FerrFlow-Org/ferrflow@"] {
+                if let Some(version) = reference.strip_prefix(prefix) {
+                    return Check::ok("FerrFlow action", Some(format!("{prefix}{version}")));
+                }
+            }
+        }
+    }
+    Check::info(
+        "FerrFlow action",
+        Some("no FerrLabs/FerrFlow action reference found".into()),
+    )
+}
+
+fn online_check(forge: Option<ForgeKind>) -> Check {
+    match forge {
+        Some(ForgeKind::Github) => match github_rate_limit() {
+            Ok((remaining, limit)) => Check::ok(
+                "forge reachable",
+                Some(format!("GitHub API: {remaining}/{limit} calls remaining")),
+            ),
+            Err(err) => Check::warn(
+                "forge reachable",
+                Some(format!("GitHub API check failed: {err}")),
+            ),
+        },
+        Some(kind) => Check::info(
+            "forge reachable",
+            Some(format!(
+                "--online check not implemented for {}",
+                forge_label(kind)
+            )),
+        ),
+        None => Check::info("forge reachable", Some("no forge to reach".into())),
+    }
+}
+
+fn github_rate_limit() -> anyhow::Result<(u64, u64)> {
+    let token = std::env::var("FERRFLOW_TOKEN")
+        .ok()
+        .or_else(|| std::env::var("GITHUB_TOKEN").ok())
+        .filter(|t| !t.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("no token in env"))?;
+
+    let body: serde_json::Value = ureq::get("https://api.github.com/rate_limit")
+        .header("Authorization", &format!("Bearer {token}"))
+        .header("User-Agent", "ferrflow-doctor")
+        .header("Accept", "application/vnd.github+json")
+        .call()?
+        .body_mut()
+        .read_json()?;
+
+    let rate = &body["rate"];
+    let remaining = rate["remaining"].as_u64().unwrap_or(0);
+    let limit = rate["limit"].as_u64().unwrap_or(0);
+    Ok((remaining, limit))
+}
+
+fn token_env(forge: Option<ForgeKind>) -> (&'static str, bool) {
+    let is_set = |var: &str| std::env::var(var).is_ok_and(|v| !v.is_empty());
+    if is_set("FERRFLOW_TOKEN") {
+        return ("FERRFLOW_TOKEN", true);
+    }
+    match forge {
+        Some(ForgeKind::Gitlab) => ("GITLAB_TOKEN", is_set("GITLAB_TOKEN")),
+        _ => ("GITHUB_TOKEN", is_set("GITHUB_TOKEN")),
+    }
+}
+
+fn forge_label(kind: ForgeKind) -> &'static str {
+    match kind {
+        ForgeKind::Github => "GitHub",
+        ForgeKind::Gitlab => "GitLab",
+        ForgeKind::Gitea => "Gitea/Forgejo",
+        ForgeKind::Auto => "auto",
+    }
+}
+
+fn dirty_count(root: &Path) -> Option<usize> {
+    let output = Command::new("git")
+        .current_dir(root)
+        .args(["status", "--porcelain"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    Some(text.lines().filter(|l| !l.trim().is_empty()).count())
+}
+
+fn redact_url(url: &str) -> String {
+    for scheme in ["https://", "http://"] {
+        if let Some(rest) = url.strip_prefix(scheme)
+            && let Some((authority, path)) = rest.split_once('/')
+            && let Some((_userinfo, host)) = authority.rsplit_once('@')
+        {
+            return format!("{scheme}{host}/{path}");
+        }
+    }
+    url.to_string()
+}
+
+fn filename(path: &std::path::Path) -> String {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("(unknown)")
+        .to_string()
+}

--- a/src/doctor/checks.rs
+++ b/src/doctor/checks.rs
@@ -112,13 +112,13 @@ pub(super) fn config_section(
                 .map(|p| filename(p))
                 .collect::<Vec<_>>()
                 .join(", ");
-            let winner = filename(&discovered[0]);
-            checks.push(Check::warn(
+            checks.push(Check::error(
                 "config file",
                 Some(format!(
-                    "multiple found ({list}); '{winner}' takes precedence"
+                    "multiple config files found ({list}) — ambiguous; pass --config to choose one"
                 )),
             ));
+            return Section::new("Config", checks);
         }
     }
 

--- a/src/doctor/mod.rs
+++ b/src/doctor/mod.rs
@@ -1,0 +1,52 @@
+use anyhow::Result;
+use std::path::Path;
+
+use crate::config::Config;
+use crate::git::{get_repo_root, open_repo};
+
+mod checks;
+mod report;
+
+use report::Report;
+
+#[derive(Clone, Copy, clap::ValueEnum)]
+pub enum DoctorFormat {
+    Human,
+    Json,
+}
+
+pub fn run(config_path: Option<&Path>, format: DoctorFormat, online: bool) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let repo = open_repo(&cwd).ok();
+    let root = repo
+        .as_ref()
+        .and_then(|r| get_repo_root(r).ok())
+        .unwrap_or_else(|| cwd.clone());
+
+    let discovered = Config::discovered_config_paths(&root);
+    let (config, config_error) = match Config::load(&root, config_path) {
+        Ok(config) => (Some(config), None),
+        Err(err) => (None, Some(format!("{err:#}"))),
+    };
+
+    let report = Report::build(vec![
+        checks::repo_section(repo.as_ref(), config.as_ref(), &root),
+        checks::config_section(config.as_ref(), config_error.as_deref(), &discovered, &root),
+        checks::versioning_section(config.as_ref(), &root),
+        checks::forge_section(repo.as_ref(), config.as_ref(), online),
+        checks::ci_section(&root),
+    ]);
+
+    match format {
+        DoctorFormat::Json => println!("{}", report.to_json()?),
+        DoctorFormat::Human => report.print_human(),
+    }
+
+    if report.exit_code != 0 {
+        std::process::exit(report.exit_code);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/doctor/report.rs
+++ b/src/doctor/report.rs
@@ -1,0 +1,137 @@
+use anyhow::Result;
+use colored::Colorize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Status {
+    Ok,
+    Info,
+    Warn,
+    Error,
+}
+
+impl Status {
+    fn glyph(self) -> colored::ColoredString {
+        match self {
+            Status::Ok => "✓".green(),
+            Status::Info => "·".dimmed(),
+            Status::Warn => "⚠".yellow(),
+            Status::Error => "✗".red(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct Check {
+    pub name: String,
+    pub status: Status,
+    pub detail: Option<String>,
+}
+
+impl Check {
+    pub fn new(name: impl Into<String>, status: Status, detail: Option<String>) -> Self {
+        Self {
+            name: name.into(),
+            status,
+            detail,
+        }
+    }
+
+    pub fn ok(name: impl Into<String>, detail: Option<String>) -> Self {
+        Self::new(name, Status::Ok, detail)
+    }
+
+    pub fn info(name: impl Into<String>, detail: Option<String>) -> Self {
+        Self::new(name, Status::Info, detail)
+    }
+
+    pub fn warn(name: impl Into<String>, detail: Option<String>) -> Self {
+        Self::new(name, Status::Warn, detail)
+    }
+
+    pub fn error(name: impl Into<String>, detail: Option<String>) -> Self {
+        Self::new(name, Status::Error, detail)
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct Section {
+    pub title: String,
+    pub checks: Vec<Check>,
+}
+
+impl Section {
+    pub fn new(title: impl Into<String>, checks: Vec<Check>) -> Self {
+        Self {
+            title: title.into(),
+            checks,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct Report {
+    pub status: Status,
+    pub exit_code: i32,
+    pub sections: Vec<Section>,
+}
+
+impl Report {
+    pub fn build(sections: Vec<Section>) -> Self {
+        let mut errors = 0usize;
+        let mut warnings = 0usize;
+        for section in &sections {
+            for check in &section.checks {
+                match check.status {
+                    Status::Error => errors += 1,
+                    Status::Warn => warnings += 1,
+                    Status::Ok | Status::Info => {}
+                }
+            }
+        }
+        let (status, exit_code) = if errors > 0 {
+            (Status::Error, 2)
+        } else if warnings > 0 {
+            (Status::Warn, 1)
+        } else {
+            (Status::Ok, 0)
+        };
+        Self {
+            status,
+            exit_code,
+            sections,
+        }
+    }
+
+    pub fn to_json(&self) -> Result<String> {
+        Ok(serde_json::to_string_pretty(self)?)
+    }
+
+    pub fn print_human(&self) {
+        tracing::info!("");
+        tracing::info!("{}", "ferrflow doctor".bold());
+
+        for section in &self.sections {
+            tracing::info!("");
+            tracing::info!("{}", section.title.bold());
+            for check in &section.checks {
+                match &check.detail {
+                    Some(detail) => {
+                        tracing::info!("  {} {}: {}", check.status.glyph(), check.name, detail)
+                    }
+                    None => tracing::info!("  {} {}", check.status.glyph(), check.name),
+                }
+            }
+        }
+
+        tracing::info!("");
+        let summary = match self.status {
+            Status::Error => "problems found — see the errors above".red().bold(),
+            Status::Warn => "ready, with warnings".yellow().bold(),
+            Status::Ok | Status::Info => "all checks passed".green().bold(),
+        };
+        tracing::info!("  {summary}");
+        tracing::info!("");
+    }
+}

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -1,0 +1,160 @@
+use super::report::{Check, Report, Section, Status};
+
+#[test]
+fn exit_code_is_zero_when_all_green() {
+    let report = Report::build(vec![Section::new(
+        "Repo",
+        vec![Check::ok("git repository", None), Check::info("tags", None)],
+    )]);
+    assert_eq!(report.exit_code, 0);
+    assert_eq!(report.status, Status::Ok);
+}
+
+#[test]
+fn a_warning_sets_exit_code_one() {
+    let report = Report::build(vec![Section::new(
+        "Repo",
+        vec![Check::ok("a", None), Check::warn("b", Some("dirty".into()))],
+    )]);
+    assert_eq!(report.exit_code, 1);
+    assert_eq!(report.status, Status::Warn);
+}
+
+#[test]
+fn an_error_sets_exit_code_two_even_with_warnings() {
+    let report = Report::build(vec![Section::new(
+        "Repo",
+        vec![
+            Check::warn("a", None),
+            Check::error("b", Some("no repo".into())),
+        ],
+    )]);
+    assert_eq!(report.exit_code, 2);
+    assert_eq!(report.status, Status::Error);
+}
+
+#[test]
+fn json_shape_is_stable_for_fixtures() {
+    let report = Report::build(vec![Section::new(
+        "Repo",
+        vec![Check::ok("git repository", Some("HEAD at abc1234".into()))],
+    )]);
+    let json: serde_json::Value = serde_json::from_str(&report.to_json().unwrap()).unwrap();
+    assert_eq!(json["status"], "ok");
+    assert_eq!(json["exit_code"], 0);
+    assert_eq!(json["sections"][0]["title"], "Repo");
+    assert_eq!(json["sections"][0]["checks"][0]["name"], "git repository");
+    assert_eq!(json["sections"][0]["checks"][0]["status"], "ok");
+    assert_eq!(
+        json["sections"][0]["checks"][0]["detail"],
+        "HEAD at abc1234"
+    );
+}
+
+mod end_to_end {
+    use crate::config::Config;
+    use crate::doctor::checks;
+    use crate::doctor::report::Status;
+    use crate::git::{get_repo_root, open_repo};
+    use crate::test_utils::{commit_file, git, init_repo, with_cwd};
+    use std::path::Path;
+
+    fn write(dir: &Path, rel: &str, content: &str) {
+        let path = dir.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+
+    fn find<'a>(section: &'a super::Section, name: &str) -> &'a super::Check {
+        section
+            .checks
+            .iter()
+            .find(|c| c.name == name)
+            .unwrap_or_else(|| panic!("missing check '{name}'"))
+    }
+
+    #[test]
+    fn fresh_repo_without_commits_flags_the_missing_pieces() {
+        let (dir, _repo) = init_repo();
+        let root = dir.path();
+        with_cwd(root, || {
+            let repo = open_repo(root).ok();
+            let repo_ref = repo.as_ref();
+            let section = checks::repo_section(repo_ref, None, root);
+            // A freshly `git init`-ed repo has no commits yet.
+            assert_eq!(find(&section, "commit history").status, Status::Error);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn misconfigured_package_path_is_pinpointed() {
+        let (dir, repo) = init_repo();
+        let root = dir.path();
+        write(
+            root,
+            ".ferrflow",
+            r#"{"package":[{"name":"api","path":"packages/api","versionedFiles":[{"path":"packages/api/Cargo.toml","format":"toml"}]}]}"#,
+        );
+        commit_file(root, "seed.txt", "x", "chore: seed", 1_900_000_000);
+
+        let config = Config::load(&get_repo_root(&repo).unwrap(), None).ok();
+        let discovered = Config::discovered_config_paths(root);
+        let section = checks::config_section(config.as_ref(), None, &discovered, root);
+
+        // packages/api does not exist on disk — the report must point at it.
+        assert!(
+            section
+                .checks
+                .iter()
+                .any(|c| c.status == Status::Error && c.name.contains("packages/api")),
+            "expected an error naming the missing package path, got: {:?}",
+            section.checks
+        );
+    }
+
+    #[test]
+    fn ci_section_reports_the_pinned_ferrflow_action() {
+        let (dir, _repo) = init_repo();
+        let root = dir.path();
+        write(
+            root,
+            ".github/workflows/release.yml",
+            "jobs:\n  release:\n    steps:\n      - uses: FerrLabs/FerrFlow@v4\n",
+        );
+        let section = checks::ci_section(root);
+        let action = find(&section, "FerrFlow action");
+        assert_eq!(action.status, Status::Ok);
+        assert_eq!(action.detail.as_deref(), Some("FerrLabs/FerrFlow@v4"));
+    }
+
+    #[test]
+    fn clean_configured_repo_is_all_green() {
+        let (dir, repo) = init_repo();
+        let root = dir.path();
+        write(
+            root,
+            "Cargo.toml",
+            "[package]\nname = \"app\"\nversion = \"1.0.0\"\n",
+        );
+        write(
+            root,
+            ".ferrflow",
+            r#"{"package":[{"name":"app","path":".","versionedFiles":[{"path":"Cargo.toml","format":"toml"}]}]}"#,
+        );
+        commit_file(root, "seed.txt", "x", "chore: seed", 1_900_000_000);
+        git(root, &["tag", "v1.0.0"]);
+
+        let config = Config::load(&get_repo_root(&repo).unwrap(), None).ok();
+        let discovered = Config::discovered_config_paths(root);
+        let section = checks::config_section(config.as_ref(), None, &discovered, root);
+
+        assert!(
+            section.checks.iter().all(|c| c.status != Status::Error),
+            "a clean config should raise no errors: {:?}",
+            section.checks
+        );
+        assert_eq!(find(&section, "config parses").status, Status::Ok);
+    }
+}

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -115,6 +115,24 @@ mod end_to_end {
     }
 
     #[test]
+    fn multiple_config_files_are_flagged_as_ambiguous() {
+        let (dir, _repo) = init_repo();
+        let root = dir.path();
+        write(root, "ferrflow.json", r#"{"package":[]}"#);
+        write(root, "ferrflow.toml", "");
+
+        let discovered = Config::discovered_config_paths(root);
+        // Config::load errors on ambiguity, so doctor sees no parsed config.
+        let section = checks::config_section(None, None, &discovered, root);
+
+        let config_file = find(&section, "config file");
+        assert_eq!(config_file.status, Status::Error);
+        assert!(config_file.detail.as_deref().unwrap().contains("ambiguous"));
+        // No second, duplicate "config parses" error.
+        assert_eq!(section.checks.len(), 1);
+    }
+
+    #[test]
     fn ci_section_reports_the_pinned_ferrflow_action() {
         let (dir, _repo) = init_repo();
         let root = dir.path();

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod concurrency;
 mod config;
 mod conventional_commits;
 mod diff;
+mod doctor;
 mod error_code;
 mod error_report;
 mod forge;

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -76,24 +76,39 @@ pub fn run(
         }
     };
 
-    let mut entries = Vec::new();
-    entries.extend(check_duplicate_names(&config));
-    entries.extend(check_duplicate_paths(&config));
-    entries.extend(check_tag_templates(&config));
-    entries.extend(check_package_paths(&config, source.as_ref()));
-    entries.extend(check_versioned_files_exist(&config, source.as_ref()));
-    let (file_entries, versions) = check_versioned_files(&config, source.as_ref());
-    entries.extend(file_entries);
-    entries.extend(check_version_consistency(&versions));
-    entries.extend(check_changelog_paths(&config, source.as_ref()));
-    entries.extend(check_shared_paths(&config, source.as_ref()));
-    entries.extend(check_groups(&config, &versions));
-    entries.extend(check_suggestions(&config));
+    let entries = collect_entries(&config, source.as_ref());
 
     let mut result = ValidationResult::from_entries(entries);
     result.config_file = Some(config_filename);
     result.package_count = config.packages.len();
     output_result(&result, json)
+}
+
+fn collect_entries(
+    config: &crate::config::Config,
+    source: &dyn FileSource,
+) -> Vec<ValidationEntry> {
+    let mut entries = Vec::new();
+    entries.extend(check_duplicate_names(config));
+    entries.extend(check_duplicate_paths(config));
+    entries.extend(check_tag_templates(config));
+    entries.extend(check_package_paths(config, source));
+    entries.extend(check_versioned_files_exist(config, source));
+    let (file_entries, versions) = check_versioned_files(config, source);
+    entries.extend(file_entries);
+    entries.extend(check_version_consistency(&versions));
+    entries.extend(check_changelog_paths(config, source));
+    entries.extend(check_shared_paths(config, source));
+    entries.extend(check_groups(config, &versions));
+    entries.extend(check_suggestions(config));
+    entries
+}
+
+pub fn local_entries(config: &crate::config::Config, root: &Path) -> Vec<ValidationEntry> {
+    let source = LocalSource {
+        root: root.to_path_buf(),
+    };
+    collect_entries(config, &source)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #363.

New `ferrflow doctor` — a read-only diagnostic that answers "is my setup sane?" without making the user grep `--verbose` logs. Modelled on `brew doctor` / `kubectl cluster-info`.

## What it checks

Grouped into five sections, each check green / yellow / red:

- **Repo** — is it a git repo, is there commit history, is the working tree clean (warn if dirty), is the remote configured (URL redacted of any userinfo), are there local tags.
- **Config** — which config file wins (warns on multiple), does it parse (parse errors are surfaced verbatim so the file/line is pinpointed), and the full `ferrflow validate` check suite (package paths, versioned files, `dependsOn`/group integrity, …) mapped into the report. This reuses validate's checks rather than duplicating them.
- **Versioning** — declared/auto strategy + each package's on-disk version. (Kept deliberately quiet: the tag-walk that computes next-version lives in `status`/`check`, and its orphaned-tag warnings would drown out the report — a one-liner points there instead.)
- **Forge** — detected forge (from remote URL or `workspace.forge`), whether an auth token is present in the env (name only, never the value), and an optional `--online` probe that hits the GitHub rate-limit API and reports remaining calls.
- **CI** — presence of `.github/workflows` / `.gitlab-ci.yml` / `.forgejo/workflows`, and whether any workflow pins the `FerrLabs/FerrFlow` action (with the version).

## Output & exit codes

- `--format human` (default) — sectioned report using the same ✓ / ⚠ / ✗ glyphs as `ferrflow validate`.
- `--format json` — stable shape (`{status, exit_code, sections:[{title, checks:[{name, status, detail}]}]}`) for CI assertions.
- Exit `0` all green, `1` any warning, `2` any error.

It degrades gracefully: not-a-repo, missing config, or a parse error each produce a report rather than a crash, so a fresh repo run explains exactly what's missing to start a release.

## Tests

- Report severity → exit-code / worst-status mapping; JSON shape.
- End-to-end on scratch repos: fresh `git init` (no commits) flags the missing history; a bad `package.path` is pinpointed with an error naming the path; a clean configured repo is all-green; the CI scan extracts a pinned `FerrLabs/FerrFlow@v4`.
- Verified manually against this repo and a fresh repo (human + JSON, exit 0/2).

`--online` for non-GitHub forges and orphaned-tag detection are deferred (the latter needs the same noisy tag walk); noted for a follow-up. Docs (CLI reference) + changelog land in their own repos.