### PR TITLE
chore(release): version ferrflow-wasm in lockstep with the ferrflow crate

### DIFF
--- a/.ferrflow
+++ b/.ferrflow
@@ -24,7 +24,8 @@
         { "path": "npm/platforms/darwin-arm64/package.json", "format": "json" },
         { "path": "npm/platforms/win32-x64/package.json", "format": "json" },
         { "path": "npm/platforms/win32-arm64/package.json", "format": "json" },
-        { "path": "npm/platforms/linux-arm/package.json", "format": "json" }
+        { "path": "npm/platforms/linux-arm/package.json", "format": "json" },
+        { "path": "ferrflow-wasm/Cargo.toml", "format": "toml" }
       ]
     }
   ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "ferrflow-wasm"
-version = "0.1.0"
+version = "5.39.0"
 dependencies = [
  "ferrflow",
  "serde",

--- a/ferrflow-wasm/Cargo.toml
+++ b/ferrflow-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrflow-wasm"
-version = "0.1.0"
+version = "5.39.0"
 edition = "2024"
 description = "FerrFlow core functions compiled to WebAssembly"
 license = "MPL-2.0"

--- a/ferrflow-wasm/README.md
+++ b/ferrflow-wasm/README.md
@@ -1,0 +1,21 @@
+# ferrflow-wasm
+
+FerrFlow's core functions compiled to WebAssembly, published to npm as
+[`@ferrflow/wasm`](https://www.npmjs.com/package/@ferrflow/wasm) and consumed by
+the ferrflow.com playground.
+
+## Versioning
+
+`ferrflow-wasm` is versioned in lockstep with the `ferrflow` crate — there is no
+independent version line. The release pipeline is the single source of truth:
+
+- `ferrflow-wasm/Cargo.toml` is listed in the `ferrflow` package's
+  `versionedFiles` (see [`.ferrflow`](../.ferrflow)), so every `ferrflow release`
+  writes the new version into it in the same commit as `Cargo.toml` and the npm
+  platform manifests.
+- The npm publish (`npm/scripts/publish-wasm.sh`) stamps the package version from
+  the release git tag, so `@ferrflow/wasm@X.Y.Z` always matches `ferrflow@X.Y.Z`.
+
+The playground therefore runs the same logic as the CLI at that version. When a
+new major ships, bump the playground's `@ferrflow/wasm` dependency in
+`FerrFlow-Cloud` to match.


### PR DESCRIPTION
Closes #413

`ferrflow-wasm/Cargo.toml` was stuck at `0.1.0` while the `ferrflow` crate was at `5.39.0` — a confusing drift, and it meant the crate manifest didn't reflect the code it wraps.

## Approach: single source of truth via `versionedFiles`

Rather than a second package + a linked/fixed group (which would flip this repo into monorepo mode and add a second release tag), `ferrflow-wasm/Cargo.toml` is added to the existing `ferrflow` package's `versionedFiles` in `.ferrflow`. The repo stays single-package (`ferrflow validate` → 1 package), keeps its single `v{version}` tag, and every `ferrflow release` now writes the wasm manifest to the same version as `Cargo.toml` and the npm platform manifests — in the same commit.

- Pre-aligned `ferrflow-wasm/Cargo.toml` to `5.39.0` so it's consistent immediately (refreshed `Cargo.lock`).
- Documented the strategy in `ferrflow-wasm/README.md`.

The npm side already tracks the CLI: `npm/scripts/publish-wasm.sh` stamps `@ferrflow/wasm`'s version from the release git tag, so `@ferrflow/wasm@X.Y.Z` matches `ferrflow@X.Y.Z`. The stale "playground pins 2.14.0" note in the issue no longer applies — the playground was relocated and FerrFlow-Cloud only references `@ferrflow/wasm` in generic install docs (no version pin), so no companion dep-bump PR is needed.

## Verification

- `ferrflow check --verbose` lists `ferrflow-wasm/Cargo.toml` in the modified set (5.39.0 → 5.40.0 alongside the other manifests).
- `ferrflow validate` → config parsed, 1 package, no issues.
- `cargo build` clean; `Cargo.lock` updated.

Typed `chore(release)` on purpose: this is release plumbing, not a user-facing CLI change, so it shouldn't force a version bump on its own — the lockstep kicks in on the next real release.