### PR TITLE
fix(release): push tags before creating forge releases

### DIFF
--- a/src/forge/bitbucket.rs
+++ b/src/forge/bitbucket.rs
@@ -21,7 +21,6 @@ impl Forge for BitbucketForge {
         _body: &str,
         _prerelease: bool,
         _draft: bool,
-        _target_commitish: Option<&str>,
     ) -> Result<ReleaseResult> {
         // Bitbucket has no "release" object — the annotated tag FerrFlow
         // already pushed *is* the release. On Cloud we look the tag up to
@@ -162,7 +161,7 @@ mod tests {
         // is_cloud == false short-circuits before any HTTP, so this must not
         // hang or panic and must report no forge URL.
         let result = make_forge(false)
-            .create_release("v1.0.0", "notes", false, false, None)
+            .create_release("v1.0.0", "notes", false, false)
             .unwrap();
         assert_eq!(result.id, None);
         assert_eq!(result.url, None);

--- a/src/forge/gitea.rs
+++ b/src/forge/gitea.rs
@@ -50,21 +50,16 @@ impl Forge for GiteaForge {
         body: &str,
         prerelease: bool,
         draft: bool,
-        target_commitish: Option<&str>,
     ) -> Result<ReleaseResult> {
         let url = format!("{}/repos/{}/releases", self.api_base, self.slug);
 
-        let mut payload = serde_json::json!({
+        let payload = serde_json::json!({
             "tag_name": tag,
             "name": tag,
             "body": body,
             "draft": draft,
             "prerelease": prerelease,
         });
-        if let Some(sha) = target_commitish.filter(|s| !s.is_empty()) {
-            payload["target_commitish"] = serde_json::Value::String(sha.to_string());
-        }
-
         let response: serde_json::Value = self
             .agent
             .post(&url)

--- a/src/forge/github.rs
+++ b/src/forge/github.rs
@@ -68,21 +68,16 @@ impl Forge for GitHubForge {
         body: &str,
         prerelease: bool,
         draft: bool,
-        target_commitish: Option<&str>,
     ) -> Result<ReleaseResult> {
         let url = format!("{}/repos/{}/releases", self.api_base, self.slug);
 
-        let mut payload = serde_json::json!({
+        let payload = serde_json::json!({
             "tag_name": tag,
             "name": tag,
             "body": body,
             "draft": draft,
             "prerelease": prerelease,
         });
-        if let Some(sha) = target_commitish.filter(|s| !s.is_empty()) {
-            payload["target_commitish"] = serde_json::Value::String(sha.to_string());
-        }
-
         let response: serde_json::Value = self
             .agent
             .post(&url)

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -59,7 +59,6 @@ impl Forge for GitLabForge {
         body: &str,
         prerelease: bool,
         draft: bool,
-        _target_commitish: Option<&str>,
     ) -> Result<ReleaseResult> {
         if draft {
             tracing::warn!(

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -29,7 +29,6 @@ pub trait Forge: Send + Sync {
         body: &str,
         prerelease: bool,
         draft: bool,
-        target_commitish: Option<&str>,
     ) -> Result<ReleaseResult>;
     fn find_draft_release(&self, tag: &str) -> Result<Option<u64>>;
     fn publish_release(&self, release_id: u64) -> Result<()>;

--- a/src/monorepo/run/checkpoint.rs
+++ b/src/monorepo/run/checkpoint.rs
@@ -251,6 +251,39 @@ mod tests {
         assert!(Phase::ReleasesCreated < Phase::PostPublishDone);
     }
 
+    // `Pushed` is written to disk for the first time as of #770 — before that
+    // it was declared but never advanced. A wrong serde rename would surface
+    // as a resume that silently re-pushes tags it already pushed.
+    #[test]
+    fn pushed_phase_round_trips_through_disk() {
+        let dir = init_test_repo();
+        let mut cp = Checkpoint::new("a".into(), vec![]);
+        cp.advance(Phase::Pushed);
+        cp.save(dir.path()).unwrap();
+
+        let loaded = Checkpoint::load(dir.path())
+            .unwrap()
+            .expect("checkpoint should load back");
+        assert_eq!(loaded.phase, Phase::Pushed);
+    }
+
+    // #770 slotted `Pushed` between `TagsCreated` and `ReleasesCreated`.
+    // Checkpoints written by earlier versions record one of the surrounding
+    // phases and must keep their meaning: a run that got as far as creating
+    // releases still skips both steps, one that only tagged still does both.
+    #[test]
+    fn checkpoints_predating_the_push_phase_keep_their_meaning() {
+        let mut tagged = Checkpoint::new("a".into(), vec![]);
+        tagged.advance(Phase::TagsCreated);
+        assert!(!tagged.is_done(Phase::Pushed));
+        assert!(!tagged.is_done(Phase::ReleasesCreated));
+
+        let mut released = Checkpoint::new("a".into(), vec![]);
+        released.advance(Phase::ReleasesCreated);
+        assert!(released.is_done(Phase::Pushed));
+        assert!(released.is_done(Phase::ReleasesCreated));
+    }
+
     #[test]
     fn is_done_threshold_check() {
         let mut cp = Checkpoint::new("a".into(), vec![]);

--- a/src/monorepo/run/execute.rs
+++ b/src/monorepo/run/execute.rs
@@ -117,11 +117,17 @@ pub(super) fn execute_release(plan: &mut ReleasePlan<'_>) -> Result<()> {
     run_package_hooks(plan, HookPoint::PrePublish)?;
 
     if !plan.dry_run {
+        if !checkpoint_is_done(plan, Phase::Pushed) {
+            push_refs(plan, mode, &floating_tag_names)?;
+            checkpoint_advance(plan, Phase::Pushed)?;
+        } else if plan.verbose {
+            tracing::info!("  ↻ Resumed: skipping push (already done)");
+        }
         if !checkpoint_is_done(plan, Phase::ReleasesCreated) {
-            push_and_publish(plan, mode, &floating_tag_names)?;
+            publish_releases(plan)?;
             checkpoint_advance(plan, Phase::ReleasesCreated)?;
         } else if plan.verbose {
-            tracing::info!("  ↻ Resumed: skipping push + publish (already done)");
+            tracing::info!("  ↻ Resumed: skipping publish (already done)");
         }
     }
 
@@ -478,7 +484,12 @@ fn run_release_summary_hook(plan: &ReleasePlan<'_>, point: HookPoint) -> Result<
     Ok(())
 }
 
-fn push_and_publish(
+// Git lands first, the forge second (#770). Publishing a release that
+// references a tag the remote doesn't have yet means every failure in between
+// leaves the forge ahead of git: releases published against a missing ref, and
+// on GitHub/Gitea a lightweight tag auto-created from `target_commitish` that
+// shadows the annotated tag carrying the changelog body.
+fn push_refs(
     plan: &mut ReleasePlan<'_>,
     mode: ReleaseCommitMode,
     floating_tag_names: &[String],
@@ -497,58 +508,6 @@ fn push_and_publish(
         ));
     }
 
-    let target_sha = plan.repo.head_id().ok().map(|id| id.to_string());
-
-    if let Some(forge_instance) = build_forge_instance(plan.repo, plan.config) {
-        let forge_ref: &dyn Forge = forge_instance.as_ref();
-        let draft = plan.draft;
-        let target_sha_ref = target_sha.as_deref();
-
-        let threads = forge_pool_threads(plan.tags_to_create.len(), crate::concurrency::max_jobs());
-        let pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(threads)
-            .build()
-            .map_err(|e| anyhow::anyhow!("failed to build release thread pool: {e}"))
-            .error_code(error_code::MONOREPO_PUSH_FAILED)?;
-
-        let outcomes: Vec<(String, String, TagReleaseOutcome)> = pool.install(|| {
-            plan.tags_to_create
-                .par_iter()
-                .map(|(tag_name, _, body, pkg_name, _, _, is_pre)| {
-                    let outcome = process_release_tag(
-                        forge_ref,
-                        tag_name,
-                        body,
-                        *is_pre,
-                        draft,
-                        target_sha_ref,
-                    );
-                    (tag_name.clone(), pkg_name.clone(), outcome)
-                })
-                .collect()
-        });
-
-        for (tag_name, pkg_name, outcome) in outcomes {
-            for warning in outcome.warnings {
-                if !warning.verbose_only || plan.verbose {
-                    tracing::warn!("{}", warning.message.yellow());
-                }
-            }
-            if let Some(result) = outcome.result {
-                plan.forge_results.push((tag_name, result));
-            }
-            if let Some(line) = outcome.success_line
-                && let Some((_, lines)) = plan
-                    .pkg_outputs
-                    .iter_mut()
-                    .rev()
-                    .find(|(n, _)| *n == pkg_name)
-            {
-                lines.push(line);
-            }
-        }
-    }
-
     if !tag_refs.is_empty() {
         push_tags(plan.repo, &plan.config.workspace.remote, &tag_refs)?;
         plan.shared_outputs.push("✓ Pushed tags".to_string());
@@ -561,7 +520,58 @@ fn push_and_publish(
             .push("✓ Pushed floating tags".to_string());
     }
 
+    Ok(())
+}
+
+fn publish_releases(plan: &mut ReleasePlan<'_>) -> Result<()> {
+    if let Some(forge_instance) = build_forge_instance(plan.repo, plan.config) {
+        publish_releases_with(plan, forge_instance.as_ref())?;
+    }
+
     write_github_step_summary(plan.tags_to_create);
+    Ok(())
+}
+
+fn publish_releases_with(plan: &mut ReleasePlan<'_>, forge: &dyn Forge) -> Result<()> {
+    let draft = plan.draft;
+
+    let threads = forge_pool_threads(plan.tags_to_create.len(), crate::concurrency::max_jobs());
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(threads)
+        .build()
+        .map_err(|e| anyhow::anyhow!("failed to build release thread pool: {e}"))
+        .error_code(error_code::MONOREPO_PUSH_FAILED)?;
+
+    let outcomes: Vec<(String, String, TagReleaseOutcome)> = pool.install(|| {
+        plan.tags_to_create
+            .par_iter()
+            .map(|(tag_name, _, body, pkg_name, _, _, is_pre)| {
+                let outcome = process_release_tag(forge, tag_name, body, *is_pre, draft);
+                (tag_name.clone(), pkg_name.clone(), outcome)
+            })
+            .collect()
+    });
+
+    for (tag_name, pkg_name, outcome) in outcomes {
+        for warning in outcome.warnings {
+            if !warning.verbose_only || plan.verbose {
+                tracing::warn!("{}", warning.message.yellow());
+            }
+        }
+        if let Some(result) = outcome.result {
+            plan.forge_results.push((tag_name, result));
+        }
+        if let Some(line) = outcome.success_line
+            && let Some((_, lines)) = plan
+                .pkg_outputs
+                .iter_mut()
+                .rev()
+                .find(|(n, _)| *n == pkg_name)
+        {
+            lines.push(line);
+        }
+    }
+
     Ok(())
 }
 
@@ -588,7 +598,6 @@ fn process_release_tag(
     body: &str,
     is_pre: bool,
     draft: bool,
-    target_sha: Option<&str>,
 ) -> TagReleaseOutcome {
     let noun = forge.release_noun();
     let mut warnings = Vec::new();
@@ -620,7 +629,7 @@ fn process_release_tag(
         }
     }
 
-    match forge.create_release(tag_name, body, is_pre, draft, target_sha) {
+    match forge.create_release(tag_name, body, is_pre, draft) {
         Ok(result) => {
             let success_line = if draft {
                 format!("  ✓ Draft {} {}", noun, tag_name.cyan())
@@ -761,7 +770,6 @@ mod tag_release_tests {
             _body: &str,
             _prerelease: bool,
             _draft: bool,
-            _target_commitish: Option<&str>,
         ) -> Result<ReleaseResult> {
             self.create_calls.lock().unwrap().push(tag.to_string());
             if self.create_fails_for.iter().any(|t| t == tag) {
@@ -854,7 +862,7 @@ mod tag_release_tests {
             drafts: HashMap::from([("v1".to_string(), 42)]),
             ..Default::default()
         };
-        let outcome = process_release_tag(&forge, "v1", "body", false, false, None);
+        let outcome = process_release_tag(&forge, "v1", "body", false, false);
 
         assert!(outcome.warnings.is_empty());
         assert!(outcome.result.is_none());
@@ -874,7 +882,7 @@ mod tag_release_tests {
             publish_fails: true,
             ..Default::default()
         };
-        let outcome = process_release_tag(&forge, "v1", "body", false, false, None);
+        let outcome = process_release_tag(&forge, "v1", "body", false, false);
 
         assert_eq!(outcome.warnings.len(), 1);
         assert!(!outcome.warnings[0].verbose_only);
@@ -890,7 +898,7 @@ mod tag_release_tests {
     #[test]
     fn creates_release_when_no_draft() {
         let forge = MockForge::default();
-        let outcome = process_release_tag(&forge, "v1", "body", false, false, None);
+        let outcome = process_release_tag(&forge, "v1", "body", false, false);
 
         assert!(outcome.warnings.is_empty());
         assert_eq!(
@@ -906,7 +914,7 @@ mod tag_release_tests {
             create_fails_for: vec!["v1".to_string()],
             ..Default::default()
         };
-        let outcome = process_release_tag(&forge, "v1", "body", false, false, None);
+        let outcome = process_release_tag(&forge, "v1", "body", false, false);
 
         assert_eq!(outcome.warnings.len(), 1);
         assert!(!outcome.warnings[0].verbose_only);
@@ -925,7 +933,7 @@ mod tag_release_tests {
             find_draft_errors_for: vec!["v1".to_string()],
             ..Default::default()
         };
-        let outcome = process_release_tag(&forge, "v1", "body", false, false, None);
+        let outcome = process_release_tag(&forge, "v1", "body", false, false);
 
         assert_eq!(outcome.warnings.len(), 1);
         assert!(outcome.warnings[0].verbose_only);
@@ -938,7 +946,7 @@ mod tag_release_tests {
             drafts: HashMap::from([("v1".to_string(), 42)]),
             ..Default::default()
         };
-        let outcome = process_release_tag(&forge, "v1", "body", false, true, None);
+        let outcome = process_release_tag(&forge, "v1", "body", false, true);
 
         assert!(outcome.warnings.is_empty());
         assert!(outcome.result.is_some());
@@ -970,7 +978,7 @@ mod tag_release_tests {
         let collected: Vec<(String, Option<String>)> = pool.install(|| {
             tags.par_iter()
                 .map(|t| {
-                    let outcome = process_release_tag(&forge, t, "body", false, false, None);
+                    let outcome = process_release_tag(&forge, t, "body", false, false);
                     (t.to_string(), outcome.result.and_then(|r| r.url))
                 })
                 .collect()


### PR DESCRIPTION
Closes #770.

## Change

`push_and_publish` is split into `push_refs` (branch → tags → floating tags) and `publish_releases` (forge), and `execute_release` runs them in that order. Git is now the source of truth and lands first; the forge only ever sees refs that already exist on the remote.

`Phase::Pushed` — declared in `checkpoint.rs` since #549 but never advanced — is now advanced between the two. A resume after a forge failure retries only release creation instead of replaying the whole push.

## `target_commitish` dropped

Removed from the `Forge` trait and all four implementations. It only ever mattered when the tag was missing at release-creation time: GitHub and Gitea would then **create the tag themselves, as a lightweight tag** at that sha. FerrFlow's annotated tag — the one carrying the changelog body — was pushed afterwards and, pointing at the same commit, was treated as already synced and skipped. So the tag that survived on the remote was the forge's lightweight one and the annotated message was silently lost.

Ordering the push first makes the parameter dead: the tag is guaranteed to exist, and GitHub/Gitea ignore `target_commitish` for an existing tag. Removing it also removes the forge's ability to invent tags behind git's back.

GitLab and Bitbucket already ignored the parameter (`_target_commitish`), so nothing changes there beyond the signature.

## Tests

Two in `checkpoint.rs`, both guarding hazards this change introduces:

- `pushed_phase_round_trips_through_disk` — `Pushed` is serialised for the first time here; a wrong serde rename would show up as a resume that re-pushes tags it already pushed.
- `checkpoints_predating_the_push_phase_keep_their_meaning` — a new phase was slotted between two existing ones, so checkpoints written by older versions must keep their meaning: `ReleasesCreated` still skips both steps, `TagsCreated` still runs both. No schema bump is needed because the variant already existed in the enum.

Full suite green (1740), `clippy --all-targets -D warnings` clean.

**What I did not test.** The issue asks for a fault-injection test (fail `push_tags`, assert no release was published). That needs a harness that doesn't exist: `ReleasePlan` is never constructed in tests today, and `publish_releases` builds its forge internally from config. I added the `publish_releases_with(plan, &dyn Forge)` seam that such a test would use, but building the rest (real repo + bare remote + injected forge) is its own piece of work — I'd rather leave the gap visible than pad this PR with a test that can't fail.

What the split does give for free is structural: `push_refs` takes no forge, so it is impossible for it to publish anything. The remaining risk is someone reordering the two calls in `execute_release`, which the phase ordering in `phases_are_strictly_ordered` documents but does not enforce.
