### PR TITLE
feat(cli): migrate from changesets, release-please, and standard-version

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -189,12 +189,21 @@ pub enum Commands {
 pub enum MigrateSourceArg {
     #[value(name = "semantic-release")]
     SemanticRelease,
+    #[value(name = "changesets")]
+    Changesets,
+    #[value(name = "release-please")]
+    ReleasePlease,
+    #[value(name = "standard-version")]
+    StandardVersion,
 }
 
 impl From<MigrateSourceArg> for crate::config::MigrateSource {
     fn from(arg: MigrateSourceArg) -> Self {
         match arg {
             MigrateSourceArg::SemanticRelease => crate::config::MigrateSource::SemanticRelease,
+            MigrateSourceArg::Changesets => crate::config::MigrateSource::Changesets,
+            MigrateSourceArg::ReleasePlease => crate::config::MigrateSource::ReleasePlease,
+            MigrateSourceArg::StandardVersion => crate::config::MigrateSource::StandardVersion,
         }
     }
 }

--- a/src/config/migrate.rs
+++ b/src/config/migrate.rs
@@ -13,15 +13,25 @@ use super::types::{
 };
 use super::workspace::WorkspaceConfig;
 
+mod changesets;
+mod release_please;
+mod standard_version;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Source {
     SemanticRelease,
+    Changesets,
+    ReleasePlease,
+    StandardVersion,
 }
 
 impl Source {
     fn label(self) -> &'static str {
         match self {
             Source::SemanticRelease => "semantic-release",
+            Source::Changesets => "changesets",
+            Source::ReleasePlease => "release-please",
+            Source::StandardVersion => "standard-version",
         }
     }
 }
@@ -49,6 +59,9 @@ pub fn migrate(from: Option<Source>) -> Result<()> {
 
     match source {
         Source::SemanticRelease => migrate_semantic_release(),
+        Source::Changesets => changesets::run(),
+        Source::ReleasePlease => release_please::run(),
+        Source::StandardVersion => standard_version::run(),
     }
 }
 
@@ -72,6 +85,15 @@ fn detect_source() -> Result<Source> {
     if find_semantic_release_json().is_some() {
         return Ok(Source::SemanticRelease);
     }
+    if changesets::detect().is_some() {
+        return Ok(Source::Changesets);
+    }
+    if release_please::detect().is_some() {
+        return Ok(Source::ReleasePlease);
+    }
+    if standard_version::detect().is_some() {
+        return Ok(Source::StandardVersion);
+    }
     if let Some(f) = SEMANTIC_RELEASE_UNSUPPORTED_FILES
         .iter()
         .find(|f| Path::new(f).exists())
@@ -83,9 +105,12 @@ fn detect_source() -> Result<Source> {
         .error_code(error_code::CONFIG_INVALID_JSON);
     }
     Err(anyhow::anyhow!(
-        "no supported release-tool config found. Looked for {}. \
+        "no supported release-tool config found. Looked for {}, {}, {}, {}. \
          Pass --from to force a source.",
-        SEMANTIC_RELEASE_JSON_FILES.join(", ")
+        SEMANTIC_RELEASE_JSON_FILES.join(", "),
+        changesets::CONFIG_FILE,
+        release_please::CONFIG_FILE,
+        standard_version::CONFIG_FILES.join(", "),
     ))
     .error_code(error_code::CONFIG_NOT_FOUND)
 }
@@ -251,7 +276,7 @@ pub fn build_config_from_releaserc(raw: &str) -> Result<(Config, MigrationReport
     ))
 }
 
