### PR TITLE
fix(ci): repair renovate-rebase.yml truncated by the pin sweep

### DIFF
--- a/.github/workflows/renovate-rebase.yml
+++ b/.github/workflows/renovate-rebase.yml
@@ -1,4 +1,12 @@
 name: Renovate rebase now
 
 on:
-  pull_request
+  pull_request:
+    types: [edited]
+
+jobs:
+  dispatch:
+    uses: FerrLabs/.github/.github/workflows/reusable-renovate-dispatch.yml@2539af69333d7c8c69c335286a4c196afad9fd49 # main
+    with:
+      runner: ubuntu-latest
+    secrets: inherit


### PR DESCRIPTION
The pin sweep truncated this workflow to an invalid YAML stub, causing startup-failures on `main`. Restores the full file with the reusable pinned to `2539af69333d7c8c69c335286a4c196afad9fd49`. Refs FerrLabs/.github#177.