### PR TITLE
feat(forge): add Bitbucket Cloud support

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -257,6 +257,16 @@ The Gitea API returned an error while listing releases to find a draft.
 
 Could not clear the draft flag on a Gitea release via the API.
 
+## Bitbucket API Errors (E3300--E3399)
+
+Covers Bitbucket Cloud. Bitbucket has no "release" object, so a release maps to the annotated tag FerrFlow already pushed; these errors only concern the optional forge-side lookup, never the tag itself.
+
+### E3301: Failed to resolve Bitbucket tag
+
+FerrFlow looked the release tag up via the Bitbucket Cloud API (`GET /2.0/repositories/{workspace}/{repo}/refs/tags/{tag}`) to return its web URL, and the request failed. The tag was still pushed, so this is reported as a warning, not a release failure.
+
+**Fix**: Check that `BITBUCKET_TOKEN` (or `FERRFLOW_TOKEN`) is set with repository read access. Bitbucket Server / Data Center is not yet supported and skips this lookup entirely.
+
 ## Version File Errors (E4000--E4799)
 
 ### TOML (E4101--E4105)

--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -112,11 +112,13 @@
         },
         "forge": {
           "type": "string",
-          "description": "Git forge type. 'auto' detects from the remote URL. Use 'github' or 'gitlab' to override (useful for self-hosted instances with custom domains).",
+          "description": "Git forge type. 'auto' detects from the remote URL. Set 'github', 'gitlab', 'gitea', or 'bitbucket' to override (useful for self-hosted instances with custom domains).",
           "enum": [
             "auto",
             "github",
-            "gitlab"
+            "gitlab",
+            "gitea",
+            "bitbucket"
           ],
           "default": "auto"
         },

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -11,6 +11,8 @@ pub enum ForgeKind {
     Gitlab,
     #[serde(alias = "Gitea", alias = "forgejo", alias = "Forgejo")]
     Gitea,
+    #[serde(alias = "Bitbucket")]
+    Bitbucket,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]

--- a/src/doctor/checks.rs
+++ b/src/doctor/checks.rs
@@ -243,7 +243,9 @@ pub(super) fn forge_section(
     } else {
         checks.push(Check::warn(
             "auth token",
-            Some("no token in env (FERRFLOW_TOKEN / GITHUB_TOKEN / GITLAB_TOKEN) — API pushes and releases will fail".into()),
+            Some(format!(
+                "no token in env ({var} or FERRFLOW_TOKEN) — API pushes and releases will fail"
+            )),
         ));
     }
 
@@ -363,6 +365,8 @@ fn token_env(forge: Option<ForgeKind>) -> (&'static str, bool) {
     }
     match forge {
         Some(ForgeKind::Gitlab) => ("GITLAB_TOKEN", is_set("GITLAB_TOKEN")),
+        Some(ForgeKind::Gitea) => ("GITEA_TOKEN", is_set("GITEA_TOKEN")),
+        Some(ForgeKind::Bitbucket) => ("BITBUCKET_TOKEN", is_set("BITBUCKET_TOKEN")),
         _ => ("GITHUB_TOKEN", is_set("GITHUB_TOKEN")),
     }
 }
@@ -372,6 +376,7 @@ fn forge_label(kind: ForgeKind) -> &'static str {
         ForgeKind::Github => "GitHub",
         ForgeKind::Gitlab => "GitLab",
         ForgeKind::Gitea => "Gitea/Forgejo",
+        ForgeKind::Bitbucket => "Bitbucket",
         ForgeKind::Auto => "auto",
     }
 }

--- a/src/error_code.rs
+++ b/src/error_code.rs
@@ -153,6 +153,9 @@ pub const GITEA_LIST_RELEASES: ErrorCode = ErrorCode(3202);
 pub const GITEA_PUBLISH_RELEASE: ErrorCode = ErrorCode(3203);
 
 #[allow(dead_code)]
+pub const BITBUCKET_CREATE_RELEASE: ErrorCode = ErrorCode(3301);
+
+#[allow(dead_code)]
 pub const TOML_READ: ErrorCode = ErrorCode(4101);
 #[allow(dead_code)]
 pub const TOML_PARSE: ErrorCode = ErrorCode(4102);