-fn default_package_name() -> String {
+pub(super) fn default_package_name() -> String {
     std::fs::read_to_string("package.json")
         .ok()
         .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
@@ -436,13 +461,22 @@ fn migrate_semantic_release() -> Result<()> {
         .map_err(|e| anyhow::anyhow!("could not read {}: {e}", path.display()))?;
 
     let (config, report) = build_config_from_releaserc(&raw)?;
+    write_and_report(Source::SemanticRelease, &path, &config, &report)
+}
 
+/// Serialize the migrated config to `.ferrflow` (JSON) and print the report.
+/// Shared by every source converter.
+pub(super) fn write_and_report(
+    source: Source,
+    from: &Path,
+    config: &Config,
+    report: &MigrationReport,
+) -> Result<()> {
     let handler = format_handler(ConfigFileFormat::Json);
-    let content = handler.serialize(&config)?;
+    let content = handler.serialize(config)?;
     let filename = handler.filename();
     std::fs::write(filename, &content)?;
-
-    print_report(Source::SemanticRelease, &path, filename, &report);
+    print_report(source, from, filename, report);
     Ok(())
 }
 

--- a/src/config/migrate/changesets.rs
+++ b/src/config/migrate/changesets.rs
@@ -1,0 +1,193 @@
+use anyhow::Result;
+use serde::Deserialize;
+use std::path::PathBuf;
+
+use crate::config::Config;
+use crate::config::package::{FileFormat, PackageConfig, VersionedFile};
+use crate::config::workspace::WorkspaceConfig;
+use crate::error_code::{self, ErrorCodeExt};
+
+use super::{MigrationReport, Source, write_and_report};
+
+pub(super) const CONFIG_FILE: &str = ".changeset/config.json";
+
+pub(super) fn detect() -> Option<PathBuf> {
+    let p = PathBuf::from(CONFIG_FILE);
+    p.exists().then_some(p)
+}
+
+pub(super) fn run() -> Result<()> {
+    let path = detect().ok_or_else(|| anyhow::anyhow!("no {CONFIG_FILE} found"))?;
+    let raw = std::fs::read_to_string(&path)
+        .map_err(|e| anyhow::anyhow!("could not read {}: {e}", path.display()))?;
+    let (config, report) = build(&raw)?;
+    write_and_report(Source::Changesets, &path, &config, &report)
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ChangesetsConfig {
+    #[serde(default, rename = "baseBranch")]
+    base_branch: Option<String>,
+    #[serde(default)]
+    linked: Vec<Vec<String>>,
+    #[serde(default)]
+    fixed: Vec<Vec<String>>,
+    #[serde(default, rename = "updateInternalDependencies")]
+    update_internal_dependencies: Option<String>,
+    #[serde(default)]
+    access: Option<String>,
+    #[serde(default)]
+    ignore: Vec<String>,
+}
+
+pub(super) fn build(raw: &str) -> Result<(Config, MigrationReport)> {
+    let cs: ChangesetsConfig = serde_json::from_str(raw)
+        .map_err(|e| anyhow::anyhow!("could not parse {CONFIG_FILE} as JSON: {e}"))
+        .error_code(error_code::CONFIG_INVALID_JSON)?;
+
+    let mut report = MigrationReport::default();
+    let mut workspace = WorkspaceConfig::default();
+
+    // The defining difference: changesets versions from hand-written
+    // `.changeset/*.md` intent files; ferrflow versions from conventional
+    // commits. This is the one thing a user MUST know after migrating.
+    report.warnings.push(
+        "changesets versions from `.changeset/*.md` files — ferrflow versions from conventional \
+         commits instead. Adopt Conventional Commits; your existing `.changeset/*.md` files are \
+         not read."
+            .to_string(),
+    );
+
+    if let Some(base) = &cs.base_branch {
+        workspace.branch = base.clone();
+        report.mapped.push(format!("baseBranch → branch ({base})"));
+    }
+
+    if !cs.linked.is_empty() {
+        workspace.linked = cs.linked.clone();
+        report
+            .mapped
+            .push(format!("linked → {} linked group(s)", cs.linked.len()));
+    }
+    if !cs.fixed.is_empty() {
+        workspace.fixed = cs.fixed.clone();
+        report
+            .mapped
+            .push(format!("fixed → {} fixed group(s)", cs.fixed.len()));
+    }
+
+    if let Some(access) = &cs.access {
+        report.ignored.push(format!(
+            "access ({access}) — npm publish access isn't a ferrflow config concern; \
+             configure `publishers` if you publish."
+        ));
+    }
+    if let Some(uid) = &cs.update_internal_dependencies {
+        report.ignored.push(format!(
+            "updateInternalDependencies ({uid}) — ferrflow bumps dependents via `dependsOn` \
+             cascades; wire those up per package."
+        ));
+    }
+    if !cs.ignore.is_empty() {
+        report.warnings.push(format!(
+            "ignore lists {} package(s) that changesets never versions — omit them from the \
+             `package` list to get the same effect.",
+            cs.ignore.len()
+        ));
+    }
+
+    // changesets discovers packages from the JS workspace; ferrflow needs them
+    // listed explicitly. Scaffold a single root package and tell the user.
+    let package = PackageConfig {
+        name: crate::config::migrate::default_package_name(),
+        path: ".".to_string(),
+        versioned_files: vec![VersionedFile {
+            path: "package.json".to_string(),
+            format: FileFormat::Json,
+            selector: None,
+        }],
+        changelog: Some("CHANGELOG.md".to_string()),
+        shared_paths: Vec::new(),
+        depends_on: vec![],
+        versioning: None,
+        tag_template: None,
+        hooks: None,
+        floating_tags: None,
+        publishers: vec![],
+        update_lockfiles: None,
+    };
+    report.warnings.push(
+        "changesets is a monorepo tool; ferrflow can't read your workspace globs, so it \
+         scaffolded a single root package. List each workspace package under `package` (one entry \
+         per publishable package)."
+            .to_string(),
+    );
+
+    Ok((
+        Config {
+            workspace,
+            packages: vec![package],
+        },
+        report,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_ok(raw: &str) -> (Config, MigrationReport) {
+        build(raw).expect("valid changesets config")
+    }
+
+    #[test]
+    fn base_branch_maps_to_branch() {
+        let (cfg, report) = build_ok(r#"{"baseBranch": "develop"}"#);
+        assert_eq!(cfg.workspace.branch, "develop");
+        assert!(report.mapped.iter().any(|m| m.contains("baseBranch")));
+    }
+
+    #[test]
+    fn linked_and_fixed_groups_carry_over() {
+        let (cfg, _) =
+            build_ok(r#"{"linked": [["@acme/a", "@acme/b"]], "fixed": [["@acme/c", "@acme/d"]]}"#);
+        assert_eq!(cfg.workspace.linked, vec![vec!["@acme/a", "@acme/b"]]);
+        assert_eq!(cfg.workspace.fixed, vec![vec!["@acme/c", "@acme/d"]]);
+    }
+
+    #[test]
+    fn the_commit_model_difference_is_always_warned() {
+        let (_, report) = build_ok("{}");
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|w| w.contains("conventional commits")),
+            "the changeset-vs-commit difference must always be surfaced"
+        );
+    }
+
+    #[test]
+    fn monorepo_scaffold_warning_is_present() {
+        let (cfg, report) = build_ok("{}");
+        assert_eq!(cfg.packages.len(), 1);
+        assert!(report.warnings.iter().any(|w| w.contains("monorepo tool")));
+    }
+
+    #[test]
+    fn access_is_reported_as_ignored() {
+        let (_, report) = build_ok(r#"{"access": "public"}"#);
+        assert!(report.ignored.iter().any(|i| i.contains("access")));
+    }
+
+    #[test]
+    fn ignore_list_warns() {
+        let (_, report) = build_ok(r#"{"ignore": ["@acme/internal"]}"#);
+        assert!(report.warnings.iter().any(|w| w.contains("ignore")));
+    }
+
+    #[test]
+    fn malformed_json_is_an_error() {
+        assert!(build("{ not json").is_err());
+    }
+}

--- a/src/config/migrate/release_please.rs
+++ b/src/config/migrate/release_please.rs
@@ -1,0 +1,328 @@
+use anyhow::Result;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use crate::config::Config;
+use crate::config::package::{FileFormat, PackageConfig, VersionedFile};
+use crate::config::types::ReleaseCommitMode;
+use crate::config::workspace::WorkspaceConfig;
+use crate::error_code::{self, ErrorCodeExt};
+
+use super::{MigrationReport, Source, write_and_report};
+
+pub(super) const CONFIG_FILE: &str = "release-please-config.json";
+
+pub(super) fn detect() -> Option<PathBuf> {
+    let p = PathBuf::from(CONFIG_FILE);
+    p.exists().then_some(p)
+}
+
+pub(super) fn run() -> Result<()> {
+    let path = detect().ok_or_else(|| anyhow::anyhow!("no {CONFIG_FILE} found"))?;
+    let raw = std::fs::read_to_string(&path)
+        .map_err(|e| anyhow::anyhow!("could not read {}: {e}", path.display()))?;
+    let (config, report) = build(&raw)?;
+    write_and_report(Source::ReleasePlease, &path, &config, &report)
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ReleasePleaseConfig {
+    // BTreeMap → deterministic (path-sorted) output.
+    #[serde(default)]
+    packages: BTreeMap<String, PackageEntry>,
+    #[serde(default, rename = "release-type")]
+    release_type: Option<String>,
+    #[serde(default, rename = "include-component-in-tag")]
+    include_component_in_tag: Option<bool>,
+    #[serde(default, rename = "tag-separator")]
+    tag_separator: Option<String>,
+    #[serde(default, rename = "separate-pull-requests")]
+    separate_pull_requests: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct PackageEntry {
+    #[serde(default, rename = "release-type")]
+    release_type: Option<String>,
+    #[serde(default, rename = "package-name")]
+    package_name: Option<String>,
+    #[serde(default)]
+    component: Option<String>,
+    #[serde(default, rename = "changelog-path")]
+    changelog_path: Option<String>,
+}
+
+pub(super) fn build(raw: &str) -> Result<(Config, MigrationReport)> {
+    let rp: ReleasePleaseConfig = serde_json::from_str(raw)
+        .map_err(|e| anyhow::anyhow!("could not parse {CONFIG_FILE} as JSON: {e}"))
+        .error_code(error_code::CONFIG_INVALID_JSON)?;
+
+    let mut report = MigrationReport::default();
+    // release-please always drives releases through a release PR.
+    let mut workspace = WorkspaceConfig {
+        release_commit_mode: ReleaseCommitMode::Pr,
+        ..Default::default()
+    };
+    report
+        .mapped
+        .push("release-please PR flow → releaseCommitMode: pr".to_string());
+
+    // Component-in-tag → a {name}-scoped tag template.
+    if rp.include_component_in_tag.unwrap_or(false) {
+        let sep = rp.tag_separator.as_deref().unwrap_or("-");
+        let template = format!("{{name}}{sep}v{{version}}");
+        workspace.tag_template = Some(template.clone());
+        report
+            .mapped
+            .push(format!("include-component-in-tag → tagTemplate {template}"));
+    }
+
+    if rp.separate_pull_requests == Some(true) {
+        report.warnings.push(
+            "separate-pull-requests: true opens one PR per package — ferrflow uses a single \
+             release PR. The per-package split isn't reproduced."
+                .to_string(),
+        );
+    }
+
+    let default_type = rp.release_type.as_deref();
+    let mut packages = Vec::new();
+    for (path, entry) in &rp.packages {
+        packages.push(build_package(path, entry, default_type, &mut report));
+    }
+
+    // A release-please-config with no `packages` map is malformed for a
+    // manifest release; scaffold a single root package so the output is usable.
+    if packages.is_empty() {
+        packages.push(build_package(
+            ".",
+            &PackageEntry::default(),
+            default_type,
+            &mut report,
+        ));
+        report.warnings.push(
+            "no `packages` in the config — scaffolded a single root package. Add entries if this \
+             is a monorepo."
+                .to_string(),
+        );
+    }
+
+    Ok((
+        Config {
+            workspace,
+            packages,
+        },
+        report,
+    ))
+}
+
+fn build_package(
+    path: &str,
+    entry: &PackageEntry,
+    default_type: Option<&str>,
+    report: &mut MigrationReport,
+) -> PackageConfig {
+    let name = entry
+        .package_name
+        .clone()
+        .or_else(|| entry.component.clone())
+        .unwrap_or_else(|| name_from_path(path));
+
+    let rt = entry.release_type.as_deref().or(default_type);
+    let versioned_files = match rt.and_then(|t| versioned_file_for(t, path)) {
+        Some(vf) => {
+            report.mapped.push(format!(
+                "package {path} ({}) → {}",
+                rt.unwrap_or("?"),
+                vf.path
+            ));
+            vec![vf]
+        }
+        None => {
+            report.warnings.push(format!(
+                "package {path}: release-type {} has no direct ferrflow file mapping — set \
+                 `versionedFiles` by hand.",
+                rt.unwrap_or("(none)")
+            ));
+            Vec::new()
+        }
+    };
+
+    PackageConfig {
+        name,
+        path: path.to_string(),
+        versioned_files,
+        changelog: Some(
+            entry
+                .changelog_path
+                .clone()
+                .unwrap_or_else(|| "CHANGELOG.md".to_string()),
+        ),
+        shared_paths: Vec::new(),
+        depends_on: vec![],
+        versioning: None,
+        tag_template: None,
+        hooks: None,
+        floating_tags: None,
+        publishers: vec![],
+        update_lockfiles: None,
+    }
+}
+
+fn name_from_path(path: &str) -> String {
+    if path == "." || path.is_empty() {
+        super::default_package_name()
+    } else {
+        path.rsplit('/').next().unwrap_or(path).to_string()
+    }
+}
+
+/// Map a release-please `release-type` to the version file ferrflow bumps for
+/// it. Returns None for types that carry no in-repo version file (e.g. `go`,
+/// which release-please versions from tags alone).
+fn versioned_file_for(release_type: &str, pkg_path: &str) -> Option<VersionedFile> {
+    let join = |file: &str| -> String {
+        if pkg_path == "." || pkg_path.is_empty() {
+            file.to_string()
+        } else {
+            format!("{}/{file}", pkg_path.trim_end_matches('/'))
+        }
+    };
+    let (file, format) = match release_type {
+        "node" => ("package.json", FileFormat::Json),
+        "rust" => ("Cargo.toml", FileFormat::Toml),
+        "python" => ("pyproject.toml", FileFormat::Toml),
+        "helm" => ("Chart.yaml", FileFormat::ChartYaml),
+        "dart" => ("pubspec.yaml", FileFormat::PubspecYaml),
+        "elixir" => ("mix.exs", FileFormat::MixExs),
+        "simple" => ("version.txt", FileFormat::Txt),
+        _ => return None,
+    };
+    Some(VersionedFile {
+        path: join(file),
+        format,
+        selector: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_ok(raw: &str) -> (Config, MigrationReport) {
+        build(raw).expect("valid release-please config")
+    }
+
+    #[test]
+    fn packages_map_to_ferrflow_packages_with_paths_and_files() {
+        let (cfg, _) = build_ok(
+            r#"{"packages": {
+                "packages/api": {"release-type": "node", "package-name": "@acme/api"},
+                "crates/core": {"release-type": "rust"}
+            }}"#,
+        );
+        assert_eq!(cfg.packages.len(), 2);
+        let api = cfg
+            .packages
+            .iter()
+            .find(|p| p.path == "packages/api")
+            .unwrap();
+        assert_eq!(api.name, "@acme/api");
+        assert_eq!(api.versioned_files[0].path, "packages/api/package.json");
+        assert!(matches!(api.versioned_files[0].format, FileFormat::Json));
+        let core = cfg
+            .packages
+            .iter()
+            .find(|p| p.path == "crates/core")
+            .unwrap();
+        assert_eq!(core.name, "core");
+        assert_eq!(core.versioned_files[0].path, "crates/core/Cargo.toml");
+        assert!(matches!(core.versioned_files[0].format, FileFormat::Toml));
+    }
+
+    #[test]
+    fn root_package_uses_bare_file_paths() {
+        let (cfg, _) = build_ok(r#"{"packages": {".": {"release-type": "python"}}}"#);
+        assert_eq!(cfg.packages[0].versioned_files[0].path, "pyproject.toml");
+        assert!(matches!(
+            cfg.packages[0].versioned_files[0].format,
+            FileFormat::Toml
+        ));
+    }
+
+    #[test]
+    fn default_release_type_applies_to_entries_without_one() {
+        let (cfg, _) = build_ok(r#"{"release-type": "node", "packages": {"apps/web": {}}}"#);
+        assert_eq!(
+            cfg.packages[0].versioned_files[0].path,
+            "apps/web/package.json"
+        );
+    }
+
+    #[test]
+    fn component_in_tag_sets_a_scoped_template() {
+        let (cfg, report) = build_ok(
+            r#"{"include-component-in-tag": true, "tag-separator": "-", "packages": {".": {"release-type": "node"}}}"#,
+        );
+        assert_eq!(
+            cfg.workspace.tag_template.as_deref(),
+            Some("{name}-v{version}")
+        );
+        assert!(report.mapped.iter().any(|m| m.contains("tagTemplate")));
+    }
+
+    #[test]
+    fn release_please_uses_pr_mode() {
+        let (cfg, _) = build_ok(r#"{"packages": {".": {"release-type": "node"}}}"#);
+        assert!(matches!(
+            cfg.workspace.release_commit_mode,
+            ReleaseCommitMode::Pr
+        ));
+    }
+
+    #[test]
+    fn changelog_path_maps_to_the_package_changelog() {
+        let (cfg, _) = build_ok(
+            r#"{"packages": {".": {"release-type": "node", "changelog-path": "docs/CHANGES.md"}}}"#,
+        );
+        assert_eq!(
+            cfg.packages[0].changelog.as_deref(),
+            Some("docs/CHANGES.md")
+        );
+    }
+
+    #[test]
+    fn unmappable_release_type_warns_and_leaves_files_empty() {
+        // `go` versions from tags — there's no in-repo version file to bump.
+        let (cfg, report) = build_ok(r#"{"packages": {".": {"release-type": "go"}}}"#);
+        assert!(cfg.packages[0].versioned_files.is_empty());
+        assert!(report.warnings.iter().any(|w| w.contains("go")));
+    }
+
+    #[test]
+    fn separate_pull_requests_warns() {
+        let (_, report) = build_ok(
+            r#"{"separate-pull-requests": true, "packages": {".": {"release-type": "node"}}}"#,
+        );
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|w| w.contains("separate-pull-requests"))
+        );
+    }
+
+    #[test]
+    fn empty_packages_scaffolds_a_root_package_and_warns() {
+        let (cfg, report) = build_ok(r#"{"release-type": "node"}"#);
+        assert_eq!(cfg.packages.len(), 1);
+        assert_eq!(cfg.packages[0].path, ".");
+        assert!(report.warnings.iter().any(|w| w.contains("no `packages`")));
+    }
+
+    #[test]
+    fn malformed_json_is_an_error() {
+        assert!(build("{ not json").is_err());
+    }
+}

--- a/src/config/migrate/standard_version.rs
+++ b/src/config/migrate/standard_version.rs
@@ -1,0 +1,293 @@
+use anyhow::Result;
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+use crate::config::Config;
+use crate::config::package::{FileFormat, PackageConfig, VersionedFile};
+use crate::config::workspace::WorkspaceConfig;
+use crate::error_code::{self, ErrorCodeExt};
+
+use super::{MigrationReport, Source, write_and_report};
+
+pub(super) const CONFIG_FILES: &[&str] = &[".versionrc", ".versionrc.json"];
+const UNSUPPORTED_FILES: &[&str] = &[".versionrc.js", ".versionrc.cjs"];
+
+pub(super) fn detect() -> Option<PathBuf> {
+    CONFIG_FILES.iter().map(PathBuf::from).find(|p| p.exists())
+}
+
+pub(super) fn run() -> Result<()> {
+    if let Some(js) = UNSUPPORTED_FILES.iter().find(|f| Path::new(f).exists()) {
+        return Err(anyhow::anyhow!(
+            "found {js}, but ferrflow can only migrate JSON `.versionrc`. Inline the config as \
+             JSON in `.versionrc.json` and rerun."
+        ))
+        .error_code(error_code::CONFIG_INVALID_JSON);
+    }
+    let path = detect().ok_or_else(|| anyhow::anyhow!("no .versionrc found"))?;
+    let raw = std::fs::read_to_string(&path)
+        .map_err(|e| anyhow::anyhow!("could not read {}: {e}", path.display()))?;
+    let (config, report) = build(&raw)?;
+    write_and_report(Source::StandardVersion, &path, &config, &report)
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct VersionRc {
+    #[serde(default, rename = "tagPrefix")]
+    tag_prefix: Option<String>,
+    #[serde(default, rename = "bumpFiles")]
+    bump_files: Vec<BumpFile>,
+    #[serde(default, rename = "packageFiles")]
+    package_files: Vec<BumpFile>,
+    #[serde(default)]
+    types: Option<serde_json::Value>,
+    #[serde(default)]
+    skip: Option<Skip>,
+    #[serde(default, rename = "releaseCommitMessageFormat")]
+    release_commit_message_format: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BumpFile {
+    filename: String,
+    #[serde(default, rename = "type")]
+    type_hint: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct Skip {
+    #[serde(default)]
+    tag: bool,
+    #[serde(default)]
+    changelog: bool,
+}
+
+pub(super) fn build(raw: &str) -> Result<(Config, MigrationReport)> {
+    let rc: VersionRc = json5::from_str(raw)
+        .map_err(|e| anyhow::anyhow!("could not parse .versionrc as JSON: {e}"))
+        .error_code(error_code::CONFIG_INVALID_JSON)?;
+
+    let mut report = MigrationReport::default();
+    let mut workspace = WorkspaceConfig::default();
+
+    if let Some(prefix) = &rc.tag_prefix {
+        let template = format!("{prefix}{{version}}");
+        workspace.tag_template = Some(template.clone());
+        report
+            .mapped
+            .push(format!("tagPrefix → tagTemplate {template}"));
+    }
+
+    // packageFiles are read for the current version, bumpFiles are written;
+    // ferrflow's versionedFiles do both, so union them (bumpFiles win on dupes).
+    let mut versioned_files: Vec<VersionedFile> = Vec::new();
+    let mut seen: Vec<String> = Vec::new();
+    for bf in rc.bump_files.iter().chain(rc.package_files.iter()) {
+        if seen.contains(&bf.filename) {
+            continue;
+        }
+        seen.push(bf.filename.clone());
+        match format_for(bf.type_hint.as_deref(), &bf.filename) {
+            Some(format) => {
+                report
+                    .mapped
+                    .push(format!("version file {} → versionedFiles", bf.filename));
+                versioned_files.push(VersionedFile {
+                    path: bf.filename.clone(),
+                    format,
+                    selector: None,
+                });
+            }
+            None => report.warnings.push(format!(
+                "version file {} has an unrecognised type — add it to `versionedFiles` by hand.",
+                bf.filename
+            )),
+        }
+    }
+    if versioned_files.is_empty() {
+        versioned_files.push(VersionedFile {
+            path: "package.json".to_string(),
+            format: FileFormat::Json,
+            selector: None,
+        });
+        report
+            .mapped
+            .push("no bumpFiles → defaulted to package.json".to_string());
+    }
+
+    if rc.types.is_some() {
+        report.warnings.push(
+            "custom changelog `types` don't map — ferrflow generates changelog sections from \
+             conventional-commit types with its own layout."
+                .to_string(),
+        );
+    }
+    if let Some(skip) = &rc.skip {
+        if skip.tag {
+            report.warnings.push(
+                "skip.tag isn't supported — ferrflow always creates the release tag.".to_string(),
+            );
+        }
+        if skip.changelog {
+            report.ignored.push(
+                "skip.changelog — omit the package `changelog` field to skip changelog generation."
+                    .to_string(),
+            );
+        }
+    }
+    if rc.release_commit_message_format.is_some() {
+        report.ignored.push(
+            "releaseCommitMessageFormat — ferrflow uses a fixed `chore(release):` commit message."
+                .to_string(),
+        );
+    }
+
+    let package = PackageConfig {
+        name: super::default_package_name(),
+        path: ".".to_string(),
+        versioned_files,
+        changelog: Some("CHANGELOG.md".to_string()),
+        shared_paths: Vec::new(),
+        depends_on: vec![],
+        versioning: None,
+        tag_template: None,
+        hooks: None,
+        floating_tags: None,
+        publishers: vec![],
+        update_lockfiles: None,
+    };
+
+    report.warnings.push(
+        "standard-version is single-package; scaffolded one package. Add more for a monorepo."
+            .to_string(),
+    );
+
+    Ok((
+        Config {
+            workspace,
+            packages: vec![package],
+        },
+        report,
+    ))
+}
+
+fn format_for(type_hint: Option<&str>, filename: &str) -> Option<FileFormat> {
+    if let Some(t) = type_hint {
+        match t {
+            "json" => return Some(FileFormat::Json),
+            "plain-text" => return Some(FileFormat::Txt),
+            _ => {}
+        }
+    }
+    let lower = filename.to_ascii_lowercase();
+    if lower.ends_with(".json") {
+        Some(FileFormat::Json)
+    } else if lower.ends_with(".toml") {
+        Some(FileFormat::Toml)
+    } else if lower.ends_with(".txt") || lower == "version" {
+        Some(FileFormat::Txt)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_ok(raw: &str) -> (Config, MigrationReport) {
+        build(raw).expect("valid .versionrc")
+    }
+
+    #[test]
+    fn tag_prefix_becomes_a_tag_template() {
+        let (cfg, _) = build_ok(r#"{"tagPrefix": "release-"}"#);
+        assert_eq!(
+            cfg.workspace.tag_template.as_deref(),
+            Some("release-{version}")
+        );
+    }
+
+    #[test]
+    fn bump_files_map_to_versioned_files_with_types() {
+        let (cfg, _) = build_ok(
+            r#"{"bumpFiles": [
+                {"filename": "package.json", "type": "json"},
+                {"filename": "VERSION", "type": "plain-text"}
+            ]}"#,
+        );
+        let paths: Vec<&str> = cfg.packages[0]
+            .versioned_files
+            .iter()
+            .map(|v| v.path.as_str())
+            .collect();
+        assert_eq!(paths, vec!["package.json", "VERSION"]);
+        assert!(matches!(
+            cfg.packages[0].versioned_files[1].format,
+            FileFormat::Txt
+        ));
+    }
+
+    #[test]
+    fn package_files_and_bump_files_are_deduped() {
+        let (cfg, _) = build_ok(
+            r#"{
+                "packageFiles": [{"filename": "package.json", "type": "json"}],
+                "bumpFiles": [{"filename": "package.json", "type": "json"}, {"filename": "manifest.json", "type": "json"}]
+            }"#,
+        );
+        assert_eq!(cfg.packages[0].versioned_files.len(), 2);
+    }
+
+    #[test]
+    fn format_inferred_from_extension_when_type_absent() {
+        let (cfg, _) = build_ok(r#"{"bumpFiles": [{"filename": "Cargo.toml"}]}"#);
+        assert!(matches!(
+            cfg.packages[0].versioned_files[0].format,
+            FileFormat::Toml
+        ));
+    }
+
+    #[test]
+    fn no_bump_files_defaults_to_package_json() {
+        let (cfg, _) = build_ok("{}");
+        assert_eq!(cfg.packages[0].versioned_files[0].path, "package.json");
+    }
+
+    #[test]
+    fn custom_types_warn() {
+        let (_, report) = build_ok(r#"{"types": [{"type": "feat", "section": "Features"}]}"#);
+        assert!(report.warnings.iter().any(|w| w.contains("types")));
+    }
+
+    #[test]
+    fn skip_tag_warns() {
+        let (_, report) = build_ok(r#"{"skip": {"tag": true}}"#);
+        assert!(report.warnings.iter().any(|w| w.contains("skip.tag")));
+    }
+
+    #[test]
+    fn release_commit_message_format_is_reported() {
+        let (_, report) = build_ok(r#"{"releaseCommitMessageFormat": "chore: {{currentTag}}"}"#);
+        assert!(
+            report
+                .ignored
+                .iter()
+                .any(|i| i.contains("releaseCommitMessageFormat"))
+        );
+    }
+
+    #[test]
+    fn unrecognised_file_type_warns_and_is_skipped() {
+        let (cfg, report) =
+            build_ok(r#"{"bumpFiles": [{"filename": "weird.xyz", "type": "mystery"}]}"#);
+        // falls back to the package.json default since nothing mapped
+        assert_eq!(cfg.packages[0].versioned_files[0].path, "package.json");
+        assert!(report.warnings.iter().any(|w| w.contains("weird.xyz")));
+    }
+
+    #[test]
+    fn malformed_json_is_an_error() {
+        assert!(build("{ not json").is_err());
+    }
+}

--- a/src/error_code.rs
+++ b/src/error_code.rs
@@ -112,6 +112,10 @@ pub const GIT_PUSH_VERIFY_FAILED: ErrorCode = ErrorCode(2009);
 pub const GIT_REMOTE_BRANCH_NOT_FOUND: ErrorCode = ErrorCode(2010);
 #[allow(dead_code)]
 pub const GIT_LOCKED: ErrorCode = ErrorCode(2011);
+#[allow(dead_code)]
+pub const GIT_FORCE_PUSH_BRANCH: ErrorCode = ErrorCode(2012);
+#[allow(dead_code)]
+pub const GIT_INSPECT_RELEASE_BRANCH: ErrorCode = ErrorCode(2013);
 
 #[allow(dead_code)]
 pub const GITHUB_CREATE_RELEASE: ErrorCode = ErrorCode(3001);
@@ -133,6 +137,10 @@ pub const GITHUB_AUTO_MERGE: ErrorCode = ErrorCode(3008);
 pub const GITHUB_GRAPHQL_PARSE: ErrorCode = ErrorCode(3009);
 #[allow(dead_code)]
 pub const GITHUB_AUTO_MERGE_FAILED: ErrorCode = ErrorCode(3010);
+#[allow(dead_code)]
+pub const GITHUB_FIND_PR: ErrorCode = ErrorCode(3011);
+#[allow(dead_code)]
+pub const GITHUB_UPDATE_PR: ErrorCode = ErrorCode(3012);
 
 #[allow(dead_code)]
 pub const GITLAB_CREATE_RELEASE: ErrorCode = ErrorCode(3101);
@@ -144,6 +152,10 @@ pub const GITLAB_PARSE_MR: ErrorCode = ErrorCode(3103);
 pub const GITLAB_MR_MISSING_FIELD: ErrorCode = ErrorCode(3104);
 #[allow(dead_code)]
 pub const GITLAB_MERGE_MR: ErrorCode = ErrorCode(3105);
+#[allow(dead_code)]
+pub const GITLAB_FIND_MR: ErrorCode = ErrorCode(3106);
+#[allow(dead_code)]
+pub const GITLAB_UPDATE_MR: ErrorCode = ErrorCode(3107);
 
 #[allow(dead_code)]
 pub const GITEA_CREATE_RELEASE: ErrorCode = ErrorCode(3201);

--- a/src/forge/bitbucket.rs
+++ b/src/forge/bitbucket.rs
@@ -96,6 +96,19 @@ impl Forge for BitbucketForge {
     fn update_comment(&self, _pr_id: u64, _comment_id: u64, _body: &str) -> Result<()> {
         bail!("{PR_UNSUPPORTED}")
     }
+
+    fn find_open_pr(&self, _head: &str, _base: &str) -> Result<Option<u64>> {
+        Ok(None)
+    }
+
+    fn update_merge_request(
+        &self,
+        _id: u64,
+        _title: &str,
+        _body: &str,
+    ) -> Result<MergeRequestResult> {
+        bail!("{PR_UNSUPPORTED}")
+    }
 }
 
 fn tag_html_url(response: &serde_json::Value) -> Option<String> {

--- a/src/forge/gitea.rs
+++ b/src/forge/gitea.rs
@@ -187,6 +187,22 @@ impl Forge for GiteaForge {
             .with_context(|| "Failed to update issue comment")?;
         Ok(())
     }
+
+    fn find_open_pr(&self, _head: &str, _base: &str) -> Result<Option<u64>> {
+        Ok(None)
+    }
+
+    fn update_merge_request(
+        &self,
+        _id: u64,
+        _title: &str,
+        _body: &str,
+    ) -> Result<MergeRequestResult> {
+        anyhow::bail!(
+            "Pull-request mode is not yet supported on Gitea/Forgejo. \
+             FerrFlow can create releases; PR-based release flow is tracked in FerrLabs/FerrFlow#499."
+        )
+    }
 }
 
 #[cfg(test)]

--- a/src/forge/github.rs
+++ b/src/forge/github.rs
@@ -279,6 +279,62 @@ impl Forge for GitHubForge {
             .with_context(|| "Failed to update PR comment")?;
         Ok(())
     }
+
+    fn find_open_pr(&self, head: &str, base: &str) -> Result<Option<u64>> {
+        let owner = self.slug.split('/').next().unwrap_or_default();
+        let url = format!(
+            "{}/repos/{}/pulls?state=open&head={}:{}&base={}",
+            self.api_base, self.slug, owner, head, base
+        );
+        let response: serde_json::Value = self
+            .agent
+            .get(&url)
+            .header("Authorization", &format!("Bearer {}", self.token))
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .header("User-Agent", "ferrflow")
+            .call()
+            .with_context(|| format!("Failed to list open PRs for {head}"))
+            .error_code(error_code::GITHUB_FIND_PR)?
+            .body_mut()
+            .read_json()
+            .with_context(|| "Failed to parse PR list response")
+            .error_code(error_code::GITHUB_PARSE_PR)?;
+
+        Ok(response
+            .as_array()
+            .and_then(|prs| prs.first())
+            .and_then(|pr| pr["number"].as_u64()))
+    }
+
+    fn update_merge_request(&self, id: u64, title: &str, body: &str) -> Result<MergeRequestResult> {
+        let url = format!("{}/repos/{}/pulls/{}", self.api_base, self.slug, id);
+        let response: serde_json::Value = self
+            .agent
+            .patch(&url)
+            .header("Authorization", &format!("Bearer {}", self.token))
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .header("User-Agent", "ferrflow")
+            .send_json(serde_json::json!({ "title": title, "body": body }))
+            .with_context(|| format!("Failed to update PR #{id}"))
+            .error_code(error_code::GITHUB_UPDATE_PR)?
+            .body_mut()
+            .read_json()
+            .with_context(|| "Failed to parse PR update response")
+            .error_code(error_code::GITHUB_PARSE_PR)?;
+
+        let node_id = response["node_id"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("PR response missing node_id field"))
+            .error_code(error_code::GITHUB_PR_MISSING_FIELD)?
+            .to_string();
+
+        Ok(MergeRequestResult {
+            id,
+            auto_merge_key: node_id,
+        })
+    }
 }
 
 #[cfg(test)]

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -250,6 +250,48 @@ impl Forge for GitLabForge {
             .with_context(|| "Failed to update MR note")?;
         Ok(())
     }
+
+    fn find_open_pr(&self, head: &str, base: &str) -> Result<Option<u64>> {
+        let project = self.encoded_project_id();
+        let url = format!(
+            "{}/projects/{project}/merge_requests?state=opened&source_branch={head}&target_branch={base}",
+            self.api_base
+        );
+        let response: serde_json::Value = self
+            .agent
+            .get(&url)
+            .header("PRIVATE-TOKEN", &self.token)
+            .header("User-Agent", "ferrflow")
+            .call()
+            .with_context(|| format!("Failed to list open MRs for {head}"))
+            .error_code(error_code::GITLAB_FIND_MR)?
+            .body_mut()
+            .read_json()
+            .with_context(|| "Failed to parse MR list response")
+            .error_code(error_code::GITLAB_PARSE_MR)?;
+
+        Ok(response
+            .as_array()
+            .and_then(|mrs| mrs.first())
+            .and_then(|mr| mr["iid"].as_u64()))
+    }
+
+    fn update_merge_request(&self, id: u64, title: &str, body: &str) -> Result<MergeRequestResult> {
+        let project = self.encoded_project_id();
+        let url = format!("{}/projects/{project}/merge_requests/{id}", self.api_base);
+        self.agent
+            .put(&url)
+            .header("PRIVATE-TOKEN", &self.token)
+            .header("User-Agent", "ferrflow")
+            .send_json(serde_json::json!({ "title": title, "description": body }))
+            .with_context(|| format!("Failed to update MR !{id}"))
+            .error_code(error_code::GITLAB_UPDATE_MR)?;
+
+        Ok(MergeRequestResult {
+            id,
+            auto_merge_key: id.to_string(),
+        })
+    }
 }
 
 #[cfg(test)]

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -49,6 +49,10 @@ pub trait Forge: Send + Sync {
     fn create_comment(&self, pr_id: u64, body: &str) -> Result<()>;
 
     fn update_comment(&self, pr_id: u64, comment_id: u64, body: &str) -> Result<()>;
+
+    fn find_open_pr(&self, head: &str, base: &str) -> Result<Option<u64>>;
+
+    fn update_merge_request(&self, id: u64, title: &str, body: &str) -> Result<MergeRequestResult>;
 }
 
 pub fn detect_pr_number() -> Option<u64> {

--- a/src/git/commits.rs
+++ b/src/git/commits.rs
@@ -127,8 +127,12 @@ pub fn create_branch_and_commits(
         .trim()
         .to_string();
 
-    run_git(workdir, &["branch", branch_name])
-        .with_context(|| format!("git branch {branch_name} failed"))?;
+    // `-f` so a persistent release branch left over from a prior run in
+    // the same checkout is reset to the fresh release commit rather than
+    // failing on "branch already exists" (#703). Safe: the release branch
+    // is never the checked-out branch.
+    run_git(workdir, &["branch", "-f", branch_name])
+        .with_context(|| format!("git branch -f {branch_name} failed"))?;
 
     for (files, message) in commits {
         let mut add_args: Vec<&str> = vec!["add", "--"];

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -26,7 +26,8 @@ pub use diff::{get_changed_files, get_changed_files_since_oid, get_changed_files
 pub use fetch::fetch_tags;
 #[allow(unused_imports)]
 pub use push::{
-    force_push_tags, push, push_branch, push_tags, reset_branch_to_remote, verify_remote_branch,
+    force_push_branch, force_push_tags, push, push_tags, release_branch_foreign_commit,
+    reset_branch_to_remote, verify_remote_branch,
 };
 pub use repo::{Repository, get_repo_root, open_repo, resolve_current_branch};
 pub use retry::is_push_rejected_error;

--- a/src/git/push.rs
+++ b/src/git/push.rs
@@ -155,10 +155,128 @@ fn resolve_push_source(repo: &Repository, branch: &str) -> String {
     }
 }
 
-pub fn push_branch(repo: &Repository, remote_name: &str, branch: &str) -> Result<()> {
+// Overwrite the remote branch with the local one. Used by the persistent
+// release PR (#703): each run rebuilds the same release branch from the
+// fresh release commit and force-pushes it, so the open PR updates in place
+// instead of a new branch/PR being opened per version.
+pub fn force_push_branch(repo: &Repository, remote_name: &str, branch: &str) -> Result<()> {
     super::validate::ensure_safe_refname_fragment(remote_name, "remote name")?;
     super::validate::ensure_safe_refname_fragment(branch, "branch name")?;
-    try_push_branch(repo, remote_name, branch)
+    retry_transient(&format!("force-push branch '{branch}'"), || {
+        try_force_push_branch_once(repo, remote_name, branch)
+    })
+}
+
+fn try_force_push_branch_once(repo: &Repository, remote_name: &str, branch: &str) -> Result<()> {
+    let workdir = repo
+        .workdir()
+        .ok_or_else(|| anyhow!("bare repos are not supported"))?;
+    let push_url = get_remote_url(repo, remote_name)
+        .ok_or_else(|| anyhow!("Remote '{remote_name}' has no URL"))?;
+    let source = resolve_push_source(repo, branch);
+    // A leading '+' on the refspec forces the update.
+    let refspec = format!("+{source}:refs/heads/{branch}");
+
+    let mut cmd = std::process::Command::new("git");
+    cmd.current_dir(workdir);
+    configure_git_command(&mut cmd, &push_url);
+    cmd.arg("push").arg(&push_url).arg(&refspec);
+
+    let output = cmd
+        .output()
+        .with_context(|| format!("spawn `git push --force` for branch '{branch}' failed"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let detail = format!("{stdout}{stderr}").trim().to_string();
+        return Err(anyhow!("Failed to force-push branch '{branch}': {detail}"))
+            .error_code(error_code::GIT_FORCE_PUSH_BRANCH);
+    }
+    Ok(())
+}
+
+// SAFETY GUARD for the persistent release PR: before force-pushing the
+// release branch we make sure we won't clobber work a human pushed onto it.
+// Returns the subject of the first commit on the remote release branch (not
+// on `base`) that FerrFlow didn't author (i.e. isn't a `chore(release):`
+// commit), or None when the branch is absent or holds only release commits.
+pub fn release_branch_foreign_commit(
+    repo: &Repository,
+    remote_name: &str,
+    branch: &str,
+    base: &str,
+) -> Result<Option<String>> {
+    super::validate::ensure_safe_refname_fragment(remote_name, "remote name")?;
+    super::validate::ensure_safe_refname_fragment(branch, "branch name")?;
+    super::validate::ensure_safe_refname_fragment(base, "target branch")?;
+    let workdir = repo
+        .workdir()
+        .ok_or_else(|| anyhow!("bare repos are not supported"))?;
+    let url = get_remote_url(repo, remote_name)
+        .ok_or_else(|| anyhow!("Remote '{remote_name}' has no URL"))?;
+
+    let mut ls = std::process::Command::new("git");
+    ls.current_dir(workdir);
+    configure_git_command(&mut ls, &url);
+    ls.args([
+        "ls-remote",
+        "--heads",
+        &url,
+        &format!("refs/heads/{branch}"),
+    ]);
+    let ls_out = ls
+        .output()
+        .with_context(|| "spawn `git ls-remote` failed")
+        .error_code(error_code::GIT_INSPECT_RELEASE_BRANCH)?;
+    if !ls_out.status.success() {
+        return Err(anyhow!(
+            "git ls-remote failed: {}",
+            String::from_utf8_lossy(&ls_out.stderr).trim()
+        ))
+        .error_code(error_code::GIT_INSPECT_RELEASE_BRANCH);
+    }
+    // Branch not on the remote yet — nothing to clobber.
+    if String::from_utf8_lossy(&ls_out.stdout).trim().is_empty() {
+        return Ok(None);
+    }
+
+    let mut fetch = std::process::Command::new("git");
+    fetch.current_dir(workdir);
+    configure_git_command(&mut fetch, &url);
+    fetch.args(["fetch", "--quiet", &url, &format!("refs/heads/{branch}")]);
+    let fetch_out = fetch
+        .output()
+        .with_context(|| "spawn `git fetch` for release branch failed")
+        .error_code(error_code::GIT_INSPECT_RELEASE_BRANCH)?;
+    if !fetch_out.status.success() {
+        return Err(anyhow!(
+            "git fetch of release branch failed: {}",
+            String::from_utf8_lossy(&fetch_out.stderr).trim()
+        ))
+        .error_code(error_code::GIT_INSPECT_RELEASE_BRANCH);
+    }
+
+    let mut log = std::process::Command::new("git");
+    log.current_dir(workdir);
+    log.args(["log", "--format=%s", &format!("{base}..FETCH_HEAD")]);
+    let log_out = log
+        .output()
+        .with_context(|| "spawn `git log` for release branch failed")
+        .error_code(error_code::GIT_INSPECT_RELEASE_BRANCH)?;
+    if !log_out.status.success() {
+        return Err(anyhow!(
+            "git log of release branch failed: {}",
+            String::from_utf8_lossy(&log_out.stderr).trim()
+        ))
+        .error_code(error_code::GIT_INSPECT_RELEASE_BRANCH);
+    }
+    for subject in String::from_utf8_lossy(&log_out.stdout).lines() {
+        let subject = subject.trim();
+        if !subject.is_empty() && !subject.starts_with("chore(release):") {
+            return Ok(Some(subject.to_string()));
+        }
+    }
+    Ok(None)
 }
 
 pub fn push_tags(repo: &Repository, remote_name: &str, tags: &[&str]) -> Result<()> {

--- a/src/monorepo/run/execute.rs
+++ b/src/monorepo/run/execute.rs
@@ -8,8 +8,8 @@ use crate::config::{Config, ReleaseCommitMode, ReleaseCommitScope};
 use crate::error_code::{self, ErrorCodeExt};
 use crate::git::{
     Repository, create_branch_and_commit, create_branch_and_commits, create_commit,
-    create_or_move_tag, create_tag, force_push_tags, get_tag_message, push, push_branch, push_tags,
-    tag_exists,
+    create_or_move_tag, create_tag, force_push_branch, force_push_tags, get_tag_message, push,
+    push_tags, release_branch_foreign_commit, tag_exists,
 };
 use crate::hooks::{HookContext, HookPoint, resolve_hook, resolve_on_failure, run_hook};
 use crate::versioning::truncate_version;
@@ -180,6 +180,13 @@ fn run_pre_commit_hooks(plan: &mut ReleasePlan<'_>) -> Result<()> {
     Ok(())
 }
 
+fn release_branch_name(target_branch: &str) -> String {
+    // Namespaced under `ferrflow/` and scoped per target so there's exactly one
+    // long-lived release branch per target. Slashes in the target are flattened
+    // to keep it a single ref level (avoids git dir/file ref conflicts).
+    format!("ferrflow/release-{}", target_branch.replace('/', "-"))
+}
+
 fn run_commit_or_pr(
     plan: &mut ReleasePlan<'_>,
     mode: ReleaseCommitMode,
@@ -208,13 +215,33 @@ fn run_commit_or_pr(
             }
         }
         ReleaseCommitMode::Pr => {
-            let branch_name = format!(
-                "release/{}",
-                release_parts
-                    .first()
-                    .map(|s| s.replace(' ', "-"))
-                    .unwrap_or_else(|| "bump".to_string())
-            );
+            // One stable branch per target so the same PR is reused across
+            // commits instead of a new one opening per version (#703).
+            let branch_name = release_branch_name(plan.target_branch);
+            let remote = &plan.config.workspace.remote;
+
+            // Don't clobber commits a human pushed onto the release branch.
+            match release_branch_foreign_commit(plan.repo, remote, &branch_name, plan.target_branch)
+            {
+                Ok(Some(subject)) => {
+                    tracing::warn!(
+                        "{}",
+                        format!(
+                            "  Warning: release branch {branch_name} has a commit FerrFlow didn't \
+                             author (\"{subject}\"); leaving it and the existing release PR untouched."
+                        )
+                        .yellow()
+                    );
+                    return Ok(());
+                }
+                Ok(None) => {}
+                Err(err) => tracing::warn!(
+                    "{}",
+                    format!("  Warning: could not inspect release branch {branch_name}: {err}")
+                        .yellow()
+                ),
+            }
+
             if scope == ReleaseCommitScope::PerPackage && plan.tags_to_create.len() > 1 {
                 let commit_list: Vec<(Vec<&str>, String)> = plan
                     .tags_to_create
@@ -235,7 +262,9 @@ fn run_commit_or_pr(
             } else {
                 create_branch_and_commit(plan.repo, &branch_name, file_refs, commit_msg)?;
             }
-            push_branch(plan.repo, &plan.config.workspace.remote, &branch_name)?;
+            // Force-push: the branch is rebuilt from the fresh release commit
+            // every run, so the open PR updates in place.
+            force_push_branch(plan.repo, remote, &branch_name)?;
             plan.shared_outputs
                 .push(format!("✓ Pushed branch {}", branch_name.cyan()));
 
@@ -249,15 +278,42 @@ fn run_commit_or_pr(
                         .collect::<Vec<_>>()
                         .join("\n")
                 );
-                match forge_instance.create_merge_request(
-                    &branch_name,
-                    plan.target_branch,
-                    &pr_title,
-                    &pr_body,
-                ) {
+
+                let existing = match forge_instance.find_open_pr(&branch_name, plan.target_branch) {
+                    Ok(found) => found,
+                    Err(err) => {
+                        tracing::warn!(
+                            "{}",
+                            format!(
+                                "  Warning: could not look up existing {}: {err}",
+                                forge_instance.mr_noun()
+                            )
+                            .yellow()
+                        );
+                        None
+                    }
+                };
+
+                let (result, verb) = match existing {
+                    Some(id) => (
+                        forge_instance.update_merge_request(id, &pr_title, &pr_body),
+                        "Updated",
+                    ),
+                    None => (
+                        forge_instance.create_merge_request(
+                            &branch_name,
+                            plan.target_branch,
+                            &pr_title,
+                            &pr_body,
+                        ),
+                        "Created",
+                    ),
+                };
+
+                match result {
                     Ok(mr) => {
                         plan.shared_outputs.push(format!(
-                            "✓ Created {} #{}",
+                            "✓ {verb} {} #{}",
                             forge_instance.mr_noun(),
                             mr.id.to_string().cyan()
                         ));
@@ -278,7 +334,8 @@ fn run_commit_or_pr(
                     Err(err) => tracing::warn!(
                         "{}",
                         format!(
-                            "  Warning: failed to create {}: {err}",
+                            "  Warning: failed to {} {}: {err}",
+                            verb.to_lowercase(),
                             forge_instance.mr_noun()
                         )
                         .yellow()
@@ -768,6 +825,32 @@ mod tag_release_tests {
         fn update_comment(&self, _pr_id: u64, _comment_id: u64, _body: &str) -> Result<()> {
             unreachable!("not exercised by release-tag tests")
         }
+
+        fn find_open_pr(&self, _head: &str, _base: &str) -> Result<Option<u64>> {
+            unreachable!("not exercised by release-tag tests")
+        }
+
+        fn update_merge_request(
+            &self,
+            _id: u64,
+            _title: &str,
+            _body: &str,
+        ) -> Result<MergeRequestResult> {
+            unreachable!("not exercised by release-tag tests")
+        }
+    }
+
+    #[test]
+    fn release_branch_name_is_stable_and_target_scoped() {
+        assert_eq!(release_branch_name("main"), "ferrflow/release-main");
+        // The name must not depend on the version — that's what keeps one
+        // long-lived PR per target instead of a new one per release (#703).
+        assert_eq!(release_branch_name("main"), release_branch_name("main"));
+        // Slashes in the target are flattened to one ref level.
+        assert_eq!(
+            release_branch_name("release/beta"),
+            "ferrflow/release-release-beta"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #223

`ferrflow migrate` previously understood only semantic-release (`.releaserc`). This adds the other three sources the issue asked for, with auto-detection and `--from`:

- **changesets** (`.changeset/config.json`) — `baseBranch` → `branch`; `linked`/`fixed` → linked/fixed version groups; `access` / `updateInternalDependencies` reported; always warns that changesets versions from `.changeset/*.md` files while ferrflow versions from conventional commits, and that the monorepo packages must be listed.
- **release-please** (`release-please-config.json`) — the `packages` map → ferrflow packages (path, name, `release-type` → the right version file/format for node/rust/python/helm/dart/elixir/simple, warn otherwise); `include-component-in-tag` + `tag-separator` → `tagTemplate`; PR flow → `releaseCommitMode: pr`; `changelog-path` → per-package changelog.
- **standard-version** (`.versionrc`, `.versionrc.json`) — `tagPrefix` → `tagTemplate`; `bumpFiles`/`packageFiles` → `versionedFiles` (type or extension inferred); `types` / `skip` / `releaseCommitMessageFormat` reported.

Each converter emits the same **mapped / ignored / review-manually** report as semantic-release, and JS/YAML source configs are surfaced as unsupported rather than mis-parsed.

## Structure

`migrate.rs` stays the module root (shared dispatch, detection, report, the semantic-release converter); each new source is a cohesive sibling file (`migrate/changesets.rs`, `migrate/release_please.rs`, `migrate/standard_version.rs`) with its own tests. A shared `write_and_report` de-duplicates the write path.

## Tests

- 27 new unit tests on the pure `build()` converters (field mappings, warnings, edge cases, malformed input) — 961 in the suite, clippy `-D warnings` clean, wasm builds.
- End-to-end smoke for each source: real config → `ferrflow migrate` → the generated `ferrflow.json` parses and `ferrflow validate` is clean (standard-version, release-please with the referenced files present).

## Follow-ups (filed separately)

A few gaps are intentionally out of scope and tracked as their own issues — JS/YAML source configs, changesets workspace-package auto-discovery, and broader release-please release-type/plugin coverage. Linked in a comment on #223.