### PR TITLE
feat(cli): add diff command to compare two versions

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -116,6 +116,15 @@ pub enum Commands {
         #[arg(long, value_enum, default_value = "text")]
         output: OutputFormat,
     },
+    /// Compare two versions of a package: commits, bumps, files, and changelog
+    Diff {
+        /// `[package] <from>..<to>` — the version range (contains `..`), optionally preceded by a package name
+        #[arg(value_name = "SPEC", required = true, num_args = 1..=2)]
+        spec: Vec<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
     /// Print the current version of a package
     Version {
         /// Package name (required in monorepos, optional in single repos)
@@ -228,6 +237,7 @@ impl Commands {
             Commands::Changelog => "changelog",
             Commands::Init { .. } => "init",
             Commands::Status { .. } => "status",
+            Commands::Diff { .. } => "diff",
             Commands::Version { .. } => "version",
             Commands::Tag { .. } => "tag",
             Commands::Validate { .. } => "validate",
@@ -295,6 +305,9 @@ impl Cli {
             Commands::Init { format, manifest } => crate::config::init(format, manifest),
             Commands::Status { output } => {
                 crate::status::run(self.config.as_deref(), &output, timing)
+            }
+            Commands::Diff { spec, json } => {
+                crate::version_diff::run(&spec, json, self.config.as_deref())
             }
             Commands::Version { package, json } => {
                 crate::query::version(self.config.as_deref(), package.as_deref(), json)

--- a/src/error_code.rs
+++ b/src/error_code.rs
@@ -300,6 +300,12 @@ pub const HOOK_FAILED: ErrorCode = ErrorCode(6001);
 pub const QUERY_NO_PACKAGES: ErrorCode = ErrorCode(7001);
 #[allow(dead_code)]
 pub const QUERY_PACKAGE_NOT_FOUND: ErrorCode = ErrorCode(7002);
+#[allow(dead_code)]
+pub const DIFF_BAD_RANGE: ErrorCode = ErrorCode(7003);
+#[allow(dead_code)]
+pub const DIFF_PACKAGE_REQUIRED: ErrorCode = ErrorCode(7004);
+#[allow(dead_code)]
+pub const DIFF_ENDPOINT_UNRESOLVED: ErrorCode = ErrorCode(7005);
 
 #[allow(dead_code)]
 pub const MONOREPO_PACKAGE_NOT_FOUND: ErrorCode = ErrorCode(8001);

--- a/src/git/commits.rs
+++ b/src/git/commits.rs
@@ -72,6 +72,43 @@ pub fn get_commits_since_oid(
     Ok(commits)
 }
 
+/// Commits reachable from `to` but not `from` — the range `from..to`, newest
+/// first. Powers `ferrflow diff`, which enumerates what went into a version
+/// range.
+pub fn get_commits_between(
+    repo: &Repository,
+    from: ObjectId,
+    to: ObjectId,
+    skip_markers: &[String],
+) -> Result<Vec<GitLog>> {
+    let walk = repo
+        .rev_walk([to])
+        .use_commit_graph(true)
+        .sorting(Sorting::BreadthFirst)
+        .with_hidden([from])
+        .all()?;
+
+    let mut commits = Vec::new();
+    for info in walk {
+        let info = info?;
+        let Ok(commit) = repo.find_commit(info.id) else {
+            continue;
+        };
+        let Ok(raw) = commit.message_raw() else {
+            continue;
+        };
+        let message = String::from_utf8_lossy(raw).into_owned();
+        if subject_has_skip_marker(&message, skip_markers) {
+            continue;
+        }
+        commits.push(GitLog {
+            hash: info.id.to_string()[..8].to_string(),
+            message,
+        });
+    }
+    Ok(commits)
+}
+
 /// Returns true if the commit subject (first line) contains any of the
 /// configured skip markers, matched case-insensitively.
 ///

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -54,6 +54,19 @@ pub fn get_changed_files_since_oid(
     changed_paths_between(repo, last_tag_oid, head)
 }
 
+/// Paths changed between two arbitrary commits (`from..to`). Used by
+/// `ferrflow diff`.
+pub fn get_changed_files_between(
+    repo: &Repository,
+    from: ObjectId,
+    to: ObjectId,
+) -> Result<Vec<String>> {
+    if repo.workdir().is_none() {
+        return Ok(vec![]);
+    }
+    changed_paths_between(repo, Some(from), to)
+}
+
 fn changed_paths_between(
     repo: &Repository,
     from: Option<ObjectId>,

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -19,10 +19,13 @@ pub use commit_walk::CommitWalkCache;
 #[allow(unused_imports)]
 pub use commits::{
     GitLog, create_branch_and_commit, create_branch_and_commits, create_commit,
-    get_commits_since_last_stable_tag, get_commits_since_last_tag, get_commits_since_oid,
-    subject_has_skip_marker,
+    get_commits_between, get_commits_since_last_stable_tag, get_commits_since_last_tag,
+    get_commits_since_oid, subject_has_skip_marker,
 };
-pub use diff::{get_changed_files, get_changed_files_since_oid, get_changed_files_since_tag};
+pub use diff::{
+    get_changed_files, get_changed_files_between, get_changed_files_since_oid,
+    get_changed_files_since_tag,
+};
 pub use fetch::fetch_tags;
 #[allow(unused_imports)]
 pub use push::{
@@ -34,7 +37,7 @@ pub use retry::is_push_rejected_error;
 pub use tags::{
     TagIndex, build_head_ancestors, collect_all_tags, create_or_move_tag, create_tag,
     find_highest_semver_tag_with_cache, find_last_tag_name, find_last_tag_name_with_cache,
-    get_tag_message, tag_exists,
+    get_tag_message, resolve_tag_name_to_commit, tag_exists,
 };
 
 #[cfg(test)]

--- a/src/git/tags.rs
+++ b/src/git/tags.rs
@@ -182,6 +182,13 @@ fn resolve_tag_to_commit(repo: &Repository, oid: ObjectId) -> Option<ObjectId> {
     }
 }
 
+/// Resolve a tag name to the commit it points at, peeling annotated tags.
+/// Returns None when the tag doesn't exist or points at a non-commit.
+pub fn resolve_tag_name_to_commit(repo: &Repository, tag_name: &str) -> Option<ObjectId> {
+    let reference = repo.find_reference(&format!("refs/tags/{tag_name}")).ok()?;
+    resolve_tag_to_commit(repo, reference.id().detach())
+}
+
 fn is_reachable(
     repo: &Repository,
     head: ObjectId,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@ pub mod manifest;
 pub mod publishers;
 #[cfg(feature = "cli")]
 pub mod validate;
+#[cfg(feature = "cli")]
+pub mod version_diff;
 
 #[cfg(all(test, feature = "cli"))]
 pub mod test_utils {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod schema;
 mod status;
 mod timing;
 mod validate;
+mod version_diff;
 mod versioning;
 
 // Allocator swap for the CLI hot paths. The default system allocator

--- a/src/version_diff.rs
+++ b/src/version_diff.rs
@@ -1,0 +1,310 @@
+use anyhow::Result;
+use colored::{ColoredString, Colorize};
+use gix::ObjectId;
+use serde::Serialize;
+use std::path::Path;
+
+use crate::changelog::{ChangelogRender, build_section_with};
+use crate::config::{Config, PackageConfig, WorkspaceConfig};
+use crate::conventional_commits::{
+    BumpType, determine_bump, is_breaking, parse_header, parse_subject,
+};
+use crate::error_code::{self, ErrorCodeExt};
+use crate::git::{
+    get_changed_files_between, get_commits_between, get_remote_url, get_repo_root, open_repo,
+    resolve_tag_name_to_commit,
+};
+
+const MAX_FILES_SHOWN: usize = 40;
+
+pub fn run(spec: &[String], json: bool, config_path: Option<&Path>) -> Result<()> {
+    let (package, range) = parse_spec(spec)?;
+    let (from_ref, to_ref) = split_range(range)?;
+
+    let repo = open_repo(&std::env::current_dir()?)?;
+    let root = get_repo_root(&repo)?;
+    let config = Config::load(&root, config_path)?;
+    let pkg = resolve_package(&config, package)?;
+    let is_monorepo = config.is_monorepo();
+
+    let (from_oid, from_tag) =
+        resolve_endpoint(&repo, pkg, &config.workspace, is_monorepo, from_ref)?;
+    let (to_oid, to_tag) = resolve_endpoint(&repo, pkg, &config.workspace, is_monorepo, to_ref)?;
+
+    let skip = config.workspace.effective_commit_skip_markers();
+    let commits = get_commits_between(&repo, from_oid, to_oid, &skip)?;
+    let files = get_changed_files_between(&repo, from_oid, to_oid).unwrap_or_default();
+
+    let overall = commits
+        .iter()
+        .map(|c| determine_bump(&c.message))
+        .max()
+        .unwrap_or(BumpType::None);
+
+    let forge_base = config.workspace.changelog.as_ref().and_then(|cl| {
+        if cl.include_commit_links || cl.include_compare_link {
+            get_remote_url(&repo, &config.workspace.remote)
+                .as_deref()
+                .and_then(crate::forge::web_base_url)
+        } else {
+            None
+        }
+    });
+    let to_version = to_ref.trim_start_matches('v').to_string();
+    let render = ChangelogRender {
+        config: config.workspace.changelog.as_ref(),
+        forge_base,
+        last_tag: Some(from_tag.clone()),
+        new_tag: Some(to_tag.clone()),
+    };
+    let changelog = build_section_with(&to_version, &commits, &render);
+
+    if json {
+        print_json(pkg, from_ref, to_ref, overall, &commits, &files, &changelog)?;
+    } else {
+        print_human(pkg, from_ref, to_ref, overall, &commits, &files, &changelog);
+    }
+    Ok(())
+}
+
+fn parse_spec(spec: &[String]) -> Result<(Option<&str>, &str)> {
+    let range = spec
+        .iter()
+        .find(|s| s.contains(".."))
+        .map(String::as_str)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "expected a version range like `v1.0.0..v2.0.0`. Usage: ferrflow diff [package] <from>..<to>"
+            )
+        })
+        .error_code(error_code::DIFF_BAD_RANGE)?;
+    let package = spec.iter().find(|s| !s.contains("..")).map(String::as_str);
+    Ok((package, range))
+}
+
+fn split_range(range: &str) -> Result<(&str, &str)> {
+    range
+        .split_once("..")
+        .filter(|(from, to)| !from.is_empty() && !to.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("range must be `<from>..<to>`, both sides non-empty"))
+        .error_code(error_code::DIFF_BAD_RANGE)
+}
+
+fn resolve_package<'a>(config: &'a Config, name: Option<&str>) -> Result<&'a PackageConfig> {
+    if config.packages.is_empty() {
+        return Err(anyhow::anyhow!(
+            "No packages configured. Run `ferrflow init` to create a config."
+        ))
+        .error_code(error_code::QUERY_NO_PACKAGES);
+    }
+    match name {
+        Some(n) => config
+            .packages
+            .iter()
+            .find(|p| p.name == n)
+            .ok_or_else(|| anyhow::anyhow!("package '{n}' not found"))
+            .error_code(error_code::QUERY_PACKAGE_NOT_FOUND),
+        None if config.packages.len() == 1 => Ok(&config.packages[0]),
+        None => Err(anyhow::anyhow!(
+            "this is a monorepo — name the package: ferrflow diff <package> <from>..<to>"
+        ))
+        .error_code(error_code::DIFF_PACKAGE_REQUIRED),
+    }
+}
+
+/// Resolve a range endpoint to a commit. Tries the endpoint as a literal tag
+/// first (real tag / `v1.4.0` in a single-package repo), then as the package's
+/// tag for that version (`api@v1.4.0`).
+fn resolve_endpoint(
+    repo: &crate::git::Repository,
+    pkg: &PackageConfig,
+    workspace: &WorkspaceConfig,
+    is_monorepo: bool,
+    endpoint: &str,
+) -> Result<(ObjectId, String)> {
+    let version = endpoint.strip_prefix('v').unwrap_or(endpoint);
+    let candidates = [
+        endpoint.to_string(),
+        pkg.tag_for_version(workspace, is_monorepo, version),
+        pkg.tag_for_version(workspace, is_monorepo, endpoint),
+    ];
+    for cand in &candidates {
+        if let Some(oid) = resolve_tag_name_to_commit(repo, cand) {
+            return Ok((oid, cand.clone()));
+        }
+    }
+    Err(anyhow::anyhow!(
+        "could not resolve '{endpoint}' to a tag (tried: {}). Pass an existing tag name or version.",
+        candidates.join(", ")
+    ))
+    .error_code(error_code::DIFF_ENDPOINT_UNRESOLVED)
+}
+
+fn bump_label(bump: BumpType) -> ColoredString {
+    match bump {
+        BumpType::Major => "major".red().bold(),
+        BumpType::Minor => "minor".yellow(),
+        BumpType::Patch => "patch".cyan(),
+        BumpType::None => "none".dimmed(),
+    }
+}
+
+fn print_human(
+    pkg: &PackageConfig,
+    from: &str,
+    to: &str,
+    overall: BumpType,
+    commits: &[crate::git::GitLog],
+    files: &[String],
+    changelog: &str,
+) {
+    println!(
+        "{}  {} → {}  ({})\n",
+        pkg.name.bold(),
+        from.cyan(),
+        to.green().bold(),
+        bump_label(overall)
+    );
+
+    println!("{}", format!("Commits ({})", commits.len()).bold());
+    if commits.is_empty() {
+        println!("  {}", "(none)".dimmed());
+    }
+    for c in commits {
+        println!(
+            "  {:<5}  {}  {}",
+            bump_label(determine_bump(&c.message)),
+            c.hash.dimmed(),
+            parse_subject(&c.message)
+        );
+    }
+
+    let breaking: Vec<&crate::git::GitLog> =
+        commits.iter().filter(|c| is_breaking(&c.message)).collect();
+    if !breaking.is_empty() {
+        println!(
+            "\n{}",
+            format!("Breaking changes ({})", breaking.len())
+                .red()
+                .bold()
+        );
+        for c in &breaking {
+            println!("  {} {}", "!".red().bold(), parse_subject(&c.message));
+        }
+    }
+
+    println!("\n{}", format!("Files changed ({})", files.len()).bold());
+    for f in files.iter().take(MAX_FILES_SHOWN) {
+        println!("  {f}");
+    }
+    if files.len() > MAX_FILES_SHOWN {
+        println!(
+            "  {}",
+            format!("… and {} more", files.len() - MAX_FILES_SHOWN).dimmed()
+        );
+    }
+
+    println!("\n{}", "Changelog".bold());
+    for line in changelog.trim_end().lines() {
+        println!("  {line}");
+    }
+}
+
+#[derive(Serialize)]
+struct CommitJson {
+    hash: String,
+    subject: String,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    commit_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scope: Option<String>,
+    breaking: bool,
+    bump: String,
+}
+
+#[derive(Serialize)]
+struct DiffJson<'a> {
+    package: &'a str,
+    from: &'a str,
+    to: &'a str,
+    bump: String,
+    commits: Vec<CommitJson>,
+    breaking: Vec<String>,
+    files_changed: &'a [String],
+    changelog: &'a str,
+}
+
+fn print_json(
+    pkg: &PackageConfig,
+    from: &str,
+    to: &str,
+    overall: BumpType,
+    commits: &[crate::git::GitLog],
+    files: &[String],
+    changelog: &str,
+) -> Result<()> {
+    let commit_json: Vec<CommitJson> = commits
+        .iter()
+        .map(|c| {
+            let header = parse_header(&c.message);
+            CommitJson {
+                hash: c.hash.clone(),
+                subject: parse_subject(&c.message).to_string(),
+                commit_type: header.as_ref().map(|h| h.commit_type.to_string()),
+                scope: header.as_ref().and_then(|h| h.scope.map(str::to_string)),
+                breaking: is_breaking(&c.message),
+                bump: determine_bump(&c.message).to_string(),
+            }
+        })
+        .collect();
+    let breaking: Vec<String> = commits
+        .iter()
+        .filter(|c| is_breaking(&c.message))
+        .map(|c| parse_subject(&c.message).to_string())
+        .collect();
+
+    let out = DiffJson {
+        package: &pkg.name,
+        from,
+        to,
+        bump: overall.to_string(),
+        commits: commit_json,
+        breaking,
+        files_changed: files,
+        changelog,
+    };
+    println!("{}", serde_json::to_string_pretty(&out)?);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_spec_finds_range_and_optional_package() {
+        let two = vec!["api".to_string(), "v1.0.0..v2.0.0".to_string()];
+        assert_eq!(parse_spec(&two).unwrap(), (Some("api"), "v1.0.0..v2.0.0"));
+
+        let one = vec!["v1.0.0..v2.0.0".to_string()];
+        assert_eq!(parse_spec(&one).unwrap(), (None, "v1.0.0..v2.0.0"));
+
+        // package can be given after the range too
+        let rev = vec!["v1.0.0..v2.0.0".to_string(), "api".to_string()];
+        assert_eq!(parse_spec(&rev).unwrap(), (Some("api"), "v1.0.0..v2.0.0"));
+    }
+
+    #[test]
+    fn parse_spec_requires_a_range() {
+        let no_range = vec!["api".to_string(), "v1.0.0".to_string()];
+        assert!(parse_spec(&no_range).is_err());
+    }
+
+    #[test]
+    fn split_range_rejects_empty_sides() {
+        assert_eq!(split_range("v1.0.0..v2.0.0").unwrap(), ("v1.0.0", "v2.0.0"));
+        assert!(split_range("..v2.0.0").is_err());
+        assert!(split_range("v1.0.0..").is_err());
+        assert!(split_range("v1.0.0").is_err());
+    }
+}


### PR DESCRIPTION
Closes #222

Adds `ferrflow diff [package] <from>..<to>` — a detailed comparison of what went into a version range.

```bash
ferrflow diff v1.4.0..v1.6.0            # single-package repo
ferrflow diff api v1.4.0..v1.6.0        # monorepo: name the package
```

## Output

- **Header** — `<package>  <from> → <to>  (<overall bump>)`.
- **Commits** — every commit in the range with its individual bump (`major`/`minor`/`patch`/`none`).
- **Breaking changes** — highlighted separately (any `!` / `BREAKING CHANGE:` commit).
- **Files changed** — the aggregate file list for the range (capped at 40 with a "… and N more").
- **Changelog** — the section FerrFlow would generate for the range, using the repo's changelog config.

`--json` emits the same data as a structured object.

## Endpoint resolution

Each side of the range resolves to a commit by trying, in order: the literal string as a tag (a real tag, or `v1.4.0` in a single-package repo), then the package's tag for that version (`api@v1.4.0`). An unresolvable endpoint errors with the candidates it tried.

## Implementation

- New `version_diff` module (the existing `diff` module is the unified-diff util). Reuses `conventional_commits` (bump/breaking classification) and `build_section_with` (changelog rendering) — no new logic duplicated.
- Three small git helpers: `get_commits_between` / `get_changed_files_between` (range `from..to`) and `resolve_tag_name_to_commit` (peels annotated tags).

## Tests

- Unit tests on spec parsing (`[package] <range>` in any order, range required) and range splitting (rejects empty sides). 973 in the suite, clippy `-D warnings` clean, wasm builds (the command is CLI-only).
- Smoke on this repo: `ferrflow diff v5.40.0..v5.43.0` lists 8 commits with bumps, 33 changed files, and the rendered changelog; `--json` produces the structured form.

## Note

For a monorepo the range spans all commits between the two tags (not path-scoped to the named package) — correct for single-package repos and a useful window audit for monorepos. Path-scoping to the package could be a follow-up.