### PR TITLE
feat(migrate): auto-discover workspace packages for changesets

### DIFF
--- a/src/config/migrate.rs
+++ b/src/config/migrate.rs
@@ -16,6 +16,7 @@ use super::workspace::WorkspaceConfig;
 mod changesets;
 mod release_please;
 mod standard_version;
+mod workspace_packages;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Source {

--- a/src/config/migrate/changesets.rs
+++ b/src/config/migrate/changesets.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use serde::Deserialize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::config::Config;
 use crate::config::package::{FileFormat, PackageConfig, VersionedFile};
@@ -20,7 +20,7 @@ pub(super) fn run() -> Result<()> {
     let path = detect().ok_or_else(|| anyhow::anyhow!("no {CONFIG_FILE} found"))?;
     let raw = std::fs::read_to_string(&path)
         .map_err(|e| anyhow::anyhow!("could not read {}: {e}", path.display()))?;
-    let (config, report) = build(&raw)?;
+    let (config, report) = build(&raw, Path::new("."))?;
     write_and_report(Source::Changesets, &path, &config, &report)
 }
 
@@ -40,7 +40,7 @@ struct ChangesetsConfig {
     ignore: Vec<String>,
 }
 
-pub(super) fn build(raw: &str) -> Result<(Config, MigrationReport)> {
+pub(super) fn build(raw: &str, root: &Path) -> Result<(Config, MigrationReport)> {
     let cs: ChangesetsConfig = serde_json::from_str(raw)
         .map_err(|e| anyhow::anyhow!("could not parse {CONFIG_FILE} as JSON: {e}"))
         .error_code(error_code::CONFIG_INVALID_JSON)?;
@@ -97,16 +97,61 @@ pub(super) fn build(raw: &str) -> Result<(Config, MigrationReport)> {
     }
 
     // changesets discovers packages from the JS workspace; ferrflow needs them
-    // listed explicitly. Scaffold a single root package and tell the user.
-    let package = PackageConfig {
-        name: crate::config::migrate::default_package_name(),
-        path: ".".to_string(),
+    // listed explicitly, so expand the same globs it uses (#747).
+    let discovered = super::workspace_packages::discover(root);
+    let packages = if discovered.is_empty() {
+        report.warnings.push(
+            "no JS workspace found (`workspaces` in package.json or pnpm-workspace.yaml), so a \
+             single root package was scaffolded. If this is a monorepo, list each publishable \
+             package under `package`."
+                .to_string(),
+        );
+        vec![scaffold_package(
+            crate::config::migrate::default_package_name(),
+            ".".to_string(),
+        )]
+    } else {
+        report.mapped.push(format!(
+            "workspace globs → {} package(s) discovered",
+            discovered.len()
+        ));
+        discovered
+            .into_iter()
+            .map(|p| scaffold_package(p.name, p.path))
+            .collect()
+    };
+
+    warn_about_unmatched_groups(&cs, &packages, &mut report);
+
+    Ok((
+        Config {
+            workspace,
+            packages,
+        },
+        report,
+    ))
+}
+
+fn scaffold_package(name: String, path: String) -> PackageConfig {
+    let manifest = if path == "." {
+        "package.json".to_string()
+    } else {
+        format!("{path}/package.json")
+    };
+    let changelog = if path == "." {
+        "CHANGELOG.md".to_string()
+    } else {
+        format!("{path}/CHANGELOG.md")
+    };
+    PackageConfig {
+        name,
+        path,
         versioned_files: vec![VersionedFile {
-            path: "package.json".to_string(),
+            path: manifest,
             format: FileFormat::Json,
             selector: None,
         }],
-        changelog: Some("CHANGELOG.md".to_string()),
+        changelog: Some(changelog),
         shared_paths: Vec::new(),
         depends_on: vec![],
         versioning: None,
@@ -115,29 +160,138 @@ pub(super) fn build(raw: &str) -> Result<(Config, MigrationReport)> {
         floating_tags: None,
         publishers: vec![],
         update_lockfiles: None,
-    };
-    report.warnings.push(
-        "changesets is a monorepo tool; ferrflow can't read your workspace globs, so it \
-         scaffolded a single root package. List each workspace package under `package` (one entry \
-         per publishable package)."
-            .to_string(),
-    );
+    }
+}
 
-    Ok((
-        Config {
-            workspace,
-            packages: vec![package],
-        },
-        report,
-    ))
+/// `linked` / `fixed` name packages by their npm name. A group entry that
+/// matches nothing we scaffolded would make the migrated config fail
+/// `ferrflow validate`, so say which ones up front.
+fn warn_about_unmatched_groups(
+    cs: &ChangesetsConfig,
+    packages: &[PackageConfig],
+    report: &mut MigrationReport,
+) {
+    let known: Vec<&str> = packages.iter().map(|p| p.name.as_str()).collect();
+    let mut unmatched: Vec<&str> = cs
+        .linked
+        .iter()
+        .chain(cs.fixed.iter())
+        .flatten()
+        .map(String::as_str)
+        .filter(|name| !known.contains(name))
+        .collect();
+    unmatched.sort_unstable();
+    unmatched.dedup();
+
+    if !unmatched.is_empty() {
+        report.warnings.push(format!(
+            "linked/fixed reference {} package(s) that were not discovered ({}). Add them under \
+             `package` or drop them from the group, otherwise `ferrflow validate` fails.",
+            unmatched.len(),
+            unmatched.join(", ")
+        ));
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// Builds against an empty directory, i.e. a repo that declares no JS
+    /// workspace — the single-root-package fallback.
     fn build_ok(raw: &str) -> (Config, MigrationReport) {
-        build(raw).expect("valid changesets config")
+        let dir = tempfile::tempdir().unwrap();
+        build(raw, dir.path()).expect("valid changesets config")
+    }
+
+    fn write(root: &std::path::Path, rel: &str, contents: &str) {
+        let path = root.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    /// A pnpm monorepo laid out the way changesets expects.
+    fn workspace_dir() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(root, "package.json", r#"{"name": "root", "private": true}"#);
+        write(root, "pnpm-workspace.yaml", "packages:\n  - 'packages/*'\n");
+        write(
+            root,
+            "packages/a/package.json",
+            r#"{"name": "@acme/a", "version": "1.0.0"}"#,
+        );
+        write(
+            root,
+            "packages/b/package.json",
+            r#"{"name": "@acme/b", "version": "2.0.0"}"#,
+        );
+        dir
+    }
+
+    #[test]
+    fn workspace_packages_are_scaffolded_one_entry_each() {
+        let dir = workspace_dir();
+        let (cfg, report) = build(r#"{}"#, dir.path()).unwrap();
+
+        let names: Vec<&str> = cfg.packages.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["@acme/a", "@acme/b"]);
+
+        let a = &cfg.packages[0];
+        assert_eq!(a.path, "packages/a");
+        assert_eq!(a.versioned_files[0].path, "packages/a/package.json");
+        assert_eq!(a.changelog.as_deref(), Some("packages/a/CHANGELOG.md"));
+
+        assert!(report.mapped.iter().any(|m| m.contains("2 package(s)")));
+        assert!(
+            !report.warnings.iter().any(|w| w.contains("single root")),
+            "the hand-list-your-packages warning is obsolete once discovery works"
+        );
+    }
+
+    // The whole point of #747: a discovered workspace makes the linked/fixed
+    // groups reference packages that actually exist in the emitted config.
+    #[test]
+    fn discovered_packages_satisfy_the_linked_groups() {
+        let dir = workspace_dir();
+        let (cfg, report) = build(r#"{"linked": [["@acme/a", "@acme/b"]]}"#, dir.path()).unwrap();
+
+        let names: Vec<&str> = cfg.packages.iter().map(|p| p.name.as_str()).collect();
+        for member in cfg.workspace.linked.iter().flatten() {
+            assert!(
+                names.contains(&member.as_str()),
+                "{member} is in a linked group but was not scaffolded"
+            );
+        }
+        assert!(!report.warnings.iter().any(|w| w.contains("not discovered")));
+    }
+
+    #[test]
+    fn a_group_member_outside_the_workspace_is_warned_about() {
+        let dir = workspace_dir();
+        let (_, report) = build(r#"{"fixed": [["@acme/a", "@acme/ghost"]]}"#, dir.path()).unwrap();
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|w| w.contains("not discovered") && w.contains("@acme/ghost")),
+            "warnings were: {:?}",
+            report.warnings
+        );
+    }
+
+    #[test]
+    fn a_repo_without_a_workspace_still_gets_a_root_package() {
+        let (cfg, report) = build_ok("{}");
+        assert_eq!(cfg.packages.len(), 1);
+        assert_eq!(cfg.packages[0].path, ".");
+        assert_eq!(cfg.packages[0].versioned_files[0].path, "package.json");
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|w| w.contains("no JS workspace"))
+        );
     }
 
     #[test]
@@ -168,13 +322,6 @@ mod tests {
     }
 
     #[test]
-    fn monorepo_scaffold_warning_is_present() {
-        let (cfg, report) = build_ok("{}");
-        assert_eq!(cfg.packages.len(), 1);
-        assert!(report.warnings.iter().any(|w| w.contains("monorepo tool")));
-    }
-
-    #[test]
     fn access_is_reported_as_ignored() {
         let (_, report) = build_ok(r#"{"access": "public"}"#);
         assert!(report.ignored.iter().any(|i| i.contains("access")));
@@ -188,6 +335,7 @@ mod tests {
 
     #[test]
     fn malformed_json_is_an_error() {
-        assert!(build("{ not json").is_err());
+        let dir = tempfile::tempdir().unwrap();
+        assert!(build("{ not json", dir.path()).is_err());
     }
 }

--- a/src/config/migrate/workspace_packages.rs
+++ b/src/config/migrate/workspace_packages.rs
@@ -1,0 +1,326 @@
+use std::path::Path;
+
+/// A `package.json` found by expanding the JS workspace globs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct DiscoveredPackage {
+    /// `name` from the manifest, falling back to the directory name when the
+    /// manifest is nameless (private workspace roots often are).
+    pub name: String,
+    /// Slash-separated path relative to the repo root.
+    pub path: String,
+}
+
+const SKIP_DIRS: &[&str] = &[
+    "node_modules",
+    ".git",
+    "target",
+    "dist",
+    "build",
+    ".next",
+    ".turbo",
+    "coverage",
+    "vendor",
+];
+
+/// Deep enough for `apps/*/packages/*` style layouts without walking a whole
+/// monorepo's build output.
+const MAX_DEPTH: usize = 6;
+
+/// Reads workspace globs from `package.json` and `pnpm-workspace.yaml`, then
+/// returns every `package.json` under a directory matching one of them.
+///
+/// Returns an empty vec when the repo declares no workspace, which is the
+/// signal to fall back to a single root package.
+pub(super) fn discover(root: &Path) -> Vec<DiscoveredPackage> {
+    let globs = workspace_globs(root);
+    if globs.is_empty() {
+        return Vec::new();
+    }
+
+    let mut found = Vec::new();
+    collect(root, root, 0, &globs, &mut found);
+    found.sort_by(|a, b| a.path.cmp(&b.path));
+    found.dedup_by(|a, b| a.path == b.path);
+
+    let excluded: Vec<&str> = globs.iter().filter_map(|g| g.strip_prefix('!')).collect();
+    found.retain(|p| !excluded.iter().any(|g| glob_match::glob_match(g, &p.path)));
+    found
+}
+
+fn workspace_globs(root: &Path) -> Vec<String> {
+    let mut globs = globs_from_package_json(root);
+    globs.extend(globs_from_pnpm_workspace(root));
+    globs.sort();
+    globs.dedup();
+    globs
+}
+
+fn globs_from_package_json(root: &Path) -> Vec<String> {
+    let Ok(raw) = std::fs::read_to_string(root.join("package.json")) else {
+        return Vec::new();
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return Vec::new();
+    };
+    match value.get("workspaces") {
+        // npm / yarn classic: "workspaces": ["packages/*"]
+        Some(serde_json::Value::Array(items)) => string_list(items),
+        // yarn berry: "workspaces": { "packages": ["packages/*"] }
+        Some(serde_json::Value::Object(obj)) => obj
+            .get("packages")
+            .and_then(|p| p.as_array())
+            .map(|items| string_list(items))
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}
+
+fn globs_from_pnpm_workspace(root: &Path) -> Vec<String> {
+    let raw = ["pnpm-workspace.yaml", "pnpm-workspace.yml"]
+        .iter()
+        .find_map(|name| std::fs::read_to_string(root.join(name)).ok());
+    let Some(raw) = raw else {
+        return Vec::new();
+    };
+    let Ok(value) = serde_norway::from_str::<serde_json::Value>(&raw) else {
+        return Vec::new();
+    };
+    value
+        .get("packages")
+        .and_then(|p| p.as_array())
+        .map(|items| string_list(items))
+        .unwrap_or_default()
+}
+
+fn string_list(items: &[serde_json::Value]) -> Vec<String> {
+    items
+        .iter()
+        .filter_map(|v| v.as_str())
+        .map(normalise_glob)
+        .collect()
+}
+
+/// `./packages/*` and `packages/*/` both mean `packages/*`.
+fn normalise_glob(raw: &str) -> String {
+    raw.trim_start_matches("./")
+        .trim_end_matches('/')
+        .to_string()
+}
+
+fn collect(
+    root: &Path,
+    dir: &Path,
+    depth: usize,
+    globs: &[String],
+    found: &mut Vec<DiscoveredPackage>,
+) {
+    if depth > MAX_DEPTH {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if name.starts_with('.') || SKIP_DIRS.contains(&name) {
+            continue;
+        }
+        if let Some(rel) = relative_slash_path(root, &path)
+            && globs.iter().any(|g| matches_glob(g, &rel))
+            && let Some(pkg) = read_manifest(&path, &rel)
+        {
+            found.push(pkg);
+        }
+        collect(root, &path, depth + 1, globs, found);
+    }
+}
+
+/// Negated globs (`!packages/internal`) never include anything; `discover`
+/// subtracts them after the walk.
+fn matches_glob(glob: &str, rel: &str) -> bool {
+    !glob.starts_with('!') && glob_match::glob_match(glob, rel)
+}
+
+fn relative_slash_path(root: &Path, path: &Path) -> Option<String> {
+    let rel = path.strip_prefix(root).ok()?;
+    Some(
+        rel.components()
+            .filter_map(|c| c.as_os_str().to_str())
+            .collect::<Vec<_>>()
+            .join("/"),
+    )
+}
+
+fn read_manifest(dir: &Path, rel: &str) -> Option<DiscoveredPackage> {
+    let manifest = dir.join("package.json");
+    let raw = std::fs::read_to_string(&manifest).ok()?;
+    let value = serde_json::from_str::<serde_json::Value>(&raw).ok()?;
+    let name = value
+        .get("name")
+        .and_then(|n| n.as_str())
+        .map(str::to_string)
+        .or_else(|| dir.file_name().and_then(|n| n.to_str()).map(str::to_string))?;
+    Some(DiscoveredPackage {
+        name,
+        path: rel.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(root: &Path, rel: &str, contents: &str) {
+        let path = root.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    fn pkg(name: &str) -> String {
+        format!("{{\"name\": \"{name}\", \"version\": \"1.0.0\"}}")
+    }
+
+    #[test]
+    fn npm_workspaces_array_is_expanded() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(root, "package.json", r#"{"workspaces": ["packages/*"]}"#);
+        write(root, "packages/a/package.json", &pkg("@acme/a"));
+        write(root, "packages/b/package.json", &pkg("@acme/b"));
+
+        let found = discover(root);
+        assert_eq!(
+            found,
+            vec![
+                DiscoveredPackage {
+                    name: "@acme/a".into(),
+                    path: "packages/a".into()
+                },
+                DiscoveredPackage {
+                    name: "@acme/b".into(),
+                    path: "packages/b".into()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn yarn_berry_object_form_is_expanded() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(
+            root,
+            "package.json",
+            r#"{"workspaces": {"packages": ["libs/*"]}}"#,
+        );
+        write(root, "libs/one/package.json", &pkg("one"));
+
+        let found = discover(root);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].path, "libs/one");
+    }
+
+    #[test]
+    fn pnpm_workspace_globs_are_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(root, "package.json", r#"{"name": "root"}"#);
+        write(root, "pnpm-workspace.yaml", "packages:\n  - 'apps/*'\n");
+        write(root, "apps/web/package.json", &pkg("@acme/web"));
+
+        let found = discover(root);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].name, "@acme/web");
+        assert_eq!(found[0].path, "apps/web");
+    }
+
+    // node_modules holds thousands of package.json files; walking into it would
+    // both be slow and scaffold dependencies as if they were our packages.
+    #[test]
+    fn node_modules_is_never_walked() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(root, "package.json", r#"{"workspaces": ["packages/*"]}"#);
+        write(root, "packages/a/package.json", &pkg("@acme/a"));
+        write(
+            root,
+            "packages/a/node_modules/left-pad/package.json",
+            &pkg("left-pad"),
+        );
+        write(root, "node_modules/react/package.json", &pkg("react"));
+
+        let found = discover(root);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].name, "@acme/a");
+    }
+
+    #[test]
+    fn nested_globs_are_matched() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(root, "package.json", r#"{"workspaces": ["apps/*/pkg/*"]}"#);
+        write(root, "apps/web/pkg/ui/package.json", &pkg("ui"));
+
+        let found = discover(root);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].path, "apps/web/pkg/ui");
+    }
+
+    #[test]
+    fn a_directory_without_a_manifest_is_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(root, "package.json", r#"{"workspaces": ["packages/*"]}"#);
+        std::fs::create_dir_all(root.join("packages/empty")).unwrap();
+        write(root, "packages/real/package.json", &pkg("real"));
+
+        let found = discover(root);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].name, "real");
+    }
+
+    #[test]
+    fn a_nameless_manifest_falls_back_to_its_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(root, "package.json", r#"{"workspaces": ["packages/*"]}"#);
+        write(root, "packages/tools/package.json", r#"{"private": true}"#);
+
+        let found = discover(root);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].name, "tools");
+    }
+
+    #[test]
+    fn no_workspace_declaration_discovers_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(root, "package.json", r#"{"name": "solo"}"#);
+        write(root, "packages/a/package.json", &pkg("@acme/a"));
+
+        assert!(discover(root).is_empty());
+    }
+
+    #[test]
+    fn negated_globs_exclude_their_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(
+            root,
+            "package.json",
+            r#"{"workspaces": ["packages/*", "!packages/internal"]}"#,
+        );
+        write(root, "packages/keep/package.json", &pkg("keep"));
+        write(root, "packages/internal/package.json", &pkg("internal"));
+
+        let found = discover(root);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].name, "keep");
+    }
+}


