### PR TITLE
feat(hooks): pass rich release context to shell and JS/TS hooks

### DIFF
--- a/src/config/loader_js.rs
+++ b/src/config/loader_js.rs
@@ -37,7 +37,7 @@ pub(crate) fn path_to_file_url(path: &Path) -> Result<String> {
 const LOADER_SCRIPT: &str = r#"
 function reifyHooks(hooks, fileUrl, runtime, hookPath) {
   if (!hooks || typeof hooks !== 'object') return hooks;
-  const ctx = `{ package: process.env.FERRFLOW_PACKAGE, oldVersion: process.env.FERRFLOW_OLD_VERSION, newVersion: process.env.FERRFLOW_NEW_VERSION, bumpType: process.env.FERRFLOW_BUMP_TYPE, tag: process.env.FERRFLOW_TAG, dryRun: process.env.FERRFLOW_DRY_RUN === 'true', packagePath: process.env.FERRFLOW_PACKAGE_PATH, channel: process.env.FERRFLOW_CHANNEL || null, isPrerelease: process.env.FERRFLOW_IS_PRERELEASE === 'true' }`;
+  const ctx = `{ package: process.env.FERRFLOW_PACKAGE, oldVersion: process.env.FERRFLOW_OLD_VERSION, newVersion: process.env.FERRFLOW_NEW_VERSION, bumpType: process.env.FERRFLOW_BUMP_TYPE, tag: process.env.FERRFLOW_TAG, dryRun: process.env.FERRFLOW_DRY_RUN === 'true', packagePath: process.env.FERRFLOW_PACKAGE_PATH, channel: process.env.FERRFLOW_CHANNEL || null, isPrerelease: process.env.FERRFLOW_IS_PRERELEASE === 'true', monorepo: process.env.FERRFLOW_MONOREPO === 'true', changelog: process.env.FERRFLOW_CHANGELOG || '', commits: JSON.parse(process.env.FERRFLOW_COMMITS_JSON || '[]'), bumpedFiles: JSON.parse(process.env.FERRFLOW_BUMPED_FILES_JSON || '[]') }`;
   const result = {};
   for (const [key, value] of Object.entries(hooks)) {
     if (typeof value === 'function') {

--- a/src/hooks/context.rs
+++ b/src/hooks/context.rs
@@ -1,5 +1,37 @@
 use std::path::Path;
 
+use serde::Serialize;
+
+#[derive(Clone, Serialize)]
+pub struct HookCommit {
+    pub hash: String,
+    pub message: String,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub commit_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+    pub breaking: bool,
+}
+
+impl HookCommit {
+    pub fn from_commit(hash: &str, message: &str) -> Self {
+        let header = crate::conventional_commits::parse_header(message);
+        HookCommit {
+            hash: hash.to_string(),
+            message: crate::conventional_commits::parse_subject(message).to_string(),
+            commit_type: header.as_ref().map(|h| h.commit_type.to_string()),
+            scope: header.as_ref().and_then(|h| h.scope.map(str::to_string)),
+            breaking: crate::conventional_commits::is_breaking(message),
+        }
+    }
+}
+
+#[derive(Clone, Serialize)]
+pub struct HookFile {
+    pub path: String,
+    pub format: String,
+}
+
 #[derive(Clone)]
 pub struct HookContext {
     pub package: String,
@@ -11,10 +43,53 @@ pub struct HookContext {
     pub package_path: String,
     pub channel: Option<String>,
     pub error_code: Option<String>,
+    pub monorepo: bool,
+    pub is_prerelease: bool,
+    pub changelog: String,
+    pub commits: Vec<HookCommit>,
+    pub bumped_files: Vec<HookFile>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hook_commit_extracts_type_scope_and_breaking() {
+        let c = HookCommit::from_commit("abc1234", "feat(api): add endpoint");
+        assert_eq!(c.hash, "abc1234");
+        assert_eq!(c.message, "feat(api): add endpoint");
+        assert_eq!(c.commit_type.as_deref(), Some("feat"));
+        assert_eq!(c.scope.as_deref(), Some("api"));
+        assert!(!c.breaking);
+
+        let breaking = HookCommit::from_commit("d", "feat!: drop the old flag");
+        assert!(breaking.breaking);
+        assert_eq!(breaking.scope, None);
+
+        let footer = HookCommit::from_commit("e", "fix: x\n\nBREAKING CHANGE: gone");
+        assert!(footer.breaking);
+        // The serialized message is the subject only, not the footer.
+        assert_eq!(footer.message, "fix: x");
+
+        let plain = HookCommit::from_commit("f", "just a plain message");
+        assert_eq!(plain.commit_type, None);
+        assert_eq!(plain.scope, None);
+        assert!(!plain.breaking);
+    }
+
+    #[test]
+    fn hook_commit_json_omits_absent_type_and_scope() {
+        let json = serde_json::to_string(&HookCommit::from_commit("h", "chore: bump")).unwrap();
+        // `type` present (chore), `scope` absent, `breaking` always present.
+        assert!(json.contains(r#""type":"chore""#));
+        assert!(!json.contains("scope"));
+        assert!(json.contains(r#""breaking":false"#));
+    }
 }
 
 impl HookContext {
-    pub fn release_summary(root: &Path, tags: &[String], dry_run: bool) -> Self {
+    pub fn release_summary(root: &Path, tags: &[String], dry_run: bool, monorepo: bool) -> Self {
         HookContext {
             package: String::new(),
             old_version: String::new(),
@@ -25,6 +100,11 @@ impl HookContext {
             package_path: root.to_string_lossy().into_owned(),
             channel: None,
             error_code: None,
+            monorepo,
+            is_prerelease: false,
+            changelog: String::new(),
+            commits: Vec::new(),
+            bumped_files: Vec::new(),
         }
     }
 }

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -3,7 +3,7 @@ mod point;
 mod resolve;
 mod runner;
 
-pub use context::HookContext;
+pub use context::{HookCommit, HookContext, HookFile};
 pub use point::HookPoint;
 pub use resolve::{resolve_hook, resolve_on_failure};
 pub use runner::run_hook;

--- a/src/hooks/runner.rs
+++ b/src/hooks/runner.rs
@@ -52,7 +52,17 @@ pub fn run_hook(
         .env("FERRFLOW_DRY_RUN", ctx.dry_run.to_string())
         .env("FERRFLOW_PACKAGE_PATH", &ctx.package_path)
         .env("FERRFLOW_CHANNEL", ctx.channel.as_deref().unwrap_or(""))
-        .env("FERRFLOW_IS_PRERELEASE", ctx.channel.is_some().to_string())
+        .env("FERRFLOW_IS_PRERELEASE", ctx.is_prerelease.to_string())
+        .env("FERRFLOW_MONOREPO", ctx.monorepo.to_string())
+        .env("FERRFLOW_CHANGELOG", &ctx.changelog)
+        .env(
+            "FERRFLOW_COMMITS_JSON",
+            serde_json::to_string(&ctx.commits).unwrap_or_else(|_| "[]".to_string()),
+        )
+        .env(
+            "FERRFLOW_BUMPED_FILES_JSON",
+            serde_json::to_string(&ctx.bumped_files).unwrap_or_else(|_| "[]".to_string()),
+        )
         .env(
             "FERRFLOW_ERROR_CODE",
             ctx.error_code.as_deref().unwrap_or(""),

--- a/src/monorepo/run/execute.rs
+++ b/src/monorepo/run/execute.rs
@@ -403,7 +403,8 @@ fn run_release_summary_hook(plan: &ReleasePlan<'_>, point: HookPoint) -> Result<
             .iter()
             .map(|(t, _, _, _, _, _, _)| t.clone())
             .collect();
-        let ctx = HookContext::release_summary(plan.root, &tags, plan.dry_run);
+        let ctx =
+            HookContext::release_summary(plan.root, &tags, plan.dry_run, plan.config.is_monorepo());
         run_hook(
             point,
             &cmd,

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -11,7 +11,9 @@ use crate::conventional_commits::BumpType;
 use crate::diff::unified_diff;
 use crate::formats::{get_handler, render_new_version, write_version};
 use crate::git::{collect_all_tags, fetch_tags, get_changed_files, open_repo, tag_exists};
-use crate::hooks::{HookContext, HookPoint, resolve_hook, resolve_on_failure, run_hook};
+use crate::hooks::{
+    HookCommit, HookContext, HookFile, HookPoint, resolve_hook, resolve_on_failure, run_hook,
+};
 use crate::prerelease::PrereleaseContext;
 use crate::timing::Timing;
 use crate::versioning::truncate_version;
@@ -401,7 +403,24 @@ pub(super) fn run_release_logic(
             pkg_outputs.push((pkg.name.clone(), lines));
         }
 
-        let hook_ctx = HookContext {
+        let hook_commits: Vec<HookCommit> = commits
+            .iter()
+            .map(|c| HookCommit::from_commit(&c.hash, &c.message))
+            .collect();
+        let hook_bumped_files: Vec<HookFile> = pkg
+            .versioned_files
+            .iter()
+            .filter(|vf| get_handler(&vf.format).modifies_file())
+            .map(|vf| HookFile {
+                path: vf.path.clone(),
+                format: serde_json::to_value(&vf.format)
+                    .ok()
+                    .and_then(|v| v.as_str().map(str::to_string))
+                    .unwrap_or_default(),
+            })
+            .collect();
+
+        let mut hook_ctx = HookContext {
             package: pkg.name.clone(),
             old_version: current_version.clone(),
             new_version: new_version.clone(),
@@ -414,6 +433,11 @@ pub(super) fn run_release_logic(
                 .into_owned(),
             channel: prerelease_ctx.channel.clone(),
             error_code: None,
+            monorepo: config.is_monorepo(),
+            is_prerelease,
+            changelog: String::new(),
+            commits: hook_commits,
+            bumped_files: hook_bumped_files,
         };
 
         let ws_hooks = config.workspace.hooks.as_ref();
@@ -486,6 +510,12 @@ pub(super) fn run_release_logic(
                 new_tag: Some(tag.clone()),
             };
 
+            // Build the release's changelog section once and hand it to the
+            // hooks (post-bump onward see it via `ctx.changelog` /
+            // FERRFLOW_CHANGELOG); it's reused for the tag body below.
+            let body = build_section_with(&new_version, &commits, &changelog_render);
+            hook_ctx.changelog = body.clone();
+
             if let Some(changelog_rel) = &pkg.changelog {
                 let changelog_path = root.join(changelog_rel);
                 update_changelog_with(
@@ -523,7 +553,6 @@ pub(super) fn run_release_logic(
                 }
             }
 
-            let body = build_section_with(&new_version, &commits, &changelog_render);
             tags_to_create.push((
                 tag.clone(),
                 format!("Release {tag}"),
@@ -679,7 +708,12 @@ pub(super) fn run_release_logic(
                     Checkpoint::delete(root)?;
                 }
                 if let Some(cmd) = resolve_hook(None, ws_hooks, HookPoint::OnSuccess) {
-                    let ctx = HookContext::release_summary(root, &released_tags, dry_run);
+                    let ctx = HookContext::release_summary(
+                        root,
+                        &released_tags,
+                        dry_run,
+                        config.is_monorepo(),
+                    );
                     let on_failure = resolve_on_failure(None, ws_hooks);
                     run_hook(
                         HookPoint::OnSuccess,
@@ -694,7 +728,12 @@ pub(super) fn run_release_logic(
             }
             Err(err) => {
                 if let Some(cmd) = resolve_hook(None, ws_hooks, HookPoint::OnError) {
-                    let mut ctx = HookContext::release_summary(root, &released_tags, dry_run);
+                    let mut ctx = HookContext::release_summary(
+                        root,
+                        &released_tags,
+                        dry_run,
+                        config.is_monorepo(),
+                    );
                     ctx.error_code = crate::error_code::code_from_error(&err);
                     let _ = run_hook(
                         HookPoint::OnError,


### PR DESCRIPTION
Closes #292

Enriches the context passed to every hook point (both shell hooks via `FERRFLOW_*` env vars and JS/TS function hooks via the `ctx` object) with the release data requested in #292.

## What's added

New `FERRFLOW_*` env vars (shell) / `ctx` properties (JS/TS), populated once per package and shared by all of that package's hook points (pre/post bump, commit, tag, publish, release, success, error):

| Env var | `ctx` property | Value |
|---|---|---|
| `FERRFLOW_MONOREPO` | `monorepo` | `true` when running a monorepo release |
| `FERRFLOW_IS_PRERELEASE` | `isPrerelease` | `true` for prerelease channels |
| `FERRFLOW_CHANGELOG` | `changelog` | the rendered changelog section (markdown) for this bump |
| `FERRFLOW_COMMITS_JSON` | `commits` | `[{ hash, message, type?, scope?, breaking }]` — parsed conventional-commit metadata |
| `FERRFLOW_BUMPED_FILES_JSON` | `bumpedFiles` | `[{ path, format }]` for every file the release actually modified |

`commits` and `bumpedFiles` are serialized as JSON so shell hooks can `jq` them and function hooks get real arrays via `JSON.parse`. The JS/TS `ctx` object is built from the same env vars — one source of truth for both hook flavours.

Batch-level hooks (`onSuccess` / `onError` release summary) also receive `monorepo`.

## Deferred (tracked as follow-ups on #292)

- `releaseUrl` / `releaseNotes` / `assets` for pre/post-publish — needs the forge-result threaded into the publish hook path.
- `allPackages` full-batch snapshot.

## Tests

- `HookCommit::from_commit` unit tests (type/scope/breaking extraction, subject-only message, JSON omission of absent `type`/`scope`).
- Full suite green (929 passed); `ferrflow-wasm` builds; clippy `-D warnings` clean.
- End-to-end smoke: real `ferrflow release` with a shell hook dumping env confirms all five vars populated with correctly-parsed commit metadata; the reified JS function hook receives the enriched `ctx` object.