### PR TITLE
feat: expose the crate version as ferrflow::VERSION

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub mod changelog;
 pub mod config;
 pub mod conventional_commits;


### PR DESCRIPTION
Adds `pub const ferrflow::VERSION` so a `default-features = false` consumer (the hosted FerrFlow API) can read the CLI's current version/major at runtime — used to gate `/v1/ferrflow/schema/v{major}` and as a fallback in `/latest`, drift-free vs a hardcoded major.

Closes #757.