### PR TITLE
ci(bench): bump Benchmarks action to v5.6.2 for like-for-like dry-run comparison

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -528,7 +528,7 @@ jobs:
           key: bench-npm-cache-${{ hashFiles('.github/workflows/ci.yml', 'benchmarks/fixtures/definitions/*.json') }}
           restore-keys: |
             bench-npm-cache-
-      - uses: FerrLabs/Benchmarks@18eba20006307afc40d39afd02d16c0b10c4582d # v5.6.1 + telemetry disabled in runs
+      - uses: FerrLabs/Benchmarks@0b826f16dc0611e42da73e9d076459dd7c38338e # v5.6.2 (competitors bucketed as release-dry-run for a like-for-like head-to-head)
         with:
           type: full
           definitions: benchmarks/fixtures/definitions
@@ -566,7 +566,7 @@ jobs:
         with:
           pattern: bench-partial-*
           path: partials/
-      - uses: FerrLabs/Benchmarks@18eba20006307afc40d39afd02d16c0b10c4582d # v5.6.1 + telemetry disabled in runs
+      - uses: FerrLabs/Benchmarks@0b826f16dc0611e42da73e9d076459dd7c38338e # v5.6.2 (competitors bucketed as release-dry-run for a like-for-like head-to-head)
         with:
           type: full
           definitions: benchmarks/fixtures/definitions


### PR DESCRIPTION
Closes #739

Bumps both `FerrLabs/Benchmarks` pins (benchmark + benchmark-aggregate jobs) from v5.6.1 to **v5.6.2** (FerrLabs/Benchmarks#188).

v5.6.2 buckets each competitor's dry-run invocation under `release-dry-run` instead of `check`, so the head-to-head compares the same operation — `release --dry-run` (compute next version + notes, write nothing) — for every tool, instead of `ferrflow check` against the competitors' full dry-run.

Effect: the next bench run on `main` produces a `latest.json` with competitors in the `release-dry-run` column; the sync workflow refreshes the site's `benchmarks.json`, and the data-driven `/performance` chart switches to that column automatically. Site copy already updated in FerrLabs/FerrFlow-Cloud#721.