### PR TITLE
fix(ci): sign release artifacts with cosign bundles

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -183,11 +183,15 @@ jobs:
         # is the workflow's OIDC token, recorded in the Rekor transparency
         # log. Verify with:
         #   cosign verify-blob \
-        #     --certificate ferrflow-linux-x64.tar.gz.crt \
-        #     --signature   ferrflow-linux-x64.tar.gz.sig \
+        #     --bundle ferrflow-linux-x64.tar.gz.bundle \
         #     --certificate-identity-regexp "https://github.com/FerrLabs/FerrFlow/.*" \
         #     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
         #     ferrflow-linux-x64.tar.gz
+        #
+        # One `.bundle` per artifact replaces the `.sig` + `.crt` pair as of
+        # cosign v3: `--use-signing-config` now defaults to true and requires
+        # `--bundle`, and `--output-signature` / `--output-certificate` are
+        # deprecated. Releases up to v5.47.4 carry the old pair.
         env:
           COSIGN_EXPERIMENTAL: "1"
         run: |
@@ -200,8 +204,7 @@ jobs:
             local artifact="$1" attempt
             for attempt in 1 2 3; do
               if cosign sign-blob --yes \
-                  --output-signature "${artifact}.sig" \
-                  --output-certificate "${artifact}.crt" \
+                  --bundle "${artifact}.bundle" \
                   "$artifact"; then
                 return 0
               fi
@@ -246,8 +249,7 @@ jobs:
           set -euo pipefail
           for attempt in 1 2 3; do
             if cosign sign-blob --yes \
-                --output-signature artifacts/sbom.cdx.json.sig \
-                --output-certificate artifacts/sbom.cdx.json.crt \
+                --bundle artifacts/sbom.cdx.json.bundle \
                 artifacts/sbom.cdx.json; then
               exit 0
             fi

--- a/docs/verifying-releases.md
+++ b/docs/verifying-releases.md
@@ -8,19 +8,24 @@ log.
 
 ## What ships per release
 
-| Artifact | Sidecars |
+| Artifact | Sidecar |
 |---|---|
-| `ferrflow-linux-x64.tar.gz` | `.sig`, `.crt` |
-| `ferrflow-linux-arm64.tar.gz` | `.sig`, `.crt` |
-| `ferrflow-darwin-x64.tar.gz` | `.sig`, `.crt` |
-| `ferrflow-darwin-arm64.tar.gz` | `.sig`, `.crt` |
-| `ferrflow-windows-x64.zip` | `.sig`, `.crt` |
-| `sbom.cdx.json` | `.sig`, `.crt` |
+| `ferrflow-linux-x64.tar.gz` | `.bundle` |
+| `ferrflow-linux-arm64.tar.gz` | `.bundle` |
+| `ferrflow-darwin-x64.tar.gz` | `.bundle` |
+| `ferrflow-darwin-arm64.tar.gz` | `.bundle` |
+| `ferrflow-windows-x64.zip` | `.bundle` |
+| `sbom.cdx.json` | `.bundle` |
 | `ghcr.io/ferrlabs/ferrflow:vX.Y.Z` | Cosign signature recorded in
 GHCR + Rekor |
 
 All sidecars are downloadable from the GitHub Release page next to the
 binary.
+
+> **Releases up to v5.47.4** ship a `.sig` + `.crt` pair instead of a single
+> `.bundle`. Verify those with `--certificate <file>.crt --signature <file>.sig`
+> in place of `--bundle`. The switch came with cosign v3, which deprecated the
+> separate signature and certificate outputs in favour of one bundle.
 
 ## Verifying a tarball
 
@@ -30,14 +35,13 @@ curl -L https://github.com/sigstore/cosign/releases/latest/download/cosign-linux
   -o /usr/local/bin/cosign && chmod +x /usr/local/bin/cosign
 
 # download the artifact + sidecars from the release page
-TAG=v5.0.1
+TAG=v5.48.0
 gh release download "$TAG" --repo FerrLabs/FerrFlow \
   -p 'ferrflow-linux-x64.tar.gz*'
 
 # verify
 cosign verify-blob \
-  --certificate ferrflow-linux-x64.tar.gz.crt \
-  --signature   ferrflow-linux-x64.tar.gz.sig \
+  --bundle ferrflow-linux-x64.tar.gz.bundle \
   --certificate-identity-regexp "https://github.com/FerrLabs/FerrFlow/.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   ferrflow-linux-x64.tar.gz
@@ -51,7 +55,7 @@ A passing verification means:
 - The signing identity was a workflow running in `FerrLabs/FerrFlow`
   triggered by GitHub Actions' OIDC issuer.
 - The signature is recorded in the public Rekor log (
-  https://search.sigstore.dev/ — search for the `.sig` value).
+  https://search.sigstore.dev/ — search for the artifact's digest).
 
 ## Verifying the Docker image
 


### PR DESCRIPTION
Unblocks the v5.48.0 publish, which failed with:

```
Error: must specify --bundle with --new-bundle-format
cosign signing failed for artifacts/ferrflow-completions.tar.gz after 3 attempts
```

All seven platform builds succeeded; `Upload Release Assets` died on signing, so npm / crates.io / Docker / wasm were all skipped and the release is sitting there with no artifacts.

## Cause

#768 bumped `cosign-release` to v3.1.2. In cosign v3, `--use-signing-config` defaults to **true** and requires `--bundle`, while `--output-signature` / `--output-certificate` are deprecated (and already hidden from `cosign sign-blob --help`). The signing step was still on the v2 flags.

## Change

One `.bundle` per artifact replaces the `.sig` + `.crt` pair, for both the release artifacts and the SBOM. `gh release upload` globs `artifacts/*`, so the new sidecars attach with no change there.

Verification becomes:

```bash
cosign verify-blob   --bundle ferrflow-linux-x64.tar.gz.bundle   --certificate-identity-regexp "https://github.com/FerrLabs/FerrFlow/.*"   --certificate-oidc-issuer https://token.actions.githubusercontent.com   ferrflow-linux-x64.tar.gz
```

`docs/verifying-releases.md` is updated to match, and keeps a note that **releases up to v5.47.4 carry the old `.sig` + `.crt` pair** — those stay verifiable with the previous flags. The example tag moved to v5.48.0 so a copy-paste actually finds a `.bundle`.

## Follow-ups (separate PRs, this is cross-repo)

- **FerrLabs-Cloud** — `GET /v1/ferrflow/latest` returns `signature_url` + `cert_url`. Needs a `bundle_url`, keeping the old fields populated for releases that still have them.
- **FerrFlow-Cloud** — the site's `verifying-releases` and `reference/api` pages (EN + FR).
- **Changelog** — user-visible change to how releases are verified.

Re-running the Publish workflow for v5.48.0 after this merges should complete it.