### PR TITLE
feat(release): persistent release PR — update the open PR instead of opening a new one

### DIFF
--- a/src/error_code.rs
+++ b/src/error_code.rs
@@ -112,6 +112,10 @@ pub const GIT_PUSH_VERIFY_FAILED: ErrorCode = ErrorCode(2009);
 pub const GIT_REMOTE_BRANCH_NOT_FOUND: ErrorCode = ErrorCode(2010);
 #[allow(dead_code)]
 pub const GIT_LOCKED: ErrorCode = ErrorCode(2011);
+#[allow(dead_code)]
+pub const GIT_FORCE_PUSH_BRANCH: ErrorCode = ErrorCode(2012);
+#[allow(dead_code)]
+pub const GIT_INSPECT_RELEASE_BRANCH: ErrorCode = ErrorCode(2013);
 
 #[allow(dead_code)]
 pub const GITHUB_CREATE_RELEASE: ErrorCode = ErrorCode(3001);
@@ -133,6 +137,10 @@ pub const GITHUB_AUTO_MERGE: ErrorCode = ErrorCode(3008);
 pub const GITHUB_GRAPHQL_PARSE: ErrorCode = ErrorCode(3009);
 #[allow(dead_code)]
 pub const GITHUB_AUTO_MERGE_FAILED: ErrorCode = ErrorCode(3010);
+#[allow(dead_code)]
+pub const GITHUB_FIND_PR: ErrorCode = ErrorCode(3011);
+#[allow(dead_code)]
+pub const GITHUB_UPDATE_PR: ErrorCode = ErrorCode(3012);
 
 #[allow(dead_code)]
 pub const GITLAB_CREATE_RELEASE: ErrorCode = ErrorCode(3101);
@@ -144,6 +152,10 @@ pub const GITLAB_PARSE_MR: ErrorCode = ErrorCode(3103);
 pub const GITLAB_MR_MISSING_FIELD: ErrorCode = ErrorCode(3104);
 #[allow(dead_code)]
 pub const GITLAB_MERGE_MR: ErrorCode = ErrorCode(3105);
+#[allow(dead_code)]
+pub const GITLAB_FIND_MR: ErrorCode = ErrorCode(3106);
+#[allow(dead_code)]
+pub const GITLAB_UPDATE_MR: ErrorCode = ErrorCode(3107);
 
 #[allow(dead_code)]
 pub const GITEA_CREATE_RELEASE: ErrorCode = ErrorCode(3201);

--- a/src/forge/bitbucket.rs
+++ b/src/forge/bitbucket.rs
@@ -96,6 +96,19 @@ impl Forge for BitbucketForge {
     fn update_comment(&self, _pr_id: u64, _comment_id: u64, _body: &str) -> Result<()> {
         bail!("{PR_UNSUPPORTED}")
     }
+
+    fn find_open_pr(&self, _head: &str, _base: &str) -> Result<Option<u64>> {
+        Ok(None)
+    }
+
+    fn update_merge_request(
+        &self,
+        _id: u64,
+        _title: &str,
+        _body: &str,
+    ) -> Result<MergeRequestResult> {
+        bail!("{PR_UNSUPPORTED}")
+    }
 }
 
 fn tag_html_url(response: &serde_json::Value) -> Option<String> {

--- a/src/forge/gitea.rs
+++ b/src/forge/gitea.rs
@@ -187,6 +187,22 @@ impl Forge for GiteaForge {
             .with_context(|| "Failed to update issue comment")?;
         Ok(())
     }
+
+    fn find_open_pr(&self, _head: &str, _base: &str) -> Result<Option<u64>> {
+        Ok(None)
+    }
+
+    fn update_merge_request(
+        &self,
+        _id: u64,
+        _title: &str,
+        _body: &str,
+    ) -> Result<MergeRequestResult> {
+        anyhow::bail!(
+            "Pull-request mode is not yet supported on Gitea/Forgejo. \
+             FerrFlow can create releases; PR-based release flow is tracked in FerrLabs/FerrFlow#499."
+        )
+    }
 }
 
 #[cfg(test)]