--- a/src/forge/bitbucket.rs
+++ b/src/forge/bitbucket.rs
@@ -1,0 +1,181 @@
+use anyhow::{Context, Result, bail};
+
+use super::{Forge, MergeRequestResult, ReleaseResult};
+use crate::error_code::{self, ErrorCodeExt};
+
+const PR_UNSUPPORTED: &str = "Pull-request mode is not yet supported on Bitbucket. FerrFlow creates the release tag; \
+     PR-based release flow is tracked in FerrLabs/FerrFlow#656.";
+
+pub struct BitbucketForge {
+    pub token: String,
+    pub slug: String,
+    pub api_base: String,
+    pub is_cloud: bool,
+    pub agent: ureq::Agent,
+}
+
+impl Forge for BitbucketForge {
+    fn create_release(
+        &self,
+        tag: &str,
+        _body: &str,
+        _prerelease: bool,
+        _draft: bool,
+        _target_commitish: Option<&str>,
+    ) -> Result<ReleaseResult> {
+        // Bitbucket has no "release" object — the annotated tag FerrFlow
+        // already pushed *is* the release. On Cloud we look the tag up to
+        // return its canonical web URL; Server / Data Center is out of scope
+        // for now (#656), so the tag stands on its own with no forge URL.
+        if !self.is_cloud {
+            return Ok(ReleaseResult::default());
+        }
+
+        let url = format!(
+            "{}/repositories/{}/refs/tags/{tag}",
+            self.api_base, self.slug
+        );
+        let response: serde_json::Value = self
+            .agent
+            .get(&url)
+            .header("Authorization", &format!("Bearer {}", self.token))
+            .header("User-Agent", "ferrflow")
+            .call()
+            .with_context(|| format!("Failed to resolve Bitbucket tag {tag}"))
+            .error_code(error_code::BITBUCKET_CREATE_RELEASE)?
+            .body_mut()
+            .read_json()
+            .unwrap_or(serde_json::Value::Null);
+
+        Ok(ReleaseResult {
+            id: None,
+            url: tag_html_url(&response),
+        })
+    }
+
+    fn find_draft_release(&self, _tag: &str) -> Result<Option<u64>> {
+        // Bitbucket has no draft releases.
+        Ok(None)
+    }
+
+    fn publish_release(&self, _release_id: u64) -> Result<()> {
+        // Nothing to publish — there are no draft releases on Bitbucket.
+        Ok(())
+    }
+
+    fn create_merge_request(
+        &self,
+        _head: &str,
+        _base: &str,
+        _title: &str,
+        _body: &str,
+    ) -> Result<MergeRequestResult> {
+        bail!("{PR_UNSUPPORTED}")
+    }
+
+    fn enable_auto_merge(&self, _mr: &MergeRequestResult) -> Result<()> {
+        bail!("Auto-merge is not yet supported on Bitbucket (PR mode). See FerrLabs/FerrFlow#656.")
+    }
+
+    fn mr_noun(&self) -> &'static str {
+        "PR"
+    }
+
+    fn release_noun(&self) -> &'static str {
+        "Bitbucket tag"
+    }
+
+    fn find_comment(&self, _pr_id: u64, _marker: &str) -> Result<Option<u64>> {
+        bail!("{PR_UNSUPPORTED}")
+    }
+
+    fn create_comment(&self, _pr_id: u64, _body: &str) -> Result<()> {
+        bail!("{PR_UNSUPPORTED}")
+    }
+
+    fn update_comment(&self, _pr_id: u64, _comment_id: u64, _body: &str) -> Result<()> {
+        bail!("{PR_UNSUPPORTED}")
+    }
+}
+
+fn tag_html_url(response: &serde_json::Value) -> Option<String> {
+    response["links"]["html"]["href"]
+        .as_str()
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_forge(is_cloud: bool) -> BitbucketForge {
+        BitbucketForge {
+            token: "test-token".to_string(),
+            slug: "workspace/repo".to_string(),
+            api_base: if is_cloud {
+                "https://api.bitbucket.org/2.0".to_string()
+            } else {
+                "https://bitbucket.example.com/rest/api/1.0".to_string()
+            },
+            is_cloud,
+            agent: ureq::Agent::new_with_defaults(),
+        }
+    }
+
+    #[test]
+    fn release_noun_is_bitbucket_tag() {
+        assert_eq!(make_forge(true).release_noun(), "Bitbucket tag");
+    }
+
+    #[test]
+    fn extracts_the_canonical_tag_url_from_the_api_shape() {
+        let response = serde_json::json!({
+            "name": "v1.0.0",
+            "type": "tag",
+            "links": {
+                "html": { "href": "https://bitbucket.org/workspace/repo/commits/tag/v1.0.0" },
+                "self": { "href": "https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/tags/v1.0.0" }
+            }
+        });
+        assert_eq!(
+            tag_html_url(&response).as_deref(),
+            Some("https://bitbucket.org/workspace/repo/commits/tag/v1.0.0")
+        );
+        assert_eq!(tag_html_url(&serde_json::Value::Null), None);
+    }
+
+    #[test]
+    fn server_release_is_tag_only_without_a_network_call() {
+        // is_cloud == false short-circuits before any HTTP, so this must not
+        // hang or panic and must report no forge URL.
+        let result = make_forge(false)
+            .create_release("v1.0.0", "notes", false, false, None)
+            .unwrap();
+        assert_eq!(result.id, None);
+        assert_eq!(result.url, None);
+    }
+
+    #[test]
+    fn drafts_are_a_noop() {
+        let forge = make_forge(true);
+        assert_eq!(forge.find_draft_release("v1.0.0").unwrap(), None);
+        assert!(forge.publish_release(1).is_ok());
+    }
+
+    #[test]
+    fn pr_mode_and_comments_are_not_supported() {
+        let forge = make_forge(true);
+        assert!(forge.create_merge_request("h", "b", "t", "body").is_err());
+        assert!(
+            forge
+                .enable_auto_merge(&MergeRequestResult {
+                    id: 1,
+                    auto_merge_key: String::new(),
+                })
+                .is_err()
+        );
+        assert!(forge.find_comment(1, "marker").is_err());
+        assert!(forge.create_comment(1, "body").is_err());
+        assert!(forge.update_comment(1, 2, "body").is_err());
+    }
+}

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -1,3 +1,4 @@
+pub mod bitbucket;
 pub mod gitea;
 pub mod github;
 pub mod gitlab;
