### PR TITLE
perf(git): write a commit-graph on cold runs of large repos

### DIFF
--- a/src/git/commit_graph.rs
+++ b/src/git/commit_graph.rs
@@ -1,0 +1,99 @@
+use std::path::Path;
+
+use super::repo::Repository;
+use super::shell::run_git;
+
+const MIN_COMMITS: usize = 1000;
+
+/// Best-effort: write a commit-graph when the repo has none and its history is
+/// large enough to pay for it. gix reads `.git/objects/info/commit-graph` on
+/// every revwalk (`use_commit_graph(true)`), but never writes one — so a fresh
+/// CI clone (a pack with no graph) never benefits. Writing it once makes later
+/// runs' tag scans and commit walks materially faster (#690).
+///
+/// Never fails the command. Callers must skip this on read-only `--dry-run`
+/// paths — it shells out to `git commit-graph write`, which touches `.git`.
+pub fn write_commit_graph_if_absent(repo: &Repository) {
+    maybe_write(repo, MIN_COMMITS);
+}
+
+fn maybe_write(repo: &Repository, min_commits: usize) {
+    let Some(workdir) = repo.workdir() else {
+        return;
+    };
+    if commit_graph_present(repo) {
+        return;
+    }
+    if reachable_commit_count(workdir).is_none_or(|count| count <= min_commits) {
+        return;
+    }
+    if run_git(workdir, &["commit-graph", "write", "--reachable"]).is_ok() {
+        tracing::debug!("wrote commit-graph for faster future revision walks");
+    }
+}
+
+fn commit_graph_present(repo: &Repository) -> bool {
+    let info = repo.git_dir().join("objects").join("info");
+    info.join("commit-graph").is_file()
+        || info
+            .join("commit-graphs")
+            .join("commit-graph-chain")
+            .is_file()
+}
+
+fn reachable_commit_count(workdir: &Path) -> Option<usize> {
+    run_git(workdir, &["rev-list", "--count", "HEAD"])
+        .ok()?
+        .trim()
+        .parse()
+        .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{commit_file, init_repo};
+
+    #[test]
+    fn counts_reachable_history() {
+        let (dir, _repo) = init_repo();
+        for i in 0..3 {
+            commit_file(
+                dir.path(),
+                &format!("f{i}.txt"),
+                "x",
+                "chore: c",
+                1_900_000_000 + i,
+            );
+        }
+        assert_eq!(reachable_commit_count(dir.path()), Some(3));
+    }
+
+    #[test]
+    fn detects_and_writes_the_graph() {
+        let (dir, repo) = init_repo();
+        commit_file(dir.path(), "a.txt", "x", "chore: a", 1_900_000_000);
+
+        assert!(!commit_graph_present(&repo), "a fresh repo has no graph");
+
+        // min_commits = 0 forces the write path on this tiny fixture.
+        maybe_write(&repo, 0);
+        assert!(
+            commit_graph_present(&repo),
+            "the graph should exist after a write"
+        );
+    }
+
+    #[test]
+    fn skips_small_histories() {
+        let (dir, repo) = init_repo();
+        commit_file(dir.path(), "a.txt", "x", "chore: a", 1_900_000_000);
+
+        // The default 1000-commit gate blocks this 1-commit repo.
+        maybe_write(&repo, MIN_COMMITS);
+        assert!(
+            !commit_graph_present(&repo),
+            "a tiny history must not trigger a write"
+        );
+    }
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod commit_graph;
 mod commit_walk;
 mod commits;
 mod diff;
@@ -13,6 +14,7 @@ mod validate;
 pub use validate::ensure_safe_refname_fragment;
 
 pub use auth::get_remote_url;
+pub use commit_graph::write_commit_graph_if_absent;
 pub use commit_walk::CommitWalkCache;
 #[allow(unused_imports)]
 pub use commits::{

--- a/src/monorepo/check.rs
+++ b/src/monorepo/check.rs
@@ -49,6 +49,10 @@ pub fn check(
         &root, &config, true, verbose, json, false, false, None, channel, false, false, timing,
     )?;
 
+    // On a cache miss we just walked the whole history; leave a commit-graph
+    // behind so the next `check` (pre-commit hook, local retry) is faster (#690).
+    crate::git::write_commit_graph_if_absent(&repo);
+
     if let (Some(key), Some(out)) = (&cache_key, &out) {
         cache::write(
             &cache_dir,

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -122,6 +122,10 @@ pub(super) fn run_release_logic(
         {
             tracing::warn!("Warning: could not fetch remote tags: {e}");
         }
+        // A real release walks tags + commits repeatedly; on a fresh clone
+        // with no commit-graph, write one so those walks use it (#690).
+        // Guarded by `!dry_run` so dry-run stays read-only.
+        crate::git::write_commit_graph_if_absent(&repo);
     }
 
     let current_branch = crate::git::resolve_current_branch(&repo, &config.workspace.branch);


### PR DESCRIPTION
Closes #690.

gix reads `.git/objects/info/commit-graph` on every revwalk (`use_commit_graph(true)` across `tags.rs` / `commits.rs` / `commit_walk.rs`) but never writes one. A fresh clone — every CI checkout — has a pack but no graph, so the optimization sits idle exactly where FerrFlow runs. On `mono-large` (200 pkg × 10k commits, packed) the graph cuts a `check` from ~106 ms to ~74 ms; writing it costs ~90 ms, so it breaks even from the third run and pays off for repeat users (local dev, pre-commit hooks, warm-runner retries).

## Change

New best-effort helper `git::write_commit_graph_if_absent`:

- skips if a graph is already present (`objects/info/commit-graph` or a `commit-graphs/…-chain`),
- skips histories ≤ 1000 commits (below the break-even — the write walks the whole graph),
- otherwise shells `git commit-graph write --reachable` (gix can't write graphs), ignoring any failure so it never fails the command.

Wired at the two points the walk-heavy work happens:

- **`check`** — after a cold run (cache miss), so a pre-commit hook or local retry is faster. Skipped on a cache hit (no walk happened).
- **`release`** — inside the existing `if !dry_run` block after `fetch_tags`, so `release --dry-run` stays fully read-only.

The "graph absent" guard makes this a one-time cost: the first cold run writes it, every later run sees it present and skips.

## Tests

- Unit: counts reachable history, detects a written graph, and the 1000-commit gate blocks tiny repos (the write path is exercised with a lowered threshold on a small fixture).
- Verified end-to-end on a 1101-commit repo: `ferrflow check` writes `.git/objects/info/commit-graph`; `ferrflow release --dry-run` leaves it absent.

Low priority per the issue — a ~30% shave on walk-heavy paths for repeat users, not a headline. No config or flag surface, so no docs change; a short changelog entry lands separately.