### PR TITLE
feat(cli): add schema subcommand to print the bundled JSON schema

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -174,6 +174,15 @@ pub enum Commands {
         #[arg(long)]
         online: bool,
     },
+    /// Print the bundled JSON schema for the ferrflow config file
+    Schema {
+        /// Pretty-print the schema instead of compact single-line JSON
+        #[arg(long)]
+        pretty: bool,
+        /// Write to a file instead of stdout
+        #[arg(long, value_name = "FILE")]
+        output: Option<PathBuf>,
+    },
 }
 
 #[derive(Clone, Copy, clap::ValueEnum)]
@@ -218,6 +227,7 @@ impl Commands {
             Commands::SyncManifest => "sync-manifest",
             Commands::Migrate { .. } => "migrate",
             Commands::Doctor { .. } => "doctor",
+            Commands::Schema { .. } => "schema",
         }
     }
 }
@@ -310,6 +320,7 @@ impl Cli {
             Commands::Doctor { format, online } => {
                 crate::doctor::run(self.config.as_deref(), format, online)
             }
+            Commands::Schema { pretty, output } => crate::schema::run(pretty, output.as_deref()),
         }
     }
 }
@@ -334,6 +345,26 @@ mod tests {
 
     fn parse(args: &[&str]) -> Cli {
         Cli::try_parse_from(args).unwrap()
+    }
+
+    #[test]
+    fn parse_schema() {
+        let cli = parse(&["ferrflow", "schema"]);
+        assert!(matches!(
+            cli.command,
+            Commands::Schema {
+                pretty: false,
+                output: None
+            }
+        ));
+        let cli = parse(&["ferrflow", "schema", "--pretty", "--output", "s.json"]);
+        assert!(matches!(
+            cli.command,
+            Commands::Schema {
+                pretty: true,
+                output: Some(_)
+            }
+        ));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod prerelease;
 mod publish;
 mod publishers;
 mod query;
+mod schema;
 mod status;
 mod timing;
 mod validate;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,0 +1,62 @@
+use anyhow::{Context, Result};
+use std::path::Path;
+
+pub const BUNDLED_SCHEMA: &str = include_str!("../schema/ferrflow.json");
+
+fn render(pretty: bool) -> Result<String> {
+    let value: serde_json::Value = serde_json::from_str(BUNDLED_SCHEMA)
+        .context("the bundled JSON schema is not valid JSON — the build artefact is corrupt")?;
+    Ok(if pretty {
+        serde_json::to_string_pretty(&value)?
+    } else {
+        serde_json::to_string(&value)?
+    })
+}
+
+pub fn run(pretty: bool, output: Option<&Path>) -> Result<()> {
+    let rendered = render(pretty)?;
+    match output {
+        Some(path) => {
+            std::fs::write(path, format!("{rendered}\n"))
+                .with_context(|| format!("failed to write schema to {}", path.display()))?;
+            tracing::info!("Wrote JSON schema to {}", path.display());
+        }
+        None => println!("{rendered}"),
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bundled_schema_is_valid_json() {
+        let value: serde_json::Value =
+            serde_json::from_str(BUNDLED_SCHEMA).expect("bundled schema must parse");
+        assert_eq!(value["$id"], "https://ferrflow.com/schema/ferrflow.json");
+        assert!(value["properties"]["workspace"].is_object());
+        assert!(value["properties"]["package"].is_object());
+    }
+
+    #[test]
+    fn bundled_schema_matches_the_checked_in_file() {
+        let on_disk =
+            std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/schema/ferrflow.json"))
+                .expect("schema/ferrflow.json must exist");
+        assert_eq!(
+            BUNDLED_SCHEMA, on_disk,
+            "the embedded schema drifted from schema/ferrflow.json — rebuild the binary"
+        );
+    }
+
+    #[test]
+    fn compact_is_single_line_and_pretty_is_multiline() {
+        let compact = render(false).unwrap();
+        let pretty = render(true).unwrap();
+        assert!(serde_json::from_str::<serde_json::Value>(&compact).is_ok());
+        assert!(serde_json::from_str::<serde_json::Value>(&pretty).is_ok());
+        assert!(!compact.contains('\n'), "compact output must be one line");
+        assert!(pretty.contains('\n'), "pretty output must be formatted");
+    }
+}


### PR DESCRIPTION
Closes #365.

`ferrflow schema` prints the config JSON schema that's now bundled into the binary via `include_str!("../schema/ferrflow.json")`. This makes the schema usable offline and in pre-commit hooks that can't reach `ferrflow.com/schema/ferrflow.json`.

```bash
ferrflow schema                       # compact JSON to stdout
ferrflow schema --pretty              # formatted
ferrflow schema --pretty --output ferrflow.schema.json
```

- Default output is compact single-line JSON; `--pretty` formats it (2-space).
- `--output <FILE>` writes to a file instead of stdout.
- The command parses the bundled schema first, so a corrupt build artefact exits non-zero (the acceptance's sanity check).
- Offline: it never touches the network — a user with no internet can `ferrflow schema > schema.json` and point VS Code / Zed at that local path, and CI can validate `.ferrflow.json` without a network call.

## The byte-for-byte guarantee

Because the schema is `include_str!`'d straight from `schema/ferrflow.json`, the embedded copy is the source file by construction. A unit test (`bundled_schema_matches_the_checked_in_file`) re-reads the file and asserts equality, so a wrong include path or a stale artefact fails the build — the CI gate the issue asks for.

## Tests

- Bundled schema is valid JSON with the expected `$id` and top-level `workspace` / `package` properties.
- Embedded schema equals `schema/ferrflow.json` byte-for-byte.
- Compact output is single-line, `--pretty` is multi-line, both valid JSON.
- CLI parse test for `schema` / `--pretty` / `--output`.
- Verified end-to-end (stdout compact + pretty, `--output` file, semantic equality with the source).

## Out of scope (noted for follow-up)

The issue also floats wiring the bundled schema into `init` / `doctor`'s config validation, and publishing versioned schema URLs (`ferrflow-v5.json`). The first would pull in a JSON-Schema validator dependency — `doctor` and `validate` already check config by parsing it with FerrFlow's own (stronger) parser, so that's redundant; the second is a site/publish concern, not the CLI. Both are left as separate follow-ups. Docs (CLI reference) + changelog land in their own repos.