### PR TITLE
feat(migrate): read JS and YAML source configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,6 +647,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_norway",
  "sha2",
  "tempfile",
  "toml_edit",
@@ -2150,6 +2151,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2212,6 +2219,19 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
 ]
 
 [[package]]
@@ -2598,6 +2618,12 @@ checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ workspace = true
 
 [features]
 default = ["cli"]
-cli = ["dep:gix", "dep:gix-traverse", "dep:gix-diff", "dep:ureq", "dep:clap", "dep:clap_complete", "dep:colored", "dep:mimalloc", "dep:rayon", "dep:tracing-subscriber"]
+cli = ["dep:gix", "dep:gix-traverse", "dep:gix-diff", "dep:ureq", "dep:clap", "dep:clap_complete", "dep:colored", "dep:mimalloc", "dep:rayon", "dep:tracing-subscriber", "dep:serde_norway"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -55,6 +55,8 @@ gix = { version = "0.85", default-features = false, features = ["sha1", "max-per
 gix-traverse = { version = "0.59", optional = true }
 gix-diff = { version = "0.65", default-features = false, optional = true }
 ureq = { version = "3", features = ["json"], optional = true }
+# YAML source configs for `ferrflow migrate` (cli-only). Maintained serde_yaml fork.
+serde_norway = { version = "0.9", optional = true }
 sha2 = "0.11.0"
 hex = "0.4.3"
 # mimalloc: faster allocator for the CLI hot paths (TagIndex::build,

--- a/src/config/migrate.rs
+++ b/src/config/migrate.rs
@@ -36,17 +36,20 @@ impl Source {
     }
 }
 
-/// A `.releaserc` shape we can parse: JSON (or JSON5) content, whatever the
-/// filename. YAML `.releaserc` and JS `release.config.js` are surfaced as
-/// unsupported rather than mis-parsed.
-const SEMANTIC_RELEASE_JSON_FILES: &[&str] = &[".releaserc", ".releaserc.json"];
-const SEMANTIC_RELEASE_UNSUPPORTED_FILES: &[&str] = &[
+/// semantic-release config filenames (cosmiconfig for the `release` key), in
+/// preference order. JSON/JSON5 is read directly; `.js/.cjs/.mjs` is evaluated
+/// with node; `.yaml/.yml` is parsed as YAML — see [`read_source_as_json`].
+const SEMANTIC_RELEASE_FILES: &[&str] = &[
+    ".releaserc",
+    ".releaserc.json",
     ".releaserc.yaml",
     ".releaserc.yml",
     ".releaserc.js",
-    "release.config.js",
-    "release.config.mjs",
     ".releaserc.cjs",
+    ".releaserc.mjs",
+    "release.config.js",
+    "release.config.cjs",
+    "release.config.mjs",
 ];
 
 pub fn migrate(from: Option<Source>) -> Result<()> {
@@ -82,7 +85,7 @@ fn ensure_no_existing_config() -> Result<()> {
 }
 
 fn detect_source() -> Result<Source> {
-    if find_semantic_release_json().is_some() {
+    if find_semantic_release_config().is_some() {
         return Ok(Source::SemanticRelease);
     }
     if changesets::detect().is_some() {
@@ -94,20 +97,10 @@ fn detect_source() -> Result<Source> {
     if standard_version::detect().is_some() {
         return Ok(Source::StandardVersion);
     }
-    if let Some(f) = SEMANTIC_RELEASE_UNSUPPORTED_FILES
-        .iter()
-        .find(|f| Path::new(f).exists())
-    {
-        return Err(anyhow::anyhow!(
-            "found {f}, but ferrflow can only migrate JSON `.releaserc` for now. \
-             Convert it to `.releaserc.json` (or inline the config as JSON) and rerun."
-        ))
-        .error_code(error_code::CONFIG_INVALID_JSON);
-    }
     Err(anyhow::anyhow!(
         "no supported release-tool config found. Looked for {}, {}, {}, {}. \
          Pass --from to force a source.",
-        SEMANTIC_RELEASE_JSON_FILES.join(", "),
+        SEMANTIC_RELEASE_FILES.join(", "),
         changesets::CONFIG_FILE,
         release_please::CONFIG_FILE,
         standard_version::CONFIG_FILES.join(", "),
@@ -115,11 +108,87 @@ fn detect_source() -> Result<Source> {
     .error_code(error_code::CONFIG_NOT_FOUND)
 }
 
-fn find_semantic_release_json() -> Option<PathBuf> {
-    SEMANTIC_RELEASE_JSON_FILES
+fn find_semantic_release_config() -> Option<PathBuf> {
+    SEMANTIC_RELEASE_FILES
         .iter()
         .map(PathBuf::from)
         .find(|p| p.exists())
+}
+
+/// Read a release-tool config file and return a JSON string the JSON
+/// converters can parse. `.js/.cjs/.mjs` is evaluated with node, `.yaml/.yml`
+/// is parsed as YAML, and everything else (`.json`, `.json5`, extensionless)
+/// is handed straight to the json5-tolerant parsers.
+pub(super) fn read_source_as_json(path: &Path) -> Result<String> {
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    match ext.as_str() {
+        "js" | "cjs" | "mjs" => eval_js_to_json(path),
+        "yaml" | "yml" => yaml_to_json(&read_file(path)?),
+        _ => read_file(path),
+    }
+}
+
+fn read_file(path: &Path) -> Result<String> {
+    std::fs::read_to_string(path)
+        .map_err(|e| anyhow::anyhow!("could not read {}: {e}", path.display()))
+        .error_code(error_code::CONFIG_NOT_FOUND)
+}
+
+/// Evaluate a JS/TS release config to JSON by importing it with node and
+/// printing its resolved default export. Same trust model as evaluating a
+/// `ferrflow.js` config — it's the user's own repo, run locally.
+fn eval_js_to_json(path: &Path) -> Result<String> {
+    let file_url = super::loader_js::path_to_file_url(path)?;
+    let script = format!(
+        "const m = await import('{file_url}'); \
+         const cfg = m.default ?? m; \
+         const resolved = typeof cfg === 'function' ? await cfg() : cfg; \
+         process.stdout.write(JSON.stringify(resolved));"
+    );
+    let mut cmd = std::process::Command::new("node");
+    cmd.args(["--input-type=module", "-e", &script]);
+    if let Some(dir) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        cmd.current_dir(dir);
+    }
+    let output = cmd
+        .output()
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                anyhow::anyhow!(
+                    "migrating a JavaScript config requires Node.js, but 'node' was not found in \
+                     PATH. Install Node.js from https://nodejs.org/, or convert the config to JSON."
+                )
+            } else {
+                anyhow::anyhow!("failed to execute node: {e}")
+            }
+        })
+        .error_code(error_code::CONFIG_EVAL_NODE)?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow::anyhow!(
+            "could not evaluate {}:\n{}",
+            path.display(),
+            stderr.trim()
+        ))
+        .error_code(error_code::CONFIG_EVAL_FAILED);
+    }
+    String::from_utf8(output.stdout)
+        .map_err(|_| anyhow::anyhow!("{} produced invalid UTF-8", path.display()))
+        .error_code(error_code::CONFIG_INVALID_OUTPUT)
+}
+
+/// Convert a YAML config to a JSON string so the JSON converters can consume it.
+pub(super) fn yaml_to_json(raw: &str) -> Result<String> {
+    let value: serde_json::Value = serde_norway::from_str(raw)
+        .map_err(|e| anyhow::anyhow!("could not parse YAML config: {e}"))
+        .error_code(error_code::CONFIG_INVALID_JSON)?;
+    serde_json::to_string(&value)
+        .map_err(|e| anyhow::anyhow!("could not re-serialize YAML to JSON: {e}"))
+        .error_code(error_code::CONFIG_INVALID_JSON)
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -451,14 +520,13 @@ fn apply_exec_plugin(
 }
 
 fn migrate_semantic_release() -> Result<()> {
-    let path = find_semantic_release_json().ok_or_else(|| {
+    let path = find_semantic_release_config().ok_or_else(|| {
         anyhow::anyhow!(
-            "no JSON .releaserc found ({})",
-            SEMANTIC_RELEASE_JSON_FILES.join(", ")
+            "no semantic-release config found ({})",
+            SEMANTIC_RELEASE_FILES.join(", ")
         )
     })?;
-    let raw = std::fs::read_to_string(&path)
-        .map_err(|e| anyhow::anyhow!("could not read {}: {e}", path.display()))?;
+    let raw = read_source_as_json(&path)?;
 
     let (config, report) = build_config_from_releaserc(&raw)?;
     write_and_report(Source::SemanticRelease, &path, &config, &report)

--- a/src/config/migrate/standard_version.rs
+++ b/src/config/migrate/standard_version.rs
@@ -1,32 +1,30 @@
 use anyhow::Result;
 use serde::Deserialize;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use crate::config::Config;
 use crate::config::package::{FileFormat, PackageConfig, VersionedFile};
 use crate::config::workspace::WorkspaceConfig;
 use crate::error_code::{self, ErrorCodeExt};
 
-use super::{MigrationReport, Source, write_and_report};
+use super::{MigrationReport, Source, read_source_as_json, write_and_report};
 
-pub(super) const CONFIG_FILES: &[&str] = &[".versionrc", ".versionrc.json"];
-const UNSUPPORTED_FILES: &[&str] = &[".versionrc.js", ".versionrc.cjs"];
+pub(super) const CONFIG_FILES: &[&str] = &[
+    ".versionrc",
+    ".versionrc.json",
+    ".versionrc.yaml",
+    ".versionrc.yml",
+    ".versionrc.js",
+    ".versionrc.cjs",
+];
 
 pub(super) fn detect() -> Option<PathBuf> {
     CONFIG_FILES.iter().map(PathBuf::from).find(|p| p.exists())
 }
 
 pub(super) fn run() -> Result<()> {
-    if let Some(js) = UNSUPPORTED_FILES.iter().find(|f| Path::new(f).exists()) {
-        return Err(anyhow::anyhow!(
-            "found {js}, but ferrflow can only migrate JSON `.versionrc`. Inline the config as \
-             JSON in `.versionrc.json` and rerun."
-        ))
-        .error_code(error_code::CONFIG_INVALID_JSON);
-    }
     let path = detect().ok_or_else(|| anyhow::anyhow!("no .versionrc found"))?;
-    let raw = std::fs::read_to_string(&path)
-        .map_err(|e| anyhow::anyhow!("could not read {}: {e}", path.display()))?;
+    let raw = read_source_as_json(&path)?;
     let (config, report) = build(&raw)?;
     write_and_report(Source::StandardVersion, &path, &config, &report)
 }

--- a/src/config/migrate/tests.rs
+++ b/src/config/migrate/tests.rs
@@ -205,3 +205,44 @@ fn json5_features_are_tolerated() {
 fn source_label_is_stable() {
     assert_eq!(Source::SemanticRelease.label(), "semantic-release");
 }
+
+// A YAML `.releaserc` converts to JSON that the existing converter accepts.
+#[test]
+fn yaml_config_converts_then_migrates() {
+    let yaml = "\
+tagFormat: \"v${version}\"
+branches:
+  - main
+  - name: beta
+    prerelease: true
+plugins:
+  - \"@semantic-release/github\"
+";
+    let json = yaml_to_json(yaml).expect("yaml converts to json");
+    let (cfg, _) = build_config_from_releaserc(&json).expect("converted json is valid");
+    assert_eq!(cfg.workspace.tag_template.as_deref(), Some("v{{version}}"));
+    assert!(matches!(cfg.workspace.forge, ForgeKind::Github));
+    let beta = cfg
+        .workspace
+        .branches
+        .as_ref()
+        .unwrap()
+        .iter()
+        .find(|b| b.name == "beta")
+        .unwrap();
+    assert!(matches!(&beta.channel, ChannelValue::Named(c) if c == "beta"));
+}
+
+#[test]
+fn yaml_to_json_produces_parseable_json() {
+    let json = yaml_to_json("a: 1\nb: [x, y]\n").expect("valid yaml");
+    let value: serde_json::Value = serde_json::from_str(&json).expect("valid json out");
+    assert_eq!(value["a"], 1);
+    assert_eq!(value["b"][1], "y");
+}
+
+#[test]
+fn malformed_yaml_is_an_error() {
+    // An unclosed flow sequence is not valid YAML.
+    assert!(yaml_to_json("plugins: [unclosed").is_err());
+}

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -461,8 +461,16 @@ criteria = "safe-to-deploy"
 version = "0.103.13"
 criteria = "safe-to-deploy"
 
+[[exemptions.ryu]]
+version = "1.0.23"
+criteria = "safe-to-deploy"
+
 [[exemptions.scopeguard]]
 version = "1.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_norway]]
+version = "0.9.42"
 criteria = "safe-to-deploy"
 
 [[exemptions.sha1]]
@@ -575,6 +583,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.unicode-normalization]]
 version = "0.1.25"
+criteria = "safe-to-deploy"
+
+[[exemptions.unsafe-libyaml-norway]]
+version = "0.2.15"
 criteria = "safe-to-deploy"
 
 [[exemptions.untrusted]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -44,8 +44,8 @@ user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.anyhow]]
-version = "1.0.103"
-when = "2026-06-25"
+version = "1.0.104"
+when = "2026-07-18"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -58,8 +58,8 @@ user-login = "cuviper"
 user-name = "Josh Stone"
 
 [[publisher.bstr]]
-version = "1.12.3"
-when = "2026-06-25"
+version = "1.13.0"
+when = "2026-07-14"
 user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
@@ -72,8 +72,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.clap]]
-version = "4.6.2"
-when = "2026-07-15"
+version = "4.6.3"
+when = "2026-07-20"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
@@ -93,8 +93,8 @@ user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.clap_derive]]
-version = "4.6.1"
-when = "2026-04-15"
+version = "4.6.3"
+when = "2026-07-20"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
@@ -184,8 +184,8 @@ user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-date]]
-version = "0.15.5"
-when = "2026-06-22"
+version = "0.15.6"
+when = "2026-07-15"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
@@ -205,8 +205,8 @@ user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-error]]
-version = "0.2.4"
-when = "2026-05-26"
+version = "0.2.5"
+when = "2026-07-15"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
@@ -296,8 +296,8 @@ user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-path]]
-version = "0.12.1"
-when = "2026-05-26"
+version = "0.12.2"
+when = "2026-07-15"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
@@ -387,15 +387,15 @@ user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-url]]
-version = "0.36.1"
-when = "2026-05-26"
+version = "0.36.2"
+when = "2026-07-15"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-utils]]
-version = "0.3.3"
-when = "2026-05-26"
+version = "0.3.4"
+when = "2026-07-15"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
@@ -429,15 +429,15 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.jiff]]
-version = "0.2.32"
-when = "2026-07-09"
+version = "0.2.34"
+when = "2026-07-19"
 user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.jiff-static]]