### PR DESCRIPTION
Closes #747.

`ferrflow migrate --from changesets` scaffolded a single root package and told you to list every workspace package by hand. It now reads the same workspace declaration changesets itself relies on and scaffolds one entry per discovered package.

## Discovery

New `workspace_packages` module, sources in priority-free union:

- `package.json` → `"workspaces": [...]` (npm / yarn classic) **and** `"workspaces": { "packages": [...] }` (yarn berry)
- `pnpm-workspace.yaml` / `.yml` → `packages:`

Globs are matched against directories walked from the root, and each match with a `package.json` becomes a package: `name` from the manifest (falling back to the directory name for nameless private packages), `path`, and a `versionedFiles` entry pointing at that manifest. Changelogs are scoped per package (`packages/a/CHANGELOG.md`) rather than all pointing at the root.

Details that matter in real repos:
- **`node_modules` is never walked** — it holds thousands of manifests, and scaffolding dependencies as if they were your packages would be worse than the old behaviour. Same for `target`, `dist`, `build`, `.next`, `.turbo`, `coverage`, `vendor` and dotdirs. There's a test for it.
- **Negated globs** (`"!packages/internal"`) are subtracted after the walk.
- Depth is capped at 6, enough for `apps/*/packages/*` layouts.
- `./packages/*` and `packages/*/` normalise to `packages/*`.

