### PR TITLE
feat(hooks): expose allPackages batch snapshot to hooks

### DIFF
--- a/src/config/loader_js.rs
+++ b/src/config/loader_js.rs
@@ -37,7 +37,7 @@ pub(crate) fn path_to_file_url(path: &Path) -> Result<String> {
 const LOADER_SCRIPT: &str = r#"
 function reifyHooks(hooks, fileUrl, runtime, hookPath) {
   if (!hooks || typeof hooks !== 'object') return hooks;
-  const ctx = `{ package: process.env.FERRFLOW_PACKAGE, oldVersion: process.env.FERRFLOW_OLD_VERSION, newVersion: process.env.FERRFLOW_NEW_VERSION, bumpType: process.env.FERRFLOW_BUMP_TYPE, tag: process.env.FERRFLOW_TAG, dryRun: process.env.FERRFLOW_DRY_RUN === 'true', packagePath: process.env.FERRFLOW_PACKAGE_PATH, channel: process.env.FERRFLOW_CHANNEL || null, isPrerelease: process.env.FERRFLOW_IS_PRERELEASE === 'true', monorepo: process.env.FERRFLOW_MONOREPO === 'true', changelog: process.env.FERRFLOW_CHANGELOG || '', commits: JSON.parse(process.env.FERRFLOW_COMMITS_JSON || '[]'), bumpedFiles: JSON.parse(process.env.FERRFLOW_BUMPED_FILES_JSON || '[]') }`;
+  const ctx = `{ package: process.env.FERRFLOW_PACKAGE, oldVersion: process.env.FERRFLOW_OLD_VERSION, newVersion: process.env.FERRFLOW_NEW_VERSION, bumpType: process.env.FERRFLOW_BUMP_TYPE, tag: process.env.FERRFLOW_TAG, dryRun: process.env.FERRFLOW_DRY_RUN === 'true', packagePath: process.env.FERRFLOW_PACKAGE_PATH, channel: process.env.FERRFLOW_CHANNEL || null, isPrerelease: process.env.FERRFLOW_IS_PRERELEASE === 'true', monorepo: process.env.FERRFLOW_MONOREPO === 'true', changelog: process.env.FERRFLOW_CHANGELOG || '', commits: JSON.parse(process.env.FERRFLOW_COMMITS_JSON || '[]'), bumpedFiles: JSON.parse(process.env.FERRFLOW_BUMPED_FILES_JSON || '[]'), allPackages: JSON.parse(process.env.FERRFLOW_ALL_PACKAGES_JSON || '[]') }`;
   const result = {};
   for (const [key, value] of Object.entries(hooks)) {
     if (typeof value === 'function') {

--- a/src/hooks/context.rs
+++ b/src/hooks/context.rs
@@ -32,6 +32,13 @@ pub struct HookFile {
     pub format: String,
 }
 
+#[derive(Clone, Serialize)]
+pub struct HookPackage {
+    pub name: String,
+    pub version: String,
+    pub bump: String,
+}
+
 #[derive(Clone)]
 pub struct HookContext {
     pub package: String,
@@ -48,6 +55,7 @@ pub struct HookContext {
     pub changelog: String,
     pub commits: Vec<HookCommit>,
     pub bumped_files: Vec<HookFile>,
+    pub all_packages: Vec<HookPackage>,
 }
 
 #[cfg(test)]
@@ -105,6 +113,7 @@ impl HookContext {
             changelog: String::new(),
             commits: Vec::new(),
             bumped_files: Vec::new(),
+            all_packages: Vec::new(),
         }
     }
 }

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -3,7 +3,7 @@ mod point;
 mod resolve;
 mod runner;
 
-pub use context::{HookCommit, HookContext, HookFile};
+pub use context::{HookCommit, HookContext, HookFile, HookPackage};
 pub use point::HookPoint;
 pub use resolve::{resolve_hook, resolve_on_failure};
 pub use runner::run_hook;

--- a/src/hooks/runner.rs
+++ b/src/hooks/runner.rs
@@ -64,6 +64,10 @@ pub fn run_hook(
             serde_json::to_string(&ctx.bumped_files).unwrap_or_else(|_| "[]".to_string()),
         )
         .env(
+            "FERRFLOW_ALL_PACKAGES_JSON",
+            serde_json::to_string(&ctx.all_packages).unwrap_or_else(|_| "[]".to_string()),
+        )
+        .env(
             "FERRFLOW_ERROR_CODE",
             ctx.error_code.as_deref().unwrap_or(""),
         );

--- a/src/monorepo/run/execute.rs
+++ b/src/monorepo/run/execute.rs
@@ -403,8 +403,11 @@ fn run_release_summary_hook(plan: &ReleasePlan<'_>, point: HookPoint) -> Result<
             .iter()
             .map(|(t, _, _, _, _, _, _)| t.clone())
             .collect();
-        let ctx =
+        let mut ctx =
             HookContext::release_summary(plan.root, &tags, plan.dry_run, plan.config.is_monorepo());
+        if let Some((first, _)) = plan.hook_contexts.first() {
+            ctx.all_packages = first.all_packages.clone();
+        }
         run_hook(
             point,
             &cmd,

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -12,7 +12,8 @@ use crate::diff::unified_diff;
 use crate::formats::{get_handler, render_new_version, write_version};
 use crate::git::{collect_all_tags, fetch_tags, get_changed_files, open_repo, tag_exists};
 use crate::hooks::{
-    HookCommit, HookContext, HookFile, HookPoint, resolve_hook, resolve_on_failure, run_hook,
+    HookCommit, HookContext, HookFile, HookPackage, HookPoint, resolve_hook, resolve_on_failure,
+    run_hook,
 };
 use crate::prerelease::PrereleaseContext;
 use crate::timing::Timing;
@@ -232,6 +233,12 @@ pub(super) fn run_release_logic(
 
     let mut plans: Vec<Option<PackagePlan>> = plans.into_iter().map(Some).collect();
     groups::apply_groups(config, root, &mut plans);
+
+    // Snapshot of every package the batch will bump, computed once (after group
+    // resolution settled the final versions) so it can be shared unchanged by
+    // every package's hooks — including the first one to run.
+    let all_packages = batch_package_snapshot(&release_order, &plans, &config.packages);
+
     for &pkg_idx in &release_order {
         let pkg = &config.packages[pkg_idx];
         let plan = plans[pkg_idx]
@@ -438,6 +445,7 @@ pub(super) fn run_release_logic(
             changelog: String::new(),
             commits: hook_commits,
             bumped_files: hook_bumped_files,
+            all_packages: all_packages.clone(),
         };
 
         let ws_hooks = config.workspace.hooks.as_ref();
@@ -708,12 +716,13 @@ pub(super) fn run_release_logic(
                     Checkpoint::delete(root)?;
                 }
                 if let Some(cmd) = resolve_hook(None, ws_hooks, HookPoint::OnSuccess) {
-                    let ctx = HookContext::release_summary(
+                    let mut ctx = HookContext::release_summary(
                         root,
                         &released_tags,
                         dry_run,
                         config.is_monorepo(),
                     );
+                    ctx.all_packages = all_packages.clone();
                     let on_failure = resolve_on_failure(None, ws_hooks);
                     run_hook(
                         HookPoint::OnSuccess,
@@ -734,6 +743,7 @@ pub(super) fn run_release_logic(
                         dry_run,
                         config.is_monorepo(),
                     );
+                    ctx.all_packages = all_packages.clone();
                     ctx.error_code = crate::error_code::code_from_error(&err);
                     let _ = run_hook(
                         HookPoint::OnError,
@@ -826,6 +836,24 @@ pub(super) fn run_release_logic(
             text_lines,
         },
     )
+}
+
+fn batch_package_snapshot(
+    release_order: &[usize],
+    plans: &[Option<PackagePlan>],
+    packages: &[PackageConfig],
+) -> Vec<HookPackage> {
+    release_order
+        .iter()
+        .filter_map(|&idx| match plans[idx].as_ref() {
+            Some(PackagePlan::Bump(bump)) => Some(HookPackage {
+                name: packages[idx].name.clone(),
+                version: bump.new_version.clone(),
+                bump: bump.bump.to_string(),
+            }),
+            _ => None,
+        })
+        .collect()
 }
 
 fn emit_dry_run_diffs(
@@ -931,5 +959,56 @@ pub(super) fn refresh_lockfiles(
             }
             UpdateOutcome::NoLockfile | UpdateOutcome::UnsupportedManifest => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conventional_commits::BumpType;
+    use plan::PackageBump;
+
+    fn pkg(name: &str) -> PackageConfig {
+        serde_json::from_str(&format!(r#"{{"name":"{name}","path":"{name}"}}"#)).unwrap()
+    }
+
+    fn bump_plan(new_version: &str, bump: BumpType) -> PackagePlan {
+        PackagePlan::Bump(Box::new(PackageBump {
+            recovered: false,
+            current_version: "1.0.0".to_string(),
+            new_version: new_version.to_string(),
+            is_prerelease: false,
+            last_tag: None,
+            commits: Vec::new(),
+            bump,
+            strategy_label: bump.to_string(),
+            tag: format!("v{new_version}"),
+        }))
+    }
+
+    #[test]
+    fn batch_snapshot_lists_only_bumped_packages_in_release_order() {
+        let packages = vec![pkg("api"), pkg("web"), pkg("cli")];
+        let plans = vec![
+            Some(bump_plan("2.0.0", BumpType::Major)),
+            Some(PackagePlan::Skipped {
+                reason: SkipReason::NotTouched,
+                recovered: false,
+            }),
+            Some(bump_plan("1.4.0", BumpType::Minor)),
+        ];
+
+        // release_order visits cli (2) before api (0) and includes the skipped
+        // web (1) — proving the snapshot follows release order and drops skips.
+        let snapshot = batch_package_snapshot(&[2, 0, 1], &plans, &packages);
+
+        assert_eq!(snapshot.len(), 2);
+        assert_eq!(snapshot[0].name, "cli");
+        assert_eq!(snapshot[0].version, "1.4.0");
+        assert_eq!(snapshot[0].bump, "minor");
+        assert_eq!(snapshot[1].name, "api");
+        assert_eq!(snapshot[1].version, "2.0.0");
+        assert_eq!(snapshot[1].bump, "major");
+        assert!(!snapshot.iter().any(|p| p.name == "web"));
     }
 }


### PR DESCRIPTION
Closes #738

Follow-up to #292 / #736. Adds `allPackages` to the hook context — `[{ name, version, bump }]` for every package the release bumps in this batch — reaching both shell hooks (`FERRFLOW_ALL_PACKAGES_JSON`) and JS/TS function hooks (`ctx.allPackages`), from the same source as the other fields.

The snapshot is computed once, right after group resolution settles the final versions and before the per-package loop runs any hook, then shared unchanged by every package's hooks — so the first package's `postBump` already sees the whole batch, and the batch-level `onSuccess` / `onError` get it too.

## Tests

- Unit test on `batch_package_snapshot`: filters skipped packages, follows release order, maps `{name, version, bump}` (bump as `major`/`minor`/`patch`).
- End-to-end smoke: a 2-package monorepo release confirms `FERRFLOW_ALL_PACKAGES_JSON=[{"name":"api","version":"1.1.0","bump":"minor"},{"name":"web","version":"2.1.0","bump":"minor"}]`, identical in every package's hook.
- Full suite green (932), clippy `-D warnings` clean, `ferrflow-wasm` builds.

Docs (config reference EN+FR) and a changelog entry follow in FerrFlow-Cloud / Changelog PRs.