### PR TITLE
feat(validate): expose the validation core without the cli feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod conventional_commits;
 pub mod error_code;
 pub mod formats;
 pub mod prerelease;
+pub mod validate;
 pub mod versioning;
 
 #[cfg(feature = "cli")]
@@ -18,8 +19,6 @@ pub mod git;
 pub mod manifest;
 #[cfg(feature = "cli")]
 pub mod publishers;
-#[cfg(feature = "cli")]
-pub mod validate;
 #[cfg(feature = "cli")]
 pub mod version_diff;
 

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -1,28 +1,36 @@
-use anyhow::Result;
+use std::collections::BTreeMap;
 use std::path::Path;
 
+use crate::config::Config;
+
+#[cfg(feature = "cli")]
 use crate::error_code::{self, ErrorCodeExt};
+#[cfg(feature = "cli")]
 use crate::git::{get_repo_root, open_repo};
+#[cfg(feature = "cli")]
+use anyhow::Result;
 
 mod checks;
+#[cfg(feature = "cli")]
 mod output;
 mod result;
 mod source;
 
 #[allow(unused_imports)]
 pub use result::{EntryOutput, ValidationEntry, ValidationLevel, ValidationResult};
-pub use source::{
-    FileSource, GitHubSource, GitLabSource, LocalSource, RemoteProvider, load_config_from_source,
-    parse_repo_spec,
-};
+pub use source::{FileSource, LocalSource, MemorySource, load_config_from_source};
+#[cfg(feature = "cli")]
+pub use source::{GitHubSource, GitLabSource, RemoteProvider, parse_repo_spec};
 
 use checks::{
     check_changelog_paths, check_duplicate_names, check_duplicate_paths, check_groups,
     check_package_paths, check_shared_paths, check_suggestions, check_tag_templates,
     check_version_consistency, check_versioned_files, check_versioned_files_exist,
 };
+#[cfg(feature = "cli")]
 use output::output_result;
 