-version = "0.2.32"
-when = "2026-07-09"
+version = "0.2.34"
+when = "2026-07-19"
 user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
@@ -457,8 +457,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.kstring]]
-version = "2.0.2"
-when = "2024-07-25"
+version = "2.0.4"
+when = "2026-07-17"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
@@ -478,8 +478,8 @@ user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.proc-macro2]]
-version = "1.0.106"
-when = "2026-01-21"
+version = "1.0.107"
+when = "2026-07-19"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -492,8 +492,8 @@ user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.quote]]
-version = "1.0.46"
-when = "2026-06-22"
+version = "1.0.47"
+when = "2026-07-19"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -555,29 +555,29 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.serde]]
-version = "1.0.228"
-when = "2025-09-27"
+version = "1.0.229"
+when = "2026-07-18"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.serde_core]]
-version = "1.0.228"
-when = "2025-09-27"
+version = "1.0.229"
+when = "2026-07-18"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.serde_derive]]
-version = "1.0.228"
-when = "2025-09-27"
+version = "1.0.229"
+when = "2026-07-18"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.serde_json]]
-version = "1.0.150"
-when = "2026-05-21"
+version = "1.0.151"
+when = "2026-07-20"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -590,22 +590,29 @@ user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.syn]]
-version = "2.0.118"
-when = "2026-06-16"
+version = "2.0.119"
+when = "2026-07-15"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.syn]]
+version = "3.0.2"
+when = "2026-07-20"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.thiserror]]
-version = "2.0.18"
-when = "2026-01-18"
+version = "2.0.19"
+when = "2026-07-18"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.thiserror-impl]]
-version = "2.0.18"
-when = "2026-01-18"
+version = "2.0.19"
+when = "2026-07-18"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -730,15 +737,15 @@ user-login = "kennykerr"
 user-name = "Kenny Kerr"
 
 [[publisher.winnow]]
