### PR TITLE
feat(formats): add Cabal (.cabal) and CMake project version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ A single compiled binary with no runtime dependencies. Native monorepo support, 
 | `mixexs` | `mix.exs` | Elixir | `version: "…"` in `def project` |
 | `gemspec` | `*.gemspec` | Ruby | `s.version = "…"` |
 | `packageswift` | `Package.swift` | Swift | top-level `let <name>Version = "…"` |
+| `cabal` | `*.cabal` | Haskell | top-level `version:` field |
+| `cmake` | `CMakeLists.txt` | C / C++ | `VERSION` argument of `project()` |
 | `gomod` | `go.mod` | Go | git tag only — no file write |
 | `txt` | `VERSION`, `VERSION.txt` | Any | entire file content |
 

--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -441,6 +441,8 @@
                     "mixexs",
                     "gemspec",
                     "packageswift",
+                    "cabal",
+                    "cmake",
                     "txt"
                   ]
                 },

--- a/src/config/migrate/release_please.rs
+++ b/src/config/migrate/release_please.rs
@@ -269,6 +269,10 @@ fn format_from_ext(path: &str) -> Option<FileFormat> {
         Some(FileFormat::Gemspec)
     } else if lower.ends_with(".xml") {
         Some(FileFormat::Xml)
+    } else if lower.ends_with(".cabal") {
+        Some(FileFormat::Cabal)
+    } else if basename == "cmakelists.txt" {
+        Some(FileFormat::Cmake)
     } else if lower.ends_with(".txt") || basename == "version" {
         Some(FileFormat::Txt)
     } else {
@@ -458,6 +462,31 @@ mod tests {
         assert!(matches!(
             cfg.packages[0].versioned_files[0].format,
             FileFormat::Gemspec
+        ));
+    }
+
+    // `CMakeLists.txt` ends in `.txt`, so the cmake branch has to be checked
+    // first or the file is inferred as a plain-text version file and the whole
+    // CMakeLists gets overwritten with a bare version string.
+    #[test]
+    fn cmakelists_is_inferred_as_cmake_not_txt() {
+        let (cfg, _) = build_ok(
+            r#"{"packages": {"native": {"release-type": "simple", "version-file": "CMakeLists.txt"}}}"#,
+        );
+        assert!(matches!(
+            cfg.packages[0].versioned_files[0].format,
+            FileFormat::Cmake
+        ));
+    }
+
+    #[test]
+    fn cabal_file_is_inferred_from_its_extension() {
+        let (cfg, _) = build_ok(
+            r#"{"packages": {"hs": {"release-type": "simple", "version-file": "my-package.cabal"}}}"#,
+        );
+        assert!(matches!(
+            cfg.packages[0].versioned_files[0].format,
+            FileFormat::Cabal
         ));
     }
 

--- a/src/config/package.rs
+++ b/src/config/package.rs
@@ -166,4 +166,9 @@ pub enum FileFormat {
     /// `Package.swift` for Swift packages.
     #[serde(rename = "packageswift")]
     PackageSwift,
+    /// `*.cabal` for Haskell packages.
+    Cabal,
+    /// `CMakeLists.txt` — the `VERSION` argument of the `project()` call.
+    #[serde(rename = "cmake")]
+    Cmake,
 }

--- a/src/error_code.rs
+++ b/src/error_code.rs
@@ -286,6 +286,24 @@ pub const PACKAGE_SWIFT_WRITE: ErrorCode = ErrorCode(4843);
 pub const PACKAGE_SWIFT_INVALID_UTF8: ErrorCode = ErrorCode(4844);
 
 #[allow(dead_code)]
+pub const CABAL_READ: ErrorCode = ErrorCode(4851);
+#[allow(dead_code)]
+pub const CABAL_VERSION_NOT_FOUND: ErrorCode = ErrorCode(4852);
+#[allow(dead_code)]
+pub const CABAL_WRITE: ErrorCode = ErrorCode(4853);
+#[allow(dead_code)]
+pub const CABAL_INVALID_UTF8: ErrorCode = ErrorCode(4854);
+
+#[allow(dead_code)]
+pub const CMAKE_READ: ErrorCode = ErrorCode(4861);
+#[allow(dead_code)]
+pub const CMAKE_VERSION_NOT_FOUND: ErrorCode = ErrorCode(4862);
+#[allow(dead_code)]
+pub const CMAKE_WRITE: ErrorCode = ErrorCode(4863);
+#[allow(dead_code)]
+pub const CMAKE_INVALID_UTF8: ErrorCode = ErrorCode(4864);
+
+#[allow(dead_code)]
 pub const PRERELEASE_EMPTY_CHANNEL: ErrorCode = ErrorCode(5001);
 #[allow(dead_code)]
 pub const PRERELEASE_INVALID_CHANNEL: ErrorCode = ErrorCode(5002);

--- a/src/formats/cabal.rs
+++ b/src/formats/cabal.rs
@@ -1,0 +1,148 @@
+use super::VersionFile;
+use crate::error_code::{self, ErrorCodeExt};
+use anyhow::{Context, Result};
+use regex::Regex;
+use std::path::Path;
+use std::sync::OnceLock;
+
+pub struct CabalVersionFile;
+
+static VERSION_RE: OnceLock<Regex> = OnceLock::new();
+
+// Cabal field names are case-insensitive and top-level fields sit at column 0,
+// which is what keeps this off `version:` fields nested inside stanzas. The
+// leading `^` also excludes `cabal-version:`, a different field that would
+// otherwise match a looser pattern.
+fn version_re() -> &'static Regex {
+    VERSION_RE.get_or_init(|| Regex::new(r"(?im)^(version[ \t]*:[ \t]*)(\S+)").unwrap())
+}
+
+impl VersionFile for CabalVersionFile {
+    fn read_version(&self, file_path: &Path) -> Result<String> {
+        let content = std::fs::read_to_string(file_path)
+            .with_context(|| format!("Cannot read {}", file_path.display()))
+            .error_code(error_code::CABAL_READ)?;
+        self.read_version_from_bytes(content.as_bytes(), &file_path.display().to_string())
+    }
+
+    fn write_version(&self, file_path: &Path, version: &str) -> Result<()> {
+        super::splice::write_via_splice(self, file_path, version, None)
+    }
+
+    fn read_version_from_bytes(&self, content: &[u8], filename: &str) -> Result<String> {
+        let text = std::str::from_utf8(content)
+            .with_context(|| format!("Invalid UTF-8 in {filename}"))
+            .error_code(error_code::CABAL_INVALID_UTF8)?;
+        version_re()
+            .captures(text)
+            .map(|c| c[2].to_string())
+            .ok_or_else(|| anyhow::anyhow!("No top-level `version:` field found in {filename}"))
+            .error_code(error_code::CABAL_VERSION_NOT_FOUND)
+    }
+}
+
+impl super::splice::FormatPreservingEditor for CabalVersionFile {
+    fn locate_version(
+        &self,
+        content: &str,
+        _selector: Option<&str>,
+    ) -> Result<std::ops::Range<usize>> {
+        version_re()
+            .captures(content)
+            .map(|c| c.get(2).unwrap().range())
+            .ok_or_else(|| anyhow::anyhow!("No top-level `version:` field found"))
+            .error_code(error_code::CABAL_VERSION_NOT_FOUND)
+    }
+
+    fn read_error(&self) -> crate::error_code::ErrorCode {
+        error_code::CABAL_READ
+    }
+
+    fn write_error(&self) -> crate::error_code::ErrorCode {
+        error_code::CABAL_WRITE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_temp(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f
+    }
+
+    const FIXTURE: &str = r#"cabal-version:      2.4
+name:               my-package
+version:            0.1.0.0
+synopsis:           An example package
+license:            BSD-3-Clause
+build-type:         Simple
+
+library
+    exposed-modules:  MyLib
+    build-depends:    base >=4.7 && <5
+    default-language: Haskell2010
+"#;
+
+    #[test]
+    fn read_canonical_cabal() {
+        let f = write_temp(FIXTURE);
+        assert_eq!(CabalVersionFile.read_version(f.path()).unwrap(), "0.1.0.0");
+    }
+
+    #[test]
+    fn write_preserves_column_alignment() {
+        let f = write_temp(FIXTURE);
+        CabalVersionFile.write_version(f.path(), "0.2.0.0").unwrap();
+        let out = std::fs::read_to_string(f.path()).unwrap();
+        assert!(out.contains("version:            0.2.0.0"));
+        assert!(out.contains("name:               my-package"));
+    }
+
+    // `cabal-version` declares the format of the file, not the package
+    // version. Bumping it would change which Cabal features are available.
+    #[test]
+    fn cabal_version_field_is_not_mistaken_for_the_package_version() {
+        let f = write_temp(FIXTURE);
+        assert_eq!(CabalVersionFile.read_version(f.path()).unwrap(), "0.1.0.0");
+
+        CabalVersionFile.write_version(f.path(), "9.9.9").unwrap();
+        let out = std::fs::read_to_string(f.path()).unwrap();
+        assert!(out.contains("cabal-version:      2.4"));
+    }
+
+    // Stanza fields are indented; only the column-0 field is the package
+    // version. A nested `version:` must not win.
+    #[test]
+    fn indented_version_field_is_ignored() {
+        let f = write_temp("name: pkg\nversion: 1.0.0\n\nlibrary\n    version: 9.9.9\n");
+        assert_eq!(CabalVersionFile.read_version(f.path()).unwrap(), "1.0.0");
+
+        CabalVersionFile.write_version(f.path(), "1.1.0").unwrap();
+        let out = std::fs::read_to_string(f.path()).unwrap();
+        assert!(out.contains("version: 1.1.0"));
+        assert!(out.contains("    version: 9.9.9"));
+    }
+
+    #[test]
+    fn read_uppercase_field_name() {
+        let f = write_temp("Name: pkg\nVersion: 2.3.4\n");
+        assert_eq!(CabalVersionFile.read_version(f.path()).unwrap(), "2.3.4");
+    }
+
+    #[test]
+    fn read_no_version_fails() {
+        let f = write_temp("name: pkg\nsynopsis: nothing here\n");
+        assert!(CabalVersionFile.read_version(f.path()).is_err());
+    }
+
+    #[test]
+    fn read_rejects_cabal_version_only_file() {
+        let f = write_temp("cabal-version: 2.4\nname: pkg\n");
+        assert!(CabalVersionFile.read_version(f.path()).is_err());
+    }
+}

--- a/src/formats/cmake.rs
+++ b/src/formats/cmake.rs
@@ -1,0 +1,157 @@
+use super::VersionFile;
+use crate::error_code::{self, ErrorCodeExt};
+use anyhow::{Context, Result};
+use regex::Regex;
+use std::path::Path;
+use std::sync::OnceLock;
+
+pub struct CmakeVersionFile;
+
+static VERSION_RE: OnceLock<Regex> = OnceLock::new();
+
+// Anchored on the `project(` call so a `set(FOO_VERSION …)` elsewhere in the
+// file can't match. `[^)]*?` keeps the search inside that call's parentheses,
+// which is also what lets the common multi-line form work:
+//
+//     project(MyProj
+//         VERSION 1.2.3
+//         LANGUAGES CXX)
+//
+// Command names are case-insensitive in CMake; the `VERSION` keyword is
+// conventionally uppercase but is matched case-insensitively for tolerance.
+fn version_re() -> &'static Regex {
+    VERSION_RE
+        .get_or_init(|| Regex::new(r"(?is)\bproject\s*\([^)]*?\bVERSION\s+([^\s)]+)").unwrap())
+}
+
+impl VersionFile for CmakeVersionFile {
+    fn read_version(&self, file_path: &Path) -> Result<String> {
+        let content = std::fs::read_to_string(file_path)
+            .with_context(|| format!("Cannot read {}", file_path.display()))
+            .error_code(error_code::CMAKE_READ)?;
+        self.read_version_from_bytes(content.as_bytes(), &file_path.display().to_string())
+    }
+
+    fn write_version(&self, file_path: &Path, version: &str) -> Result<()> {
+        super::splice::write_via_splice(self, file_path, version, None)
+    }
+
+    fn read_version_from_bytes(&self, content: &[u8], filename: &str) -> Result<String> {
+        let text = std::str::from_utf8(content)
+            .with_context(|| format!("Invalid UTF-8 in {filename}"))
+            .error_code(error_code::CMAKE_INVALID_UTF8)?;
+        version_re()
+            .captures(text)
+            .map(|c| c[1].to_string())
+            .ok_or_else(|| {
+                anyhow::anyhow!("No `project(… VERSION …)` declaration found in {filename}")
+            })
+            .error_code(error_code::CMAKE_VERSION_NOT_FOUND)
+    }
+}
+
+impl super::splice::FormatPreservingEditor for CmakeVersionFile {
+    fn locate_version(
+        &self,
+        content: &str,
+        _selector: Option<&str>,
+    ) -> Result<std::ops::Range<usize>> {
+        version_re()
+            .captures(content)
+            .map(|c| c.get(1).unwrap().range())
+            .ok_or_else(|| anyhow::anyhow!("No `project(… VERSION …)` declaration found"))
+            .error_code(error_code::CMAKE_VERSION_NOT_FOUND)
+    }
+
+    fn read_error(&self) -> crate::error_code::ErrorCode {
+        error_code::CMAKE_READ
+    }
+
+    fn write_error(&self) -> crate::error_code::ErrorCode {
+        error_code::CMAKE_WRITE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_temp(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f
+    }
+
+    const FIXTURE: &str = r#"cmake_minimum_required(VERSION 3.20)
+
+project(MyProject VERSION 1.2.3 LANGUAGES CXX)
+
+add_executable(app main.cpp)
+"#;
+
+    #[test]
+    fn read_single_line_project() {
+        let f = write_temp(FIXTURE);
+        assert_eq!(CmakeVersionFile.read_version(f.path()).unwrap(), "1.2.3");
+    }
+
+    #[test]
+    fn write_preserves_the_rest_of_the_call() {
+        let f = write_temp(FIXTURE);
+        CmakeVersionFile.write_version(f.path(), "2.0.0").unwrap();
+        let out = std::fs::read_to_string(f.path()).unwrap();
+        assert!(out.contains("project(MyProject VERSION 2.0.0 LANGUAGES CXX)"));
+    }
+
+    // `cmake_minimum_required(VERSION 3.20)` is the CMake tool version, not the
+    // project version. Bumping it would raise the required toolchain.
+    #[test]
+    fn cmake_minimum_required_is_not_mistaken_for_the_project_version() {
+        let f = write_temp(FIXTURE);
+        CmakeVersionFile.write_version(f.path(), "9.9.9").unwrap();
+        let out = std::fs::read_to_string(f.path()).unwrap();
+        assert!(out.contains("cmake_minimum_required(VERSION 3.20)"));
+        assert!(out.contains("VERSION 9.9.9 LANGUAGES"));
+    }
+
+    #[test]
+    fn read_multiline_project() {
+        let f = write_temp(
+            "project(MyProject\n    VERSION 0.4.1\n    DESCRIPTION \"demo\"\n    LANGUAGES C CXX\n)\n",
+        );
+        assert_eq!(CmakeVersionFile.read_version(f.path()).unwrap(), "0.4.1");
+    }
+
+    #[test]
+    fn write_multiline_project_keeps_layout() {
+        let f = write_temp("project(MyProject\n    VERSION 0.4.1\n    LANGUAGES C CXX\n)\n");
+        CmakeVersionFile.write_version(f.path(), "0.5.0").unwrap();
+        let out = std::fs::read_to_string(f.path()).unwrap();
+        assert_eq!(
+            out,
+            "project(MyProject\n    VERSION 0.5.0\n    LANGUAGES C CXX\n)\n"
+        );
+    }
+
+    #[test]
+    fn read_lowercase_command_name() {
+        let f = write_temp("PROJECT(Foo VERSION 3.1.4)\n");
+        assert_eq!(CmakeVersionFile.read_version(f.path()).unwrap(), "3.1.4");
+    }
+
+    // A `set(..._VERSION ...)` variable is not the project version, and must not
+    // be picked up when the project() call carries no VERSION of its own.
+    #[test]
+    fn set_version_variable_is_not_matched() {
+        let f = write_temp("project(Foo LANGUAGES CXX)\nset(FOO_VERSION 7.7.7)\n");
+        assert!(CmakeVersionFile.read_version(f.path()).is_err());
+    }
+
+    #[test]
+    fn read_no_project_fails() {
+        let f = write_temp("cmake_minimum_required(VERSION 3.20)\nadd_library(x x.c)\n");
+        assert!(CmakeVersionFile.read_version(f.path()).is_err());
+    }
+}

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -1,4 +1,6 @@
+pub mod cabal;
 pub mod chart_yaml;
+pub mod cmake;
 pub mod csproj;
 pub mod gemspec;
 pub mod gomod;
@@ -102,6 +104,8 @@ pub fn get_handler(format: &FileFormat) -> Box<dyn VersionFile> {
         FileFormat::ChartYaml => Box::new(chart_yaml::ChartYamlVersionFile),
         FileFormat::Gemspec => Box::new(gemspec::GemspecVersionFile),
         FileFormat::PackageSwift => Box::new(package_swift::PackageSwiftVersionFile),
+        FileFormat::Cabal => Box::new(cabal::CabalVersionFile),
+        FileFormat::Cmake => Box::new(cmake::CmakeVersionFile),
     }
 }
 