@@ -68,6 +69,8 @@ pub fn detect_forge_from_url(url: &str) -> Option<ForgeKind> {
         Some(ForgeKind::Gitlab)
     } else if url.contains("codeberg.org") || url.contains("gitea.io") {
         Some(ForgeKind::Gitea)
+    } else if url.contains("bitbucket.org") {
+        Some(ForgeKind::Bitbucket)
     } else {
         None
     }
@@ -143,7 +146,7 @@ pub fn web_base_url(remote_url: &str) -> Option<String> {
     let host = extract_host(remote_url)?;
     let slug = extract_repo_slug(remote_url)?;
     match kind {
-        ForgeKind::Github | ForgeKind::Gitlab | ForgeKind::Gitea => {
+        ForgeKind::Github | ForgeKind::Gitlab | ForgeKind::Gitea | ForgeKind::Bitbucket => {
             Some(format!("https://{host}/{slug}"))
         }
         ForgeKind::Auto => None,
@@ -167,6 +170,9 @@ pub fn resolve_token(kind: ForgeKind) -> Option<String> {
                     .ok()
                     .filter(|t| !t.is_empty())
             }),
+        ForgeKind::Bitbucket => std::env::var("BITBUCKET_TOKEN")
+            .ok()
+            .filter(|t| !t.is_empty()),
         ForgeKind::Auto => None,
     }
 }
@@ -208,6 +214,25 @@ pub fn build_forge(kind: ForgeKind, token: String, slug: String, host: String) -
                 token,
                 slug,
                 api_base,
+                agent,
+            })
+        }
+        ForgeKind::Bitbucket => {
+            // Cloud speaks REST 2.0 under api.bitbucket.org; Server / Data
+            // Center uses a different base (`/rest/api/1.0`) and is out of
+            // scope for now (#656) — build it so the tag still lands, but
+            // only Cloud gets a forge-side release URL.
+            let is_cloud = host == "bitbucket.org";
+            let api_base = if is_cloud {
+                "https://api.bitbucket.org/2.0".to_string()
+            } else {
+                format!("https://{host}/rest/api/1.0")
+            };
+            Box::new(bitbucket::BitbucketForge {
+                token,
+                slug,
+                api_base,
+                is_cloud,
                 agent,
             })
         }
