### PR TITLE
fix(release): replan against the winning run instead of failing with E2006 on concurrent releases

### DIFF
--- a/src/git/push.rs
+++ b/src/git/push.rs
@@ -410,98 +410,6 @@ fn try_push_branch_once(repo: &Repository, remote_name: &str, branch: &str) -> R
     Ok(())
 }
 
-pub(super) fn fetch_and_rebase(repo: &Repository, remote_name: &str, branch: &str) -> Result<()> {
-    let workdir = repo
-        .workdir()
-        .ok_or_else(|| anyhow!("bare repos are not supported"))?;
-    let push_url = get_remote_url(repo, remote_name)
-        .ok_or_else(|| anyhow!("Remote '{remote_name}' has no URL"))?;
-
-    let mut fetch_cmd = std::process::Command::new("git");
-    fetch_cmd.current_dir(workdir);
-    configure_git_command(&mut fetch_cmd, &push_url);
-    fetch_cmd.arg("fetch").arg(remote_name).arg(format!(
-        "+refs/heads/{branch}:refs/remotes/{remote_name}/{branch}"
-    ));
-    let fetch_out = fetch_cmd
-        .output()
-        .with_context(|| "spawn `git fetch` failed")?;
-    if !fetch_out.status.success() {
-        let stderr = String::from_utf8_lossy(&fetch_out.stderr);
-        return Err(anyhow!("git fetch failed: {}", stderr.trim()));
-    }
-
-    let remote_oid_str = run_git(
-        workdir,
-        &["rev-parse", &format!("refs/remotes/{remote_name}/{branch}")],
-    )
-    .with_context(|| format!("could not resolve refs/remotes/{remote_name}/{branch}"))?
-    .trim()
-    .to_string();
-    let local_oid_str = run_git(workdir, &["rev-parse", "HEAD"])
-        .with_context(|| "could not resolve HEAD")?
-        .trim()
-        .to_string();
-
-    if remote_oid_str == local_oid_str {
-        return Ok(());
-    }
-
-    if run_git(
-        workdir,
-        &[
-            "merge-base",
-            "--is-ancestor",
-            &remote_oid_str,
-            &local_oid_str,
-        ],
-    )
-    .is_ok()
-    {
-        return Ok(());
-    }
-
-    let local_ref = format!("refs/heads/{branch}");
-    // Distinguish "detached HEAD" (legit state — bail with a clear error
-    // instead of silently rewriting a branch we may not even be tracking)
-    // from "on a different branch" (still a hard error: we shouldn't try
-    // to fast-forward a branch the user isn't on). The previous code
-    // collapsed both into a destructive `update-ref` + `checkout -f`.
-    let current_head = run_git(workdir, &["symbolic-ref", "-q", "HEAD"])
-        .ok()
-        .map(|s| s.trim().to_string());
-    match current_head.as_deref() {
-        Some(r) if r == local_ref => {
-            let rebase_result = run_git(
-                workdir,
-                &["rebase", &format!("refs/remotes/{remote_name}/{branch}")],
-            );
-            if let Err(err) = rebase_result {
-                let _ = run_git(workdir, &["rebase", "--abort"]);
-                return Err(anyhow!(
-                    "Rebase conflict: cannot rebase release commits on top of remote '{branch}'. \
-                     Run manually or use releaseCommitMode = \"pr\".\n{err}"
-                ));
-            }
-        }
-        Some(other) => {
-            return Err(anyhow!(
-                "Refusing to rebase: HEAD is on '{other}', not '{local_ref}'. \
-                 Check out '{branch}' before retrying."
-            ));
-        }
-        None => {
-            return Err(anyhow!(
-                "Refusing to rebase: HEAD is detached. Check out '{branch}' before retrying. \
-                 (If a previous release left a stale lock, clear it with `ferrflow release \
-                 --force-unlock`, or reset the branch manually.)"
-            ));
-        }
-    }
-
-    Ok(())
-}
-
 pub fn reset_branch_to_remote(repo: &Repository, remote_name: &str, branch: &str) -> Result<()> {
     super::validate::ensure_safe_refname_fragment(remote_name, "remote name")?;
     super::validate::ensure_safe_refname_fragment(branch, "branch name")?;
@@ -550,37 +458,16 @@ pub fn reset_branch_to_remote(repo: &Repository, remote_name: &str, branch: &str
     Ok(())
 }
 
-const MAX_PUSH_RETRIES: usize = 3;
-
-pub fn push(repo: &Repository, remote_name: &str, branch: &str, tags: &[&str]) -> Result<()> {
-    for attempt in 1..=MAX_PUSH_RETRIES {
-        match try_push_branch(repo, remote_name, branch) {
-            Ok(()) => break,
-            Err(e) => {
-                let is_non_ff = e.chain().any(|cause| {
-                    let msg = cause.to_string().to_lowercase();
-                    msg.contains("non-fastforward")
-                        || msg.contains("not fast forward")
-                        || msg.contains("non-fast-forward")
-                        || msg.contains("push rejected")
-                        || msg.contains("rejected")
-                });
-
-                if !is_non_ff || attempt == MAX_PUSH_RETRIES {
-                    return Err(e)
-                        .with_context(|| {
-                            format!("Failed to push branch '{branch}' after {attempt} attempt(s)")
-                        })
-                        .error_code(error_code::GIT_PUSH_BRANCH);
-                }
-
-                tracing::warn!(
-                    "Push rejected (non-fast-forward), rebasing on remote and retrying ({attempt}/{MAX_PUSH_RETRIES})..."
-                );
-                fetch_and_rebase(repo, remote_name, branch)?;
-            }
-        }
-    }
+// Rebasing here would rewrite HEAD while the release tags created in an
+// earlier phase stay pinned to the pre-rebase commit, so the run would push
+// orphaned tags — or collide with a version a concurrent run just published
+// (E2006). A rejected push is surfaced instead, letting the regenerate loop in
+// `monorepo::release` reset to the remote tip and recompute the whole plan
+// against the new base.
+pub fn push(repo: &Repository, remote_name: &str, branch: &str) -> Result<()> {
+    try_push_branch(repo, remote_name, branch)
+        .with_context(|| format!("Failed to push branch '{branch}'"))
+        .error_code(error_code::GIT_PUSH_BRANCH)?;
 
     let workdir = repo
         .workdir()
@@ -591,8 +478,6 @@ pub fn push(repo: &Repository, remote_name: &str, branch: &str, tags: &[&str]) -
     verify_remote_branch(repo, remote_name, branch, head_oid)
         .with_context(|| "Post-push verification failed: release commit not on remote branch")
         .error_code(error_code::GIT_PUSH_VERIFY_FAILED)?;
-
-    push_tags(repo, remote_name, tags)?;
 
     Ok(())
 }

--- a/src/git/retry.rs
+++ b/src/git/retry.rs
@@ -99,9 +99,16 @@ pub(super) fn is_transient_git_error(err: &anyhow::Error) -> bool {
 }
 
 pub fn is_push_rejected_error(err: &anyhow::Error) -> bool {
+    // GIT_PUSH_TAGS covers the concurrent-release case: another run published
+    // the version this plan plotted, so the tag exists on the remote at a
+    // different commit. Regenerating recomputes the plan against the winner's
+    // history and picks the next version on top of it, which is the only safe
+    // resolution — deleting or force-pushing the tag would destroy a published
+    // release.
     let push_codes: &[String] = &[
         error_code::GIT_PUSH_REJECTED.to_string(),
         error_code::GIT_PUSH_BRANCH.to_string(),
+        error_code::GIT_PUSH_TAGS.to_string(),
     ];
     err.chain().any(|cause| {
         let raw = cause.to_string();

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -1,5 +1,5 @@
 use super::auth::{configure_git_command, extract_url_password, server_config_url, token_for_url};
-use super::push::{fetch_and_rebase, local_tag_target_sha, parse_ls_remote_tags};
+use super::push::{local_tag_target_sha, parse_ls_remote_tags};
 use super::repo::Repository;
 use super::retry::{is_transient_git_error, retry_transient};
 use super::tags::{find_highest_semver_tag, find_last_tag, is_floating_tag, is_prerelease_tag};
@@ -1482,7 +1482,7 @@ fn resolve_branch_detached_returns_non_empty() {
 }
 
 // -----------------------------------------------------------------------
-// fetch_and_rebase — regression test for #367
+// push — concurrent-release rejection (#765, supersedes the #367 rebase)
 // -----------------------------------------------------------------------
 
 /// Simulates what the release bot does when a concurrent push advances
@@ -1493,12 +1493,14 @@ fn resolve_branch_detached_returns_non_empty() {
 ///   │       analog of a feature PR merging just before we push)
 ///   └── X   (our local release commit, parent = A)
 ///
-/// After fetch_and_rebase, the replayed X' must contain BOTH B's changes
-/// and X's changes. Issue #367: the previous merge_trees arg order quietly
-/// reverted B so the rebased commit ended up as "A + X — B" — losing
-/// every file B had touched.
+/// `push` must REJECT here rather than rebase X onto B. Release tags are
+/// created before the push, so rebasing would rewrite HEAD and strand them
+/// on the orphaned X — and the tag names themselves are stale once a
+/// concurrent run has published that version (#765). The rejection is what
+/// drives `monorepo::release`'s regenerate loop, which resets to the remote
+/// tip and recomputes the plan against B.
 #[test]
-fn fetch_and_rebase_preserves_concurrent_remote_changes() {
+fn push_rejects_when_remote_advanced_instead_of_rebasing() {
     let base_dir = tempfile::tempdir().unwrap();
 
     let remote_path = base_dir.path().join("remote.git");
@@ -1541,16 +1543,29 @@ fn fetch_and_rebase_preserves_concurrent_remote_changes() {
 
     create_commit_in_repo(&repo, &local_path, "release_commit.txt", "commit X");
 
+    let local_head_before = git(&local_path, &["rev-parse", "HEAD"]);
+
     let repo = open_repo(&local_path).unwrap();
-    fetch_and_rebase(&repo, "origin", "main").expect("rebase should succeed");
+    let err = super::push::push(&repo, "origin", "main")
+        .expect_err("push onto an advanced remote must be rejected, not rebased");
+
+    assert!(
+        is_push_rejected_error(&err),
+        "the rejection must be classified as retryable so the release regenerate \
+         loop replans against the new base; got: {err:#}"
+    );
+
+    let local_head_after = git(&local_path, &["rev-parse", "HEAD"]);
+    assert_eq!(
+        local_head_before, local_head_after,
+        "push must not rewrite HEAD: release tags already point at it"
+    );
 
     let head_tree = git(&local_path, &["ls-tree", "-r", "--name-only", "HEAD"]);
-    assert!(head_tree.contains("base.txt"));
-    assert!(head_tree.contains("from_concurrent_pr.txt"));
-    assert!(head_tree.contains("release_commit.txt"));
-
-    let parent_tree = git(&local_path, &["ls-tree", "-r", "--name-only", "HEAD^"]);
-    assert!(parent_tree.contains("from_concurrent_pr.txt"));
+    assert!(
+        !head_tree.contains("from_concurrent_pr.txt"),
+        "no rebase should have happened"
+    );
 }
 
 // ── reset_branch_to_remote — used by the release retry path ─────────
@@ -1648,6 +1663,17 @@ fn is_push_rejected_error_recognises_known_signatures() {
     let e = anyhow::anyhow!(
         "Updates were rejected because the tip of your current branch is non-fast-forward"
     );
+    assert!(is_push_rejected_error(&e));
+
+    // A concurrent run published the version this plan plotted, so the tag
+    // exists on the remote at a different commit (#765). Regenerating replans
+    // on top of the winner; without this the run hard-failed with E2006 and
+    // silently dropped every other package it was about to release.
+    let e = anyhow::anyhow!(
+        "Tag(s) already exist on remote pointing to a different commit: \
+         api@v3.13.3 (local 1e3ed96 != remote c3ae651)."
+    )
+    .context(error_code::GIT_PUSH_TAGS);
     assert!(is_push_rejected_error(&e));
 
     // Unrelated error must not match.

--- a/src/monorepo/run/execute.rs
+++ b/src/monorepo/run/execute.rs
@@ -490,12 +490,7 @@ fn push_and_publish(
         .collect();
 
     if let ReleaseCommitMode::Commit = mode {
-        push(
-            plan.repo,
-            &plan.config.workspace.remote,
-            plan.target_branch,
-            &[],
-        )?;
+        push(plan.repo, &plan.config.workspace.remote, plan.target_branch)?;
         plan.shared_outputs.push(format!(
             "✓ Pushed and verified on {}/{}",
             plan.config.workspace.remote, plan.target_branch


### PR DESCRIPTION
Closes #765.

## Root cause — slightly different from the issue

The issue blames `push()` keeping a stale tag list. That param was actually dead: the only caller passed `&[]`, and tags are pushed separately later. The real chain is:

1. Release tags are created locally in an earlier phase (`execute.rs`), pinned to the release commit.
2. On a non-fast-forward, `push()` **silently rebased** onto the remote. That rewrites HEAD and strands those tags on the now-orphaned pre-rebase commit — and their names are stale anyway once a concurrent run has published that version.
3. E2006 then fires on the separate tag push.
4. `is_push_rejected_error` did **not** match `GIT_PUSH_TAGS`, so the run hard-failed instead of recovering.

The recovery the issue asks for (recompute the plan after rebasing) **already existed** one level up: the regenerate loop in `monorepo::release` deletes the new tags, resets to the remote tip, drops the checkpoint, and replans from scratch. The two retry layers were fighting: the inner one silently rebased and thereby prevented the outer one — which does it correctly — from ever running.

## Fix

- `push()` no longer rebases. A rejected push is surfaced so the regenerate loop owns recovery. `fetch_and_rebase` had no other caller and is removed, along with the now-dead `tags` param.
- `GIT_PUSH_TAGS` (E2006) joins the retryable set, so a concurrently-taken tag triggers a replan instead of a hard failure.

This also fixes the silent-incompleteness in the issue: the run replans as a whole, so a second package's bump is no longer dropped when the first collides.

## On "bump to the next available version"

Implemented as a **full replan**, not a next-free-slot search — the issue's wording is subtly wrong. If a concurrent run publishes `api@v1.1.0` while we planned `api@v1.0.1` (a fix off `1.0.0`), `1.0.1` *is* free, but taking it would publish a fix *below* the latest release: nobody on `1.1.0` would ever receive it and the tag order goes backwards. Replanning derives `current_version` from the highest existing tag (`plan.rs`), so the fix lands on top of the winner as `1.1.1`. Same mechanism gives `3.13.4` in the issue's own trace.

E2006 stays reserved for the genuine divergence case, so its "delete the divergent remote tag" wording is now correct when it does appear — no valid published release is ever deleted or force-overwritten.

## Tests

- `push_rejects_when_remote_advanced_instead_of_rebasing` — real bare remote + two clones; asserts the push is rejected, classified retryable, and that **HEAD is not rewritten** (the property that keeps tags from being orphaned). Replaces the old #367 test, whose scenario is now handled by the regenerate loop.
- `is_push_rejected_error_recognises_known_signatures` gains the E2006 case.

Full suite green (1738 tests), `clippy --all-targets -D warnings` clean.