+#[cfg(feature = "cli")]
 pub fn run(
     config_path: Option<&Path>,
     json: bool,
@@ -104,7 +112,15 @@ fn collect_entries(
     entries
 }
 
-pub fn local_entries(config: &crate::config::Config, root: &Path) -> Vec<ValidationEntry> {
+#[cfg_attr(feature = "cli", allow(dead_code))]
+pub fn validate_files(config: &Config, files: BTreeMap<String, Vec<u8>>) -> ValidationResult {
+    let source = MemorySource::new(files);
+    let mut result = ValidationResult::from_entries(collect_entries(config, &source));
+    result.package_count = config.packages.len();
+    result
+}
+
+pub fn local_entries(config: &Config, root: &Path) -> Vec<ValidationEntry> {
     let source = LocalSource {
         root: root.to_path_buf(),
     };

--- a/src/validate/source.rs
+++ b/src/validate/source.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use crate::config::Config;
@@ -8,6 +9,7 @@ use crate::error_code::{self, ErrorCodeExt};
 /// slashes so a multi-segment path (`src/lib/foo.rs`) keeps its
 /// structure. Used when interpolating user-supplied paths into URL
 /// path positions. See #553.
+#[cfg(feature = "cli")]
 fn encode_path(s: &str) -> String {
     encode_with_safe(s, |b| matches!(b, b'/'))
 }
@@ -16,10 +18,12 @@ fn encode_path(s: &str) -> String {
 /// the value lands in a single URL query parameter and must not
 /// smuggle further `?`, `&`, `=`, or `#` characters. Used for the git
 /// ref (`?ref=…`).
+#[cfg(feature = "cli")]
 fn encode_query_value(s: &str) -> String {
     encode_with_safe(s, |_| false)
 }
 
+#[cfg(feature = "cli")]
 fn encode_with_safe(s: &str, extra_safe: impl Fn(u8) -> bool) -> String {
     let mut out = String::with_capacity(s.len());
     for b in s.bytes() {
@@ -58,12 +62,40 @@ impl FileSource for LocalSource {
     }
 }
 
+#[cfg_attr(feature = "cli", allow(dead_code))]
+pub struct MemorySource {
+    files: BTreeMap<String, Vec<u8>>,
+}
+
+#[cfg_attr(feature = "cli", allow(dead_code))]
+impl MemorySource {
+    pub fn new(files: BTreeMap<String, Vec<u8>>) -> Self {
+        Self { files }
+    }
+}
+
+impl FileSource for MemorySource {
+    fn read_file(&self, path: &str) -> Result<Option<Vec<u8>>> {
+        Ok(self.files.get(path).cloned())
+    }
+
+    fn path_exists(&self, path: &str) -> Result<bool> {
+        if self.files.contains_key(path) {
+            return Ok(true);
+        }
+        let prefix = format!("{}/", path.trim_end_matches('/'));
+        Ok(self.files.keys().any(|key| key.starts_with(&prefix)))
+    }
+}
+
+#[cfg(feature = "cli")]
 #[derive(Debug, PartialEq)]
 pub enum RemoteProvider {
     GitHub,
     GitLab,
 }
 
+#[cfg(feature = "cli")]
 pub fn parse_repo_spec(spec: &str) -> Result<(RemoteProvider, String, String)> {
     let spec = spec
         .trim_start_matches("https://")
@@ -91,6 +123,7 @@ pub fn parse_repo_spec(spec: &str) -> Result<(RemoteProvider, String, String)> {
     }
 }
 
+#[cfg(feature = "cli")]
 pub struct GitHubSource {
     pub owner: String,
     pub repo: String,
@@ -98,6 +131,7 @@ pub struct GitHubSource {
     pub token: Option<String>,
 }
 
+#[cfg(feature = "cli")]
 impl FileSource for GitHubSource {
     fn read_file(&self, path: &str) -> Result<Option<Vec<u8>>> {
         let mut url = format!(
@@ -130,6 +164,7 @@ impl FileSource for GitHubSource {
     }
 }
 
+#[cfg(feature = "cli")]
 pub struct GitLabSource {
     pub owner: String,
     pub repo: String,
@@ -137,6 +172,7 @@ pub struct GitLabSource {
     pub token: Option<String>,
 }
 
+#[cfg(feature = "cli")]
 impl FileSource for GitLabSource {
     fn read_file(&self, path: &str) -> Result<Option<Vec<u8>>> {
         let project_id = format!("{}/{}", self.owner, self.repo);
@@ -222,7 +258,7 @@ pub fn load_config_from_source(
     .error_code(error_code::VALIDATE_NO_CONFIG)?
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "cli"))]
 mod tests {
     use super::*;
 

--- a/src/validate/tests.rs
+++ b/src/validate/tests.rs
@@ -1,7 +1,7 @@
 use super::checks::*;
 use super::*;
 use crate::config::{Config, FileFormat, PackageConfig, VersionedFile, WorkspaceConfig};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use tempfile::TempDir;
 
@@ -313,4 +313,125 @@ fn run_ref_without_repo_errors() {
     let result = run(None, false, None, Some("main"));
     assert!(result.is_err());
     assert!(format!("{:?}", result.unwrap_err()).contains("--ref"));
+}
+
+fn app_with_two_versioned_files() -> Config {
+    let mut pkg = make_package("app", ".");
+    pkg.versioned_files = vec![
+        VersionedFile {
+            path: "package.json".to_string(),
+            format: FileFormat::Json,
+            selector: None,
+        },
+        VersionedFile {
+            path: "Cargo.toml".to_string(),
+            format: FileFormat::Toml,
+            selector: None,
+        },
+    ];
+    make_config(vec![pkg])
+}
+
+#[test]
+fn validate_files_flags_version_mismatch_across_provided_files() {
+    let config = app_with_two_versioned_files();
+    let mut files = BTreeMap::new();
+    files.insert(
+        "package.json".to_string(),
+        br#"{"name":"app","version":"1.0.0"}"#.to_vec(),
+    );
+    files.insert(
+        "Cargo.toml".to_string(),
+        b"[package]\nname = \"app\"\nversion = \"1.1.0\"\n".to_vec(),
+    );
+
+    let result = validate_files(&config, files);
+
+    assert!(!result.valid);
+    assert_eq!(result.package_count, 1);
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|e| e.message.contains("1.0.0") && e.message.contains("1.1.0")),
+        "expected a version-consistency error, got {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn validate_files_passes_when_provided_versions_agree() {
+    let config = app_with_two_versioned_files();
+    let mut files = BTreeMap::new();
+    files.insert(
+        "package.json".to_string(),
+        br#"{"name":"app","version":"2.3.4"}"#.to_vec(),
+    );
+    files.insert(
+        "Cargo.toml".to_string(),
+        b"[package]\nname = \"app\"\nversion = \"2.3.4\"\n".to_vec(),
+    );
+
+    let result = validate_files(&config, files);
+
+    assert!(
+        result.valid,
+        "expected valid, got errors: {:?}",
+        result.errors
+    );
+    assert_eq!(result.package_count, 1);
+}
+
+#[test]
+fn validate_files_treats_a_package_dir_as_present_when_files_live_under_it() {
+    let mut pkg = make_package("api", "packages/api");
+    pkg.versioned_files = vec![VersionedFile {
+        path: "packages/api/package.json".to_string(),
+        format: FileFormat::Json,
+        selector: None,
+    }];
+    let config = make_config(vec![pkg]);
+    let mut files = BTreeMap::new();
+    files.insert(
+        "packages/api/package.json".to_string(),
+        br#"{"name":"api","version":"1.0.0"}"#.to_vec(),
+    );
+
+    let result = validate_files(&config, files);
+
+    assert!(
+        result.valid,
+        "expected valid, got errors: {:?}",
+        result.errors
+    );
+    assert!(
+        !result
+            .errors
+            .iter()
+            .any(|e| e.message.contains("does not exist")),
+        "package dir should count as present via its files, got {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn validate_files_reports_missing_versioned_file() {
+    let config = app_with_two_versioned_files();
+    let mut files = BTreeMap::new();
+    files.insert(
+        "package.json".to_string(),
+        br#"{"name":"app","version":"1.0.0"}"#.to_vec(),
+    );
+
+    let result = validate_files(&config, files);
+
+    assert!(!result.valid);
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|e| e.message.contains("Cargo.toml") && e.message.contains("does not exist")),
+        "expected a missing-file error, got {:?}",
+        result.errors
+    );
 }


### PR DESCRIPTION
## What

Makes the FerrFlow validation core reachable with `default-features = false`, so the hosted FerrFlow API can validate configs server-side with results byte-identical to `ferrflow validate` — no second implementation to drift.

- Un-gates the `validate` module; gates only the cli-only pieces (`run`, `output` via `colored`, the remote `GitHubSource`/`GitLabSource` via `ureq`, `RemoteProvider`/`parse_repo_spec` and the URL-encode helpers).
- Adds `MemorySource`, an in-memory `FileSource` over caller-provided file contents — no repo, git, or network. Its `path_exists` counts a package directory as present when any provided file lives under it, so the package-path check stays correct for monorepo layouts.
- Adds `validate::validate_files(&Config, BTreeMap<String, Vec<u8>>) -> ValidationResult`, running the same `collect_entries` the CLI runs.

The server-only surface carries `#[cfg_attr(feature = "cli", allow(dead_code))]` because `main.rs` re-includes the module into the binary, which doesn't consume it.

## Verification

- `cargo build --no-default-features --lib` — server core compiles without gix/clap/ureq.
- `cargo build -p ferrflow-wasm` — the existing no-default-features consumer still builds.
- `cargo clippy --all-targets` clean; 758 lib tests pass.
- New tests exercise `validate_files` over an in-memory source: version mismatch, agreement, missing file, monorepo package dir.

Closes #753. Unblocks FerrLabs/FerrLabs-Cloud#647 and `/v1/ferrflow/validate` (FerrLabs/FerrLabs-Cloud#651).