@@ -285,9 +310,39 @@ mod tests {
     #[test]
     fn detect_unknown_host() {
         assert_eq!(
-            detect_forge_from_url("https://bitbucket.org/owner/repo.git"),
+            detect_forge_from_url("https://git.example.com/owner/repo.git"),
             None
         );
+    }
+
+    #[test]
+    fn detect_bitbucket_cloud() {
+        assert_eq!(
+            detect_forge_from_url("https://bitbucket.org/workspace/repo.git"),
+            Some(ForgeKind::Bitbucket)
+        );
+        assert_eq!(
+            detect_forge_from_url("git@bitbucket.org:workspace/repo.git"),
+            Some(ForgeKind::Bitbucket)
+        );
+        assert_eq!(
+            web_base_url("https://bitbucket.org/workspace/repo.git").as_deref(),
+            Some("https://bitbucket.org/workspace/repo")
+        );
+    }
+
+    #[test]
+    fn resolve_token_bitbucket_from_bitbucket_token() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe {
+            std::env::remove_var("FERRFLOW_TOKEN");
+            std::env::set_var("BITBUCKET_TOKEN", "bb-tok");
+        }
+        let result = resolve_token(ForgeKind::Bitbucket);
+        unsafe {
+            std::env::remove_var("BITBUCKET_TOKEN");
+        }
+        assert_eq!(result, Some("bb-tok".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
Closes #656. Split out from #499 (Gitea/Forgejo/Codeberg).

Bitbucket users fell through `detect_forge_from_url` and got no automatic release step. This adds a `Bitbucket` forge, mirroring the `gitea.rs` shape.

## What it does

- **Detection**: `bitbucket.org` (HTTPS + SSH) → `ForgeKind::Bitbucket`; explicit `forge = "bitbucket"` for overrides. Token from `BITBUCKET_TOKEN` (or `FERRFLOW_TOKEN`).
- **Release = tag**: Bitbucket Cloud has no "release" object, so a release maps to the annotated tag FerrFlow already pushed. `create_release` looks the tag up via the Cloud REST 2.0 API (`GET /2.0/repositories/{workspace}/{repo}/refs/tags/{tag}`) and returns its canonical `links.html.href` as the release URL. The lookup is best-effort — a failure is a warning (`E3301`), never a release failure, since the tag is already there.
- **No drafts**: `find_draft_release` → `None`, `publish_release` → no-op (Bitbucket has neither).
- **PR mode + preview comments**: stubbed with a clear "not yet supported on Bitbucket, tracked in #656" error, matching how Gitea landed (release-first, PR-mode later).
- **Bitbucket Server / Data Center**: out of scope (#656). It's built (so the tag still lands) but skips the Cloud-only tag lookup, so there's no wrong-shaped API call against a Server base.

## Also

- Error code **`E3301`** (`E33xx` range, per the issue) + `docs/errors.md` section.
- Schema: added `bitbucket` **and** `gitea` to the `workspace.forge` enum — `gitea` had been missing since #499, so a valid `forge: "gitea"` was being flagged by editors. Updated the field description too.
- `doctor` now labels Bitbucket and reports the forge-correct token env var (`BITBUCKET_TOKEN` / `GITEA_TOKEN`), not always `GITHUB_TOKEN`.

## Tests

- Detection (`bitbucket.org` HTTPS/SSH, `web_base_url`), token resolution from `BITBUCKET_TOKEN`, canonical-URL extraction from the API shape, Server short-circuits with no network call, drafts are no-ops, and PR/comment methods all error. 924 total, clippy clean, wasm builds.
- Verified end-to-end: `ferrflow doctor` on a `bitbucket.org` remote reports `forge: Bitbucket`; `forge: "bitbucket"` config parses.

## Out of scope (per #656)

PR-mode auto-merge parity, preview comments (needs Bitbucket PR detection in `detect_pr_number`), and Server/Data Center. Docs (config reference EN/FR) + changelog land in their own repos; the served schema auto-resyncs via FerrLabs/FerrFlow-Cloud#703.