### PR TITLE
feat(schema): expose the bundled JSON schema from the library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod conventional_commits;
 pub mod error_code;
 pub mod formats;
 pub mod prerelease;
+pub mod schema;
 pub mod validate;
 pub mod versioning;
 


### PR DESCRIPTION
Adds `pub mod schema;` to `lib.rs` so a `default-features = false` consumer (the hosted FerrFlow API) can serve `ferrflow::schema::BUNDLED_SCHEMA` — the exact bundled bytes, source of truth — instead of a hand-copied file.

`schema.rs` is already non-cli (serde_json + std::fs + tracing) and `schema::run` stays bin-used, so no dead-code guard is needed. Verified: `cargo build --no-default-features --lib`, `clippy --all-targets` clean, schema tests pass.

Closes #755. Unblocks `/v1/ferrflow/schema` (FerrLabs/FerrLabs-Cloud#649).