--- a/src/forge/github.rs
+++ b/src/forge/github.rs
@@ -279,6 +279,62 @@ impl Forge for GitHubForge {
             .with_context(|| "Failed to update PR comment")?;
         Ok(())
     }
+
+    fn find_open_pr(&self, head: &str, base: &str) -> Result<Option<u64>> {
+        let owner = self.slug.split('/').next().unwrap_or_default();
+        let url = format!(
+            "{}/repos/{}/pulls?state=open&head={}:{}&base={}",
+            self.api_base, self.slug, owner, head, base
+        );
+        let response: serde_json::Value = self
+            .agent
+            .get(&url)
+            .header("Authorization", &format!("Bearer {}", self.token))
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .header("User-Agent", "ferrflow")
+            .call()
+            .with_context(|| format!("Failed to list open PRs for {head}"))
+            .error_code(error_code::GITHUB_FIND_PR)?
+            .body_mut()
+            .read_json()
+            .with_context(|| "Failed to parse PR list response")
+            .error_code(error_code::GITHUB_PARSE_PR)?;
+
+        Ok(response
+            .as_array()
+            .and_then(|prs| prs.first())
+            .and_then(|pr| pr["number"].as_u64()))
+    }
+
+    fn update_merge_request(&self, id: u64, title: &str, body: &str) -> Result<MergeRequestResult> {
+        let url = format!("{}/repos/{}/pulls/{}", self.api_base, self.slug, id);
+        let response: serde_json::Value = self
+            .agent
+            .patch(&url)
+            .header("Authorization", &format!("Bearer {}", self.token))
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .header("User-Agent", "ferrflow")
+            .send_json(serde_json::json!({ "title": title, "body": body }))
+            .with_context(|| format!("Failed to update PR #{id}"))
+            .error_code(error_code::GITHUB_UPDATE_PR)?
+            .body_mut()
+            .read_json()
+            .with_context(|| "Failed to parse PR update response")
+            .error_code(error_code::GITHUB_PARSE_PR)?;
+
+        let node_id = response["node_id"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("PR response missing node_id field"))
+            .error_code(error_code::GITHUB_PR_MISSING_FIELD)?
+            .to_string();
+
+        Ok(MergeRequestResult {
+            id,
+            auto_merge_key: node_id,
+        })
+    }
 }
 
 #[cfg(test)]

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -250,6 +250,48 @@ impl Forge for GitLabForge {
             .with_context(|| "Failed to update MR note")?;
         Ok(())
     }
