### PR TITLE
feat(diff): scope the range to the named package in a monorepo

### DIFF
--- a/src/config/package.rs
+++ b/src/config/package.rs
@@ -51,6 +51,34 @@ pub enum FloatingTagLevel {
 }
 
 impl PackageConfig {
+    /// Whether this package owns any of `changed_files` — its own `path`, or
+    /// one of its `shared_paths`.
+    ///
+    /// A single-package repo always owns everything, as does a package rooted
+    /// at the repo root, so both short-circuit to true.
+    pub fn is_touched_by(&self, changed_files: &[String], is_monorepo: bool) -> bool {
+        if !is_monorepo {
+            return true;
+        }
+
+        let pkg_path = self.path.trim_start_matches("./").trim_end_matches('/');
+        if pkg_path == "." || pkg_path.is_empty() {
+            return true;
+        }
+
+        let prefix = format!("{pkg_path}/");
+        if changed_files.iter().any(|f| f.starts_with(&prefix)) {
+            return true;
+        }
+
+        self.shared_paths.iter().any(|shared| {
+            let shared = shared.trim_end_matches('/');
+            changed_files
+                .iter()
+                .any(|f| f.starts_with(shared) || f == shared)
+        })
+    }
+
     /// Resolve the effective versioning strategy for this package. Priority:
     ///   1. package.versioning if explicitly set
     ///   2. workspace.versioning if explicitly set
@@ -171,4 +199,93 @@ pub enum FileFormat {
     /// `CMakeLists.txt` — the `VERSION` argument of the `project()` call.
     #[serde(rename = "cmake")]
     Cmake,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pkg(path: &str, shared: &[&str]) -> PackageConfig {
+        PackageConfig {
+            name: "api".to_string(),
+            path: path.to_string(),
+            versioned_files: Vec::new(),
+            changelog: None,
+            shared_paths: shared.iter().map(|s| s.to_string()).collect(),
+            depends_on: Vec::new(),
+            versioning: None,
+            tag_template: None,
+            floating_tags: None,
+            hooks: None,
+            publishers: Vec::new(),
+            update_lockfiles: None,
+        }
+    }
+
+    fn files(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn matches_files_under_the_package_path() {
+        let p = pkg("packages/api", &[]);
+        assert!(p.is_touched_by(&files(&["packages/api/src/main.rs"]), true));
+    }
+
+    // The whole point of scoping: a sibling package's commit must not count.
+    #[test]
+    fn ignores_files_of_a_sibling_package() {
+        let p = pkg("packages/api", &[]);
+        assert!(!p.is_touched_by(&files(&["packages/web/src/app.ts"]), true));
+    }
+
+    // `packages/api-client` must not match the `packages/api` package just
+    // because the string starts the same way.
+    #[test]
+    fn a_sibling_with_a_shared_prefix_does_not_match() {
+        let p = pkg("packages/api", &[]);
+        assert!(!p.is_touched_by(&files(&["packages/api-client/index.ts"]), true));
+    }
+
+    #[test]
+    fn shared_paths_count_as_a_touch() {
+        let p = pkg("packages/api", &["proto"]);
+        assert!(p.is_touched_by(&files(&["proto/schema.proto"]), true));
+    }
+
+    #[test]
+    fn a_shared_path_file_itself_counts() {
+        let p = pkg("packages/api", &["Cargo.lock"]);
+        assert!(p.is_touched_by(&files(&["Cargo.lock"]), true));
+    }
+
+    // A single-package repo owns every commit, so scoping must never filter.
+    #[test]
+    fn a_single_package_repo_owns_everything() {
+        let p = pkg("packages/api", &[]);
+        assert!(p.is_touched_by(&files(&["anywhere/else.txt"]), false));
+    }
+
+    #[test]
+    fn a_root_package_owns_everything() {
+        for path in [".", "", "./"] {
+            let p = pkg(path, &[]);
+            assert!(
+                p.is_touched_by(&files(&["anywhere/else.txt"]), true),
+                "path {path:?} should own the whole tree"
+            );
+        }
+    }
+
+    #[test]
+    fn a_trailing_slash_on_the_package_path_is_tolerated() {
+        let p = pkg("packages/api/", &[]);
+        assert!(p.is_touched_by(&files(&["packages/api/src/main.rs"]), true));
+    }
+
+    #[test]
+    fn no_changed_files_is_not_a_touch() {
+        let p = pkg("packages/api", &[]);
+        assert!(!p.is_touched_by(&[], true));
+    }
 }

--- a/src/git/commits.rs
+++ b/src/git/commits.rs
@@ -75,11 +75,19 @@ pub fn get_commits_since_oid(
 /// Commits reachable from `to` but not `from` — the range `from..to`, newest
 /// first. Powers `ferrflow diff`, which enumerates what went into a version
 /// range.
+/// Commits in `from..to`, minus those whose subject carries a skip marker and
+/// those rejected by `keep`.
+///
+/// `keep` receives the **full** object id. That is why per-commit filtering
+/// belongs here rather than over the returned list: [`GitLog::hash`] is
+/// abbreviated for display and cannot be turned back into an id afterwards.
+/// Pass `|_, _| true` for the whole range.
 pub fn get_commits_between(
     repo: &Repository,
     from: ObjectId,
     to: ObjectId,
     skip_markers: &[String],
+    mut keep: impl FnMut(&Repository, ObjectId) -> bool,
 ) -> Result<Vec<GitLog>> {
     let walk = repo
         .rev_walk([to])
@@ -99,6 +107,9 @@ pub fn get_commits_between(
         };
         let message = String::from_utf8_lossy(raw).into_owned();
         if subject_has_skip_marker(&message, skip_markers) {
+            continue;
+        }
+        if !keep(repo, info.id) {
             continue;
         }
         commits.push(GitLog {

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -67,6 +67,23 @@ pub fn get_changed_files_between(
     changed_paths_between(repo, Some(from), to)
 }
 
+/// Paths a single commit changed, against its first parent. A root commit has
+/// no parent, so its whole tree counts as added. Merge commits are compared to
+/// the first parent only, which is what `git log --name-only` reports and what
+/// per-package scoping wants.
+pub fn get_changed_files_for_commit(repo: &Repository, commit: ObjectId) -> Result<Vec<String>> {
+    if repo.workdir().is_none() {
+        return Ok(vec![]);
+    }
+    let parent = repo
+        .find_commit(commit)
+        .with_context(|| format!("commit {commit} not found"))?
+        .parent_ids()
+        .next()
+        .map(|id| id.detach());
+    changed_paths_between(repo, parent, commit)
+}
+
 fn changed_paths_between(
     repo: &Repository,
     from: Option<ObjectId>,

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -23,8 +23,8 @@ pub use commits::{
     get_commits_since_oid, subject_has_skip_marker,
 };
 pub use diff::{
-    get_changed_files, get_changed_files_between, get_changed_files_since_oid,
-    get_changed_files_since_tag,
+    get_changed_files, get_changed_files_between, get_changed_files_for_commit,
+    get_changed_files_since_oid, get_changed_files_since_tag,
 };
 pub use fetch::fetch_tags;
 #[allow(unused_imports)]

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -1680,3 +1680,51 @@ fn is_push_rejected_error_recognises_known_signatures() {
     let e = anyhow::anyhow!("hook failed: prettier exited with status 1");
     assert!(!is_push_rejected_error(&e));
 }
+
+// ── get_changed_files_for_commit — feeds per-package scoping in `diff` ──
+
+fn commit_file_at(dir: &Path, rel: &str, message: &str) -> String {
+    let path = dir.join(rel);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, format!("content of {rel}")).unwrap();
+    git(dir, &["add", "--", rel]);
+    let ts = next_commit_ts();
+    let date = format!("{ts} +0000");
+    git_with_env(
+        dir,
+        &["commit", "-m", message],
+        &[("GIT_AUTHOR_DATE", &date), ("GIT_COMMITTER_DATE", &date)],
+    );
+    git(dir, &["rev-parse", "HEAD"]).trim().to_string()
+}
+
+fn oid(sha: &str) -> gix::ObjectId {
+    gix::ObjectId::from_hex(sha.as_bytes()).expect("valid sha")
+}
+
+/// A commit reports only what it changed, not the whole tree — otherwise every
+/// commit would look like it touched every package.
+#[test]
+fn changed_files_for_commit_lists_only_that_commit_s_paths() {
+    let (dir, _repo) = init_repo();
+    commit_file_at(dir.path(), "packages/api/main.rs", "feat: api");
+    let web = commit_file_at(dir.path(), "packages/web/app.ts", "feat: web");
+
+    let repo = open_repo(dir.path()).unwrap();
+    let files = get_changed_files_for_commit(&repo, oid(&web)).expect("diffs against the parent");
+
+    assert_eq!(files, vec!["packages/web/app.ts".to_string()]);
+}
+
+/// The first commit has no parent, so its whole tree counts as added rather
+/// than erroring out.
+#[test]
+fn changed_files_for_the_root_commit_is_its_whole_tree() {
+    let (dir, _repo) = init_repo();
+    let root = commit_file_at(dir.path(), "packages/api/main.rs", "feat: api");
+
+    let repo = open_repo(dir.path()).unwrap();
+    let files = get_changed_files_for_commit(&repo, oid(&root)).expect("root commit is diffable");
+
+    assert_eq!(files, vec!["packages/api/main.rs".to_string()]);
+}

--- a/src/monorepo/util.rs
+++ b/src/monorepo/util.rs
@@ -79,30 +79,5 @@ pub(super) fn is_package_touched(
     changed_files: &[String],
     is_monorepo: bool,
 ) -> bool {
-    if !is_monorepo {
-        return true;
-    }
-
-    let pkg_path = pkg.path.trim_start_matches("./").trim_end_matches('/');
-
-    if pkg_path == "." || pkg_path.is_empty() {
-        return true;
-    }
-
-    let prefix = format!("{pkg_path}/");
-    if changed_files.iter().any(|f| f.starts_with(&prefix)) {
-        return true;
-    }
-
-    for shared in &pkg.shared_paths {
-        let shared = shared.trim_end_matches('/');
-        if changed_files
-            .iter()
-            .any(|f| f.starts_with(shared) || f == shared)
-        {
-            return true;
-        }
-    }
-
-    false
+    pkg.is_touched_by(changed_files, is_monorepo)
 }

--- a/src/version_diff.rs
+++ b/src/version_diff.rs
@@ -11,8 +11,8 @@ use crate::conventional_commits::{
 };
 use crate::error_code::{self, ErrorCodeExt};
 use crate::git::{
-    get_changed_files_between, get_commits_between, get_remote_url, get_repo_root, open_repo,
-    resolve_tag_name_to_commit,
+    get_changed_files_between, get_changed_files_for_commit, get_commits_between, get_remote_url,
+    get_repo_root, open_repo, resolve_tag_name_to_commit,
 };
 
 const MAX_FILES_SHOWN: usize = 40;
@@ -32,8 +32,14 @@ pub fn run(spec: &[String], json: bool, config_path: Option<&Path>) -> Result<()
     let (to_oid, to_tag) = resolve_endpoint(&repo, pkg, &config.workspace, is_monorepo, to_ref)?;
 
     let skip = config.workspace.effective_commit_skip_markers();
-    let commits = get_commits_between(&repo, from_oid, to_oid, &skip)?;
-    let files = get_changed_files_between(&repo, from_oid, to_oid).unwrap_or_default();
+    let commits = get_commits_between(&repo, from_oid, to_oid, &skip, |repo, oid| {
+        commit_touches_package(repo, pkg, is_monorepo, oid)
+    })?;
+    let files = scope_files_to_package(
+        pkg,
+        is_monorepo,
+        get_changed_files_between(&repo, from_oid, to_oid).unwrap_or_default(),
+    );
 
     let overall = commits
         .iter()
@@ -65,6 +71,42 @@ pub fn run(spec: &[String], json: bool, config_path: Option<&Path>) -> Result<()
         print_human(pkg, from_ref, to_ref, overall, &commits, &files, &changelog);
     }
     Ok(())
+}
+
+/// The raw range holds every commit between the two tags, including ones that
+/// only touched other packages. Keeping just the ones that touched this package
+/// makes the commit list, the breaking-change list and the rendered changelog
+/// match what `ferrflow release` would produce for it (#752).
+///
+/// A commit whose changed files can't be read is kept rather than dropped —
+/// over-reporting is recoverable, silently hiding a commit is not.
+fn commit_touches_package(
+    repo: &crate::git::Repository,
+    pkg: &PackageConfig,
+    is_monorepo: bool,
+    oid: ObjectId,
+) -> bool {
+    if !is_monorepo {
+        return true;
+    }
+    match get_changed_files_for_commit(repo, oid) {
+        Ok(files) => pkg.is_touched_by(&files, true),
+        Err(_) => true,
+    }
+}
+
+fn scope_files_to_package(
+    pkg: &PackageConfig,
+    is_monorepo: bool,
+    files: Vec<String>,
+) -> Vec<String> {
+    if !is_monorepo {
+        return files;
+    }
+    files
+        .into_iter()
+        .filter(|f| pkg.is_touched_by(std::slice::from_ref(f), true))
+        .collect()
 }
 
 fn parse_spec(spec: &[String]) -> Result<(Option<&str>, &str)> {
@@ -306,5 +348,35 @@ mod tests {
         assert!(split_range("..v2.0.0").is_err());
         assert!(split_range("v1.0.0..").is_err());
         assert!(split_range("v1.0.0").is_err());
+    }
+
+    fn scoped_pkg() -> PackageConfig {
+        serde_json::from_str(r#"{"name":"api","path":"packages/api","sharedPaths":["proto"]}"#)
+            .expect("valid package json")
+    }
+
+    #[test]
+    fn file_list_is_scoped_to_the_package_in_a_monorepo() {
+        let files = vec![
+            "packages/api/src/main.rs".to_string(),
+            "packages/web/app.ts".to_string(),
+            "proto/schema.proto".to_string(),
+        ];
+        let scoped = scope_files_to_package(&scoped_pkg(), true, files);
+        assert_eq!(
+            scoped,
+            vec![
+                "packages/api/src/main.rs".to_string(),
+                "proto/schema.proto".to_string()
+            ],
+            "the sibling package's file must be dropped, the shared path kept"
+        );
+    }
+
+    #[test]
+    fn file_list_is_untouched_in_a_single_package_repo() {
+        let files = vec!["anything/at/all.rs".to_string()];
+        let scoped = scope_files_to_package(&scoped_pkg(), false, files.clone());
+        assert_eq!(scoped, files);
     }
 }


### PR DESCRIPTION
Closes #752.

`ferrflow diff <package> <from>..<to>` listed the raw git range, so in a monorepo the commit list, breaking-change list and generated changelog were a superset of what actually went into the package. On a real two-package fixture:

```
$ git log --oneline api@v1.0.0..api@v1.1.0
  fix(proto): correct field
  feat(web): redesign landing      <- not api's
  feat(api): add handler
```

`diff api` reported all three, and a changelog claiming api shipped a web redesign.

## Change

Commits are kept when they touch the package's `path` or one of its `sharedPaths` — the same rule `compute_plan` applies when releasing, so `diff`'s changelog now matches what `release` would actually generate. The file list is scoped the same way. Single-package repos and root-path packages are unaffected: they own everything, and the filter short-circuits.

After:

```
api  api@v1.0.0 → api@v1.1.0  (minor)
Commits (2)
  patch  fix(proto): correct field     <- kept: `proto` is a sharedPath of api
  minor  feat(api): add handler
Files changed (2)
  packages/api/handler.rs
  proto/schema.proto
```

`diff web` on the same repo reports exactly one commit and one file, and `proto` is correctly *not* kept for it.

## Shape

The scoping rule moved from `monorepo::util::is_package_touched` to `PackageConfig::is_touched_by`. It had to: `version_diff` is compiled into the library while `monorepo` is binary-only, so the logic was unreachable from there. `is_package_touched` now delegates, so there is one implementation and no drift. `config` is a library module, so this also makes the rule available to the hosted API later.

Filtering happens **inside** the rev-walk (`get_commits_between` gained a `keep` predicate) rather than over the returned list. That is not a style choice — see below.

New git primitive: `get_changed_files_for_commit`, diffing a commit against its first parent (whole tree for a root commit, first parent only for merges, matching `git log --name-only`).

## The bug the end-to-end test caught

My first version filtered the returned `Vec<GitLog>` by re-parsing `commit.hash` into an `ObjectId`. That silently did nothing: `GitLog.hash` is **truncated to 8 characters** at construction, so `ObjectId::from_hex` always failed and the "on error, keep the commit" fallback kept everything. Unit tests passed — they covered the pure file filter — and the feature was completely inert.

Running the CLI against a real fixture is what surfaced it, which is why the predicate now runs where the full object id exists.

The keep-on-error fallback is deliberate and stays: over-reporting a commit is recoverable, silently hiding one from a changelog is not.

## Tests

- `config::package` — 9 tests on `is_touched_by`, including that `packages/api-client` does **not** match `packages/api` (a prefix bug here would silently mis-attribute commits), sharedPath files, root packages, trailing slashes.
- `git::tests` — `get_changed_files_for_commit` reports only that commit's paths, and handles the parentless root commit.
- `version_diff` — file-list scoping, and the single-package no-op.

Full suite green (1827), `clippy --all-targets -D warnings` clean. Verified end to end on real monorepo fixtures for both packages, for `--json`, and for a single-package repo.