## The linked/fixed payoff

This is the part the issue was really after: `linked`/`fixed` groups name packages by npm name, and those packages now exist in the emitted config, so the migrated config passes `ferrflow validate` unchanged. `discovered_packages_satisfy_the_linked_groups` asserts every group member was scaffolded.

When a group names something outside the workspace, that is now called out explicitly ("linked/fixed reference 1 package(s) that were not discovered (@acme/ghost)") instead of failing later in `validate`.

## Fallback preserved

A repo with no workspace declaration still gets the single root package, with a warning that now says what was actually looked for rather than claiming FerrFlow can't read workspaces.

## Scope

changesets only, as the issue scopes it. release-please already lists its packages, and the "generic monorepo path" it mentions doesn't exist yet — `workspace_packages::discover` is a plain function, so wiring it into a future converter is a one-liner.

## Tests

12 new (9 discovery, 3 converter). One existing test, `monorepo_scaffold_warning_is_present`, was removed: it asserted the "FerrFlow can't read your workspace" wording that this PR makes untrue, and `a_repo_without_a_workspace_still_gets_a_root_package` covers the same fallback with the current message.

Full suite green (1801), `clippy --all-targets -D warnings` clean. Site docs follow in a FerrFlow-Cloud PR — `reference/cli` currently states the old limitation.