+
+    fn find_open_pr(&self, head: &str, base: &str) -> Result<Option<u64>> {
+        let project = self.encoded_project_id();
+        let url = format!(
+            "{}/projects/{project}/merge_requests?state=opened&source_branch={head}&target_branch={base}",
+            self.api_base
+        );
+        let response: serde_json::Value = self
+            .agent
+            .get(&url)
+            .header("PRIVATE-TOKEN", &self.token)
+            .header("User-Agent", "ferrflow")
+            .call()
+            .with_context(|| format!("Failed to list open MRs for {head}"))
+            .error_code(error_code::GITLAB_FIND_MR)?
+            .body_mut()
+            .read_json()
+            .with_context(|| "Failed to parse MR list response")
+            .error_code(error_code::GITLAB_PARSE_MR)?;
+
+        Ok(response
+            .as_array()
+            .and_then(|mrs| mrs.first())
+            .and_then(|mr| mr["iid"].as_u64()))
+    }
+
+    fn update_merge_request(&self, id: u64, title: &str, body: &str) -> Result<MergeRequestResult> {
+        let project = self.encoded_project_id();
+        let url = format!("{}/projects/{project}/merge_requests/{id}", self.api_base);
+        self.agent
+            .put(&url)
+            .header("PRIVATE-TOKEN", &self.token)
+            .header("User-Agent", "ferrflow")
+            .send_json(serde_json::json!({ "title": title, "description": body }))
+            .with_context(|| format!("Failed to update MR !{id}"))
+            .error_code(error_code::GITLAB_UPDATE_MR)?;
+
+        Ok(MergeRequestResult {
+            id,
+            auto_merge_key: id.to_string(),
+        })
+    }
 }
 
 #[cfg(test)]

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -49,6 +49,10 @@ pub trait Forge: Send + Sync {
     fn create_comment(&self, pr_id: u64, body: &str) -> Result<()>;
 
     fn update_comment(&self, pr_id: u64, comment_id: u64, body: &str) -> Result<()>;
+
+    fn find_open_pr(&self, head: &str, base: &str) -> Result<Option<u64>>;
+
+    fn update_merge_request(&self, id: u64, title: &str, body: &str) -> Result<MergeRequestResult>;
 }
 
 pub fn detect_pr_number() -> Option<u64> {

--- a/src/git/commits.rs
+++ b/src/git/commits.rs
@@ -127,8 +127,12 @@ pub fn create_branch_and_commits(
         .trim()
         .to_string();
 
-    run_git(workdir, &["branch", branch_name])
-        .with_context(|| format!("git branch {branch_name} failed"))?;
+    // `-f` so a persistent release branch left over from a prior run in
+    // the same checkout is reset to the fresh release commit rather than
+    // failing on "branch already exists" (#703). Safe: the release branch
+    // is never the checked-out branch.
+    run_git(workdir, &["branch", "-f", branch_name])
+        .with_context(|| format!("git branch -f {branch_name} failed"))?;
 
     for (files, message) in commits {
         let mut add_args: Vec<&str> = vec!["add", "--"];

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -26,7 +26,8 @@ pub use diff::{get_changed_files, get_changed_files_since_oid, get_changed_files
 pub use fetch::fetch_tags;
 #[allow(unused_imports)]
 pub use push::{
-    force_push_tags, push, push_branch, push_tags, reset_branch_to_remote, verify_remote_branch,
+    force_push_branch, force_push_tags, push, push_tags, release_branch_foreign_commit,
+    reset_branch_to_remote, verify_remote_branch,
 };
 pub use repo::{Repository, get_repo_root, open_repo, resolve_current_branch};
 pub use retry::is_push_rejected_error;

--- a/src/git/push.rs
+++ b/src/git/push.rs
@@ -155,10 +155,128 @@ fn resolve_push_source(repo: &Repository, branch: &str) -> String {
     }
 }
 
-pub fn push_branch(repo: &Repository, remote_name: &str, branch: &str) -> Result<()> {
+// Overwrite the remote branch with the local one. Used by the persistent
+// release PR (#703): each run rebuilds the same release branch from the
+// fresh release commit and force-pushes it, so the open PR updates in place
+// instead of a new branch/PR being opened per version.
+pub fn force_push_branch(repo: &Repository, remote_name: &str, branch: &str) -> Result<()> {
     super::validate::ensure_safe_refname_fragment(remote_name, "remote name")?;
     super::validate::ensure_safe_refname_fragment(branch, "branch name")?;
-    try_push_branch(repo, remote_name, branch)
+    retry_transient(&format!("force-push branch '{branch}'"), || {
+        try_force_push_branch_once(repo, remote_name, branch)
+    })
+}
+
+fn try_force_push_branch_once(repo: &Repository, remote_name: &str, branch: &str) -> Result<()> {
+    let workdir = repo
+        .workdir()
+        .ok_or_else(|| anyhow!("bare repos are not supported"))?;
+    let push_url = get_remote_url(repo, remote_name)
+        .ok_or_else(|| anyhow!("Remote '{remote_name}' has no URL"))?;
+    let source = resolve_push_source(repo, branch);
+    // A leading '+' on the refspec forces the update.
+    let refspec = format!("+{source}:refs/heads/{branch}");
+
+    let mut cmd = std::process::Command::new("git");
+    cmd.current_dir(workdir);
+    configure_git_command(&mut cmd, &push_url);
+    cmd.arg("push").arg(&push_url).arg(&refspec);
+
+    let output = cmd
+        .output()
+        .with_context(|| format!("spawn `git push --force` for branch '{branch}' failed"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let detail = format!("{stdout}{stderr}").trim().to_string();
+        return Err(anyhow!("Failed to force-push branch '{branch}': {detail}"))
+            .error_code(error_code::GIT_FORCE_PUSH_BRANCH);
+    }
+    Ok(())
+}
+
+// SAFETY GUARD for the persistent release PR: before force-pushing the
+// release branch we make sure we won't clobber work a human pushed onto it.
+// Returns the subject of the first commit on the remote release branch (not
+// on `base`) that FerrFlow didn't author (i.e. isn't a `chore(release):`
+// commit), or None when the branch is absent or holds only release commits.
+pub fn release_branch_foreign_commit(
+    repo: &Repository,
+    remote_name: &str,
+    branch: &str,
+    base: &str,
+) -> Result<Option<String>> {
+    super::validate::ensure_safe_refname_fragment(remote_name, "remote name")?;
+    super::validate::ensure_safe_refname_fragment(branch, "branch name")?;
+    super::validate::ensure_safe_refname_fragment(base, "target branch")?;
+    let workdir = repo
+        .workdir()
+        .ok_or_else(|| anyhow!("bare repos are not supported"))?;
+    let url = get_remote_url(repo, remote_name)
+        .ok_or_else(|| anyhow!("Remote '{remote_name}' has no URL"))?;
+
+    let mut ls = std::process::Command::new("git");
+    ls.current_dir(workdir);
+    configure_git_command(&mut ls, &url);
+    ls.args([
+        "ls-remote",
+        "--heads",
+        &url,
+        &format!("refs/heads/{branch}"),
+    ]);
+    let ls_out = ls
+        .output()
+        .with_context(|| "spawn `git ls-remote` failed")
+        .error_code(error_code::GIT_INSPECT_RELEASE_BRANCH)?;
+    if !ls_out.status.success() {
+        return Err(anyhow!(
+            "git ls-remote failed: {}",
+            String::from_utf8_lossy(&ls_out.stderr).trim()
+        ))
+        .error_code(error_code::GIT_INSPECT_RELEASE_BRANCH);
+    }
+    // Branch not on the remote yet — nothing to clobber.
+    if String::from_utf8_lossy(&ls_out.stdout).trim().is_empty() {
+        return Ok(None);
+    }
+
+    let mut fetch = std::process::Command::new("git");
+    fetch.current_dir(workdir);
+    configure_git_command(&mut fetch, &url);
+    fetch.args(["fetch", "--quiet", &url, &format!("refs/heads/{branch}")]);
+    let fetch_out = fetch
+        .output()
+        .with_context(|| "spawn `git fetch` for release branch failed")
+        .error_code(error_code::GIT_INSPECT_RELEASE_BRANCH)?;
+    if !fetch_out.status.success() {
+        return Err(anyhow!(
+            "git fetch of release branch failed: {}",
+            String::from_utf8_lossy(&fetch_out.stderr).trim()
+        ))
+        .error_code(error_code::GIT_INSPECT_RELEASE_BRANCH);
+    }
+
+    let mut log = std::process::Command::new("git");
+    log.current_dir(workdir);
+    log.args(["log", "--format=%s", &format!("{base}..FETCH_HEAD")]);
+    let log_out = log
+        .output()
+        .with_context(|| "spawn `git log` for release branch failed")
+        .error_code(error_code::GIT_INSPECT_RELEASE_BRANCH)?;
+    if !log_out.status.success() {
+        return Err(anyhow!(
+            "git log of release branch failed: {}",
+            String::from_utf8_lossy(&log_out.stderr).trim()
+        ))
+        .error_code(error_code::GIT_INSPECT_RELEASE_BRANCH);
+    }
+    for subject in String::from_utf8_lossy(&log_out.stdout).lines() {
+        let subject = subject.trim();
+        if !subject.is_empty() && !subject.starts_with("chore(release):") {
+            return Ok(Some(subject.to_string()));
+        }
+    }
+    Ok(None)
 }
 
 pub fn push_tags(repo: &Repository, remote_name: &str, tags: &[&str]) -> Result<()> {

--- a/src/monorepo/run/execute.rs
+++ b/src/monorepo/run/execute.rs
@@ -8,8 +8,8 @@ use crate::config::{Config, ReleaseCommitMode, ReleaseCommitScope};
 use crate::error_code::{self, ErrorCodeExt};
 use crate::git::{
     Repository, create_branch_and_commit, create_branch_and_commits, create_commit,
-    create_or_move_tag, create_tag, force_push_tags, get_tag_message, push, push_branch, push_tags,
-    tag_exists,
+    create_or_move_tag, create_tag, force_push_branch, force_push_tags, get_tag_message, push,
+    push_tags, release_branch_foreign_commit, tag_exists,
 };
 use crate::hooks::{HookContext, HookPoint, resolve_hook, resolve_on_failure, run_hook};
 use crate::versioning::truncate_version;
@@ -180,6 +180,13 @@ fn run_pre_commit_hooks(plan: &mut ReleasePlan<'_>) -> Result<()> {
     Ok(())
 }
 
+fn release_branch_name(target_branch: &str) -> String {
+    // Namespaced under `ferrflow/` and scoped per target so there's exactly one
+    // long-lived release branch per target. Slashes in the target are flattened
+    // to keep it a single ref level (avoids git dir/file ref conflicts).
+    format!("ferrflow/release-{}", target_branch.replace('/', "-"))
+}
+
 fn run_commit_or_pr(
     plan: &mut ReleasePlan<'_>,
     mode: ReleaseCommitMode,
@@ -208,13 +215,33 @@ fn run_commit_or_pr(
             }
         }
         ReleaseCommitMode::Pr => {
-            let branch_name = format!(
-                "release/{}",
-                release_parts
-                    .first()
-                    .map(|s| s.replace(' ', "-"))
-                    .unwrap_or_else(|| "bump".to_string())
-            );
+            // One stable branch per target so the same PR is reused across
+            // commits instead of a new one opening per version (#703).
+            let branch_name = release_branch_name(plan.target_branch);
+            let remote = &plan.config.workspace.remote;
+
+            // Don't clobber commits a human pushed onto the release branch.
+            match release_branch_foreign_commit(plan.repo, remote, &branch_name, plan.target_branch)
+            {
+                Ok(Some(subject)) => {
+                    tracing::warn!(
+                        "{}",
+                        format!(
+                            "  Warning: release branch {branch_name} has a commit FerrFlow didn't \
+                             author (\"{subject}\"); leaving it and the existing release PR untouched."
+                        )
+                        .yellow()
+                    );
+                    return Ok(());
+                }
+                Ok(None) => {}
+                Err(err) => tracing::warn!(
+                    "{}",
+                    format!("  Warning: could not inspect release branch {branch_name}: {err}")
+                        .yellow()
+                ),
+            }
+
             if scope == ReleaseCommitScope::PerPackage && plan.tags_to_create.len() > 1 {
                 let commit_list: Vec<(Vec<&str>, String)> = plan
                     .tags_to_create
@@ -235,7 +262,9 @@ fn run_commit_or_pr(
             } else {
                 create_branch_and_commit(plan.repo, &branch_name, file_refs, commit_msg)?;
             }
-            push_branch(plan.repo, &plan.config.workspace.remote, &branch_name)?;
+            // Force-push: the branch is rebuilt from the fresh release commit
+            // every run, so the open PR updates in place.
+            force_push_branch(plan.repo, remote, &branch_name)?;
             plan.shared_outputs
                 .push(format!("✓ Pushed branch {}", branch_name.cyan()));
 
@@ -249,15 +278,42 @@ fn run_commit_or_pr(
                         .collect::<Vec<_>>()
                         .join("\n")
                 );
-                match forge_instance.create_merge_request(
-                    &branch_name,
-                    plan.target_branch,
-                    &pr_title,
-                    &pr_body,
-                ) {
+
+                let existing = match forge_instance.find_open_pr(&branch_name, plan.target_branch) {
+                    Ok(found) => found,
+                    Err(err) => {
+                        tracing::warn!(
+                            "{}",
+                            format!(
+                                "  Warning: could not look up existing {}: {err}",
+                                forge_instance.mr_noun()
+                            )
+                            .yellow()
+                        );
+                        None
+                    }
+                };
+
+                let (result, verb) = match existing {
+                    Some(id) => (
+                        forge_instance.update_merge_request(id, &pr_title, &pr_body),
+                        "Updated",
+                    ),
+                    None => (
+                        forge_instance.create_merge_request(
+                            &branch_name,
+                            plan.target_branch,
+                            &pr_title,
+                            &pr_body,
+                        ),
+                        "Created",
+                    ),
+                };
+
+                match result {
                     Ok(mr) => {
                         plan.shared_outputs.push(format!(
-                            "✓ Created {} #{}",
+                            "✓ {verb} {} #{}",
                             forge_instance.mr_noun(),
                             mr.id.to_string().cyan()
                         ));
@@ -278,7 +334,8 @@ fn run_commit_or_pr(
                     Err(err) => tracing::warn!(
                         "{}",
                         format!(
-                            "  Warning: failed to create {}: {err}",
+                            "  Warning: failed to {} {}: {err}",
+                            verb.to_lowercase(),
                             forge_instance.mr_noun()
                         )
                         .yellow()
@@ -768,6 +825,32 @@ mod tag_release_tests {
         fn update_comment(&self, _pr_id: u64, _comment_id: u64, _body: &str) -> Result<()> {
             unreachable!("not exercised by release-tag tests")
         }
+
+        fn find_open_pr(&self, _head: &str, _base: &str) -> Result<Option<u64>> {
+            unreachable!("not exercised by release-tag tests")
+        }
+
+        fn update_merge_request(
+            &self,
+            _id: u64,
+            _title: &str,
+            _body: &str,
+        ) -> Result<MergeRequestResult> {
+            unreachable!("not exercised by release-tag tests")
+        }
+    }
+
+    #[test]
+    fn release_branch_name_is_stable_and_target_scoped() {
+        assert_eq!(release_branch_name("main"), "ferrflow/release-main");
+        // The name must not depend on the version — that's what keeps one
+        // long-lived PR per target instead of a new one per release (#703).
+        assert_eq!(release_branch_name("main"), release_branch_name("main"));
+        // Slashes in the target are flattened to one ref level.
+        assert_eq!(
+            release_branch_name("release/beta"),
+            "ferrflow/release-release-beta"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #703

Under `releaseCommitMode: pr`, the release PR was keyed to the version it was opened for (`release/<version>`), so a new commit spawned a *second* PR and left the first stale. This makes it a single, long-lived PR per target — the release-please / Changesets behaviour.

## What changed

- **Stable branch** — `ferrflow/release-<target-branch>` (was `release/<version>`). One release branch per target, independent of the computed version.
- **Force-push, don't branch afresh** — the branch is rebuilt from the fresh release commit each run and force-pushed, so the open PR updates in place. New `git::force_push_branch`; `create_branch_and_commits` now `git branch -f`.
- **Update, don't duplicate** — new `Forge::find_open_pr(head, base)`; if an open PR/MR from the release branch exists, its title/body are updated via new `Forge::update_merge_request` instead of `create_merge_request`. Implemented for GitHub + GitLab (the forges that support PR mode); Gitea/Bitbucket keep their existing "PR mode unsupported" behaviour.
- **Auto-merge stays opt-in** — `autoMergeReleases` re-applies `enable_auto_merge` on both create and update; a no-op when off.
- **Force-push guard** — before force-pushing, `git::release_branch_foreign_commit` inspects the remote release branch; if it holds a commit FerrFlow didn't author (not a `chore(release):` commit — e.g. a human's review commit), FerrFlow warns and leaves the branch and PR untouched rather than clobbering it.

## Verification

- Unit test: `release_branch_name` is version-independent and target-scoped (the property that keeps one PR per target).
- Unit test: `release_url_for_tag` unchanged; full suite green (934), clippy `-D warnings` clean, wasm builds.
- End-to-end smoke (bare local remote): two consecutive releases at different versions push the **same** `ferrflow/release-main` branch (no per-version branch); injecting a foreign `fix:` commit onto the release branch makes the next run **warn and skip the force-push**, leaving the human commit intact.

## Caveats (from the issue)

- Per-package scope (`releaseCommitScope: perPackage`) rebuilds the branch's commit set each run (it never appends) — preserved here since the branch is force-rebuilt from scratch every run.
- The guard covers the branch force-push (the stated hazard). PR-mode tag creation is unchanged.

Docs (config reference) and a changelog entry follow in FerrFlow-Cloud / Changelog PRs.