@@ -157,6 +161,8 @@ mod tests {
             FileFormat::ChartYaml,
             FileFormat::Gemspec,
             FileFormat::PackageSwift,
+            FileFormat::Cabal,
+            FileFormat::Cmake,
         ] {
             let _ = get_handler(format);
         }
@@ -222,6 +228,8 @@ mod tests {
             FileFormat::ChartYaml,
             FileFormat::Gemspec,
             FileFormat::PackageSwift,
+            FileFormat::Cabal,
+            FileFormat::Cmake,
         ] {
             let handler = get_handler(format);
             assert!(


### PR DESCRIPTION
Closes #415.

Adds `cabal` and `cmake` to the supported version-file formats, bringing the table to 16. Both follow the existing regex + `write_via_splice` pattern, so the surrounding bytes of the file are untouched — only the version span is replaced.

## `cabal`

Matches the top-level `version:` field. Cabal field names are case-insensitive and top-level fields sit at column 0, so the pattern is anchored to the start of a line. Two things that anchoring buys:

- **`cabal-version:` is never touched.** It declares which Cabal format the file uses; bumping it would change which language features are available. A looser pattern would have matched it.
- **Indented `version:` fields inside stanzas are ignored** — only the package's own version is a candidate.

## `cmake`

Matches the `VERSION` argument of the `project()` call, anchored on `project(` with the search confined inside its parentheses. That confinement is what makes the common multi-line form work:

```cmake
project(MyProject
    VERSION 1.2.3
    LANGUAGES CXX)
```

and what keeps two neighbours safe: **`cmake_minimum_required(VERSION 3.20)`** (the toolchain floor, not the project version) and a stray **`set(FOO_VERSION …)`** variable. Both have regression tests.

## Format inference

Wired into `format_from_ext` (the release-please migration path). One ordering detail worth flagging: **`CMakeLists.txt` ends in `.txt`**, so the cmake branch has to be checked before the txt branch — otherwise the file is inferred as a plain-text version file and `write_version` overwrites the entire CMakeLists with a bare version string. `cmakelists_is_inferred_as_cmake_not_txt` guards it.

## Also updated

- `FileFormat` enum (`cabal`, `cmake`), handler registry, and the two exhaustive-format test lists in `formats/mod.rs`.
- Error codes `4851–4854` (Cabal) and `4861–4864` (CMake), following the per-format block convention.
- `schema/ferrflow.json` enum, and README table 14 → 16.
- The cloud schema copy and the docs site are a separate FerrFlow-Cloud PR (cross-repo changes don't share a PR).

17 new tests. Full suite green (1777), `clippy --all-targets -D warnings` clean.

## Note on the acceptance criteria

The issue asks for fixtures under `tests/fixtures/cabal/` and `tests/fixtures/cmake/`. That layout doesn't exist in the repo — `tests/fixtures/` holds `conventional_commits/`, `definitions/` and `run-tests.sh`, and every format module keeps its fixtures inline in a `#[cfg(test)] mod tests`. I followed the existing convention rather than introducing a second one.