-version = "1.0.3"
-when = "2026-05-14"
+version = "1.0.4"
+when = "2026-07-13"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.zmij]]
-version = "1.0.22"
-when = "2026-07-12"
+version = "1.0.23"
+when = "2026-07-13"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"


### PR DESCRIPTION
Closes #746

`ferrflow migrate` previously read only JSON source configs and surfaced JS/YAML as unsupported. Now it handles both, so migrating no longer requires converting your config to JSON first:

- **JavaScript** (`.releaserc.js` / `.cjs` / `.mjs`, `release.config.js` / `.cjs` / `.mjs`, `.versionrc.js` / `.cjs`) — evaluated with `node` (import the config, resolve a function export if there is one, print JSON). Same trust model as evaluating a `ferrflow.js` config: it's your own repo, run locally. If `node` isn't on PATH the error says so.
- **YAML** (`.releaserc.yaml` / `.yml`, `.versionrc.yaml` / `.yml`) — parsed with `serde_norway` (a maintained serde_yaml fork), converted to JSON, then fed to the existing converters.

A single `read_source_as_json(path)` helper dispatches on the extension; the per-tool converters are unchanged. `serde_norway` is a CLI-only optional dependency (behind the `cli` feature), so it doesn't touch the `ferrflow-wasm` build.

## Tests

- Unit tests on `yaml_to_json` (round-trips through the semantic-release converter, produces parseable JSON, errors on malformed YAML) — 964 in the suite, clippy `-D warnings` clean, wasm builds (without serde_norway).
- End-to-end smokes: a CJS `release.config.js`, a `.releaserc.yaml`, and a `.versionrc.js` each migrate to a correct `ferrflow.json` (tagTemplate, branches/channels, forge, hooks, versionedFiles).

Supply chain: `serde_norway` + `unsafe-libyaml-norway` + `ryu` added to `supply-chain/config.toml` exemptions (`cargo vet` green).

This closes the JS/YAML follow-up from #223. The remaining one is #747 (workspace package auto-discovery).