### PR TITLE
feat(monorepo): propagate the upstream bump type through the dependency cascade

### DIFF
--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -463,9 +463,25 @@
           },
           "dependsOn": {
             "type": "array",
-            "description": "Package names this package depends on. When a dependency is bumped, this package gets a patch bump automatically.",
+            "description": "Packages this package depends on. When one is bumped, this package is bumped too — by default with the same bump type. Each entry is either a package name or an object with a `propagate` policy.",
             "items": {
-              "type": "string"
+              "oneOf": [
+                { "type": "string" },
+                {
+                  "type": "object",
+                  "required": ["name"],
+                  "properties": {
+                    "name": { "type": "string" },
+                    "propagate": {
+                      "type": "string",
+                      "enum": ["same", "major-on-major", "patch", "none"],
+                      "default": "same",
+                      "description": "How this dependency's bump becomes a bump here. same: identical bump (a breaking upstream makes this package breaking too). major-on-major: major stays major, anything lower becomes a patch. patch: always a patch. none: no cascade from this dependency."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
             }
           },
           "versioning": {
@@ -566,9 +582,25 @@
           },
           "depends_on": {
             "type": "array",
-            "description": "Snake_case form of `dependsOn` — both spellings are accepted. Package names this package depends on. When a dependency is bumped, this package gets a patch bump automatically.",
+            "description": "Snake_case form of `dependsOn` — both spellings are accepted. Packages this package depends on. When one is bumped, this package is bumped too — by default with the same bump type. Each entry is either a package name or an object with a `propagate` policy.",
             "items": {
-              "type": "string"
+              "oneOf": [
+                { "type": "string" },
+                {
+                  "type": "object",
+                  "required": ["name"],
+                  "properties": {
+                    "name": { "type": "string" },
+                    "propagate": {
+                      "type": "string",
+                      "enum": ["same", "major-on-major", "patch", "none"],
+                      "default": "same",
+                      "description": "How this dependency's bump becomes a bump here. same: identical bump (a breaking upstream makes this package breaking too). major-on-major: major stays major, anything lower becomes a patch. patch: always a patch. none: no cascade from this dependency."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
             }
           },
           "tag_template": {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -24,7 +24,11 @@ pub use groups::{GroupKind, PackageGroup};
 pub use init::init;
 #[cfg(feature = "cli")]
 pub use migrate::{Source as MigrateSource, migrate};
-pub use package::{FileFormat, FloatingTagLevel, PackageConfig, VersionedFile, VersioningStrategy};
+#[allow(unused_imports)]
+pub use package::{
+    Dependency, FileFormat, FloatingTagLevel, PackageConfig, PropagatePolicy, VersionedFile,
+    VersioningStrategy,
+};
 #[allow(unused_imports)]
 pub use types::{
     BranchChannelConfig, ChannelValue, DockerSign, ForgeKind, HooksConfig, OnFailure,

--- a/src/config/package.rs
+++ b/src/config/package.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::conventional_commits::BumpType;
+
 use super::types::{HooksConfig, PublisherConfig};
 use super::workspace::WorkspaceConfig;
 
@@ -13,7 +15,7 @@ pub struct PackageConfig {
     #[serde(default, alias = "sharedPaths")]
     pub shared_paths: Vec<String>,
     #[serde(default, alias = "dependsOn")]
-    pub depends_on: Vec<String>,
+    pub depends_on: Vec<Dependency>,
     pub versioning: Option<VersioningStrategy>,
     #[serde(alias = "tagTemplate")]
     pub tag_template: Option<String>,
@@ -29,6 +31,75 @@ pub struct PackageConfig {
     pub publishers: Vec<PublisherConfig>,
     #[serde(default, alias = "updateLockfiles")]
     pub update_lockfiles: Option<bool>,
+}
+
+/// An upstream package this one depends on.
+///
+/// Accepts both the plain name (`"core"`) and the detailed form
+/// (`{ name = "core", propagate = "major-on-major" }`); the plain form is
+/// equivalent to the detailed one with the default policy.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[serde(untagged)]
+pub enum Dependency {
+    Name(String),
+    Detailed {
+        name: String,
+        #[serde(default)]
+        propagate: PropagatePolicy,
+    },
+}
+
+impl Dependency {
+    pub fn name(&self) -> &str {
+        match self {
+            Dependency::Name(name) => name,
+            Dependency::Detailed { name, .. } => name,
+        }
+    }
+
+    pub fn propagate(&self) -> PropagatePolicy {
+        match self {
+            Dependency::Name(_) => PropagatePolicy::default(),
+            Dependency::Detailed { propagate, .. } => *propagate,
+        }
+    }
+}
+
+/// How an upstream package's bump translates into its dependents' bump.
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum PropagatePolicy {
+    /// The dependent gets the same bump the upstream got. A breaking upstream
+    /// makes the dependent breaking too, which is the honest signal: the
+    /// dependent now builds against a breaking API.
+    #[default]
+    Same,
+    /// A major upstream makes the dependent major; anything else is a patch.
+    MajorOnMajor,
+    /// Always a patch, whatever the upstream did. FerrFlow's behaviour before
+    /// propagation existed.
+    Patch,
+    /// The dependent is not bumped at all for this upstream.
+    None,
+}
+
+impl PropagatePolicy {
+    /// The bump a dependent receives when its upstream got `upstream`.
+    pub fn resolve(self, upstream: BumpType) -> BumpType {
+        match self {
+            PropagatePolicy::Same => upstream,
+            PropagatePolicy::MajorOnMajor => match upstream {
+                BumpType::Major => BumpType::Major,
+                BumpType::None => BumpType::None,
+                _ => BumpType::Patch,
+            },
+            PropagatePolicy::Patch => match upstream {
+                BumpType::None => BumpType::None,
+                _ => BumpType::Patch,
+            },
+            PropagatePolicy::None => BumpType::None,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Default)]
@@ -224,6 +295,79 @@ mod tests {
 
     fn files(list: &[&str]) -> Vec<String> {
         list.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn dep(json: &str) -> Dependency {
+        serde_json::from_str(json).expect("valid dependency")
+    }
+
+    // The plain-string form predates policies and must keep working.
+    #[test]
+    fn a_plain_string_dependency_uses_the_default_policy() {
+        let d = dep(r#""core""#);
+        assert_eq!(d.name(), "core");
+        assert_eq!(d.propagate(), PropagatePolicy::Same);
+    }
+
+    #[test]
+    fn the_detailed_form_carries_its_policy() {
+        let d = dep(r#"{"name":"core","propagate":"major-on-major"}"#);
+        assert_eq!(d.name(), "core");
+        assert_eq!(d.propagate(), PropagatePolicy::MajorOnMajor);
+    }
+
+    #[test]
+    fn the_detailed_form_without_a_policy_defaults_like_the_string_form() {
+        assert_eq!(dep(r#"{"name":"core"}"#).propagate(), PropagatePolicy::Same);
+    }
+
+    // The bug this feature exists for: a breaking upstream used to hand its
+    // dependents a patch, so consumers upgraded straight into a breaking API.
+    #[test]
+    fn same_policy_forwards_the_upstream_bump_unchanged() {
+        for bump in [BumpType::Major, BumpType::Minor, BumpType::Patch] {
+            assert_eq!(PropagatePolicy::Same.resolve(bump), bump);
+        }
+    }
+
+    #[test]
+    fn major_on_major_downgrades_everything_below_major() {
+        assert_eq!(
+            PropagatePolicy::MajorOnMajor.resolve(BumpType::Major),
+            BumpType::Major
+        );
+        assert_eq!(
+            PropagatePolicy::MajorOnMajor.resolve(BumpType::Minor),
+            BumpType::Patch
+        );
+    }
+
+    #[test]
+    fn patch_policy_reproduces_the_old_behaviour() {
+        for bump in [BumpType::Major, BumpType::Minor, BumpType::Patch] {
+            assert_eq!(PropagatePolicy::Patch.resolve(bump), BumpType::Patch);
+        }
+    }
+
+    #[test]
+    fn none_policy_opts_out_of_the_cascade() {
+        assert_eq!(
+            PropagatePolicy::None.resolve(BumpType::Major),
+            BumpType::None
+        );
+    }
+
+    // An upstream that did not move must never manufacture a downstream bump.
+    #[test]
+    fn no_upstream_bump_never_produces_one_downstream() {
+        for p in [
+            PropagatePolicy::Same,
+            PropagatePolicy::MajorOnMajor,
+            PropagatePolicy::Patch,
+            PropagatePolicy::None,
+        ] {
+            assert_eq!(p.resolve(BumpType::None), BumpType::None, "policy {p:?}");
+        }
     }
 
     #[test]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1216,7 +1216,7 @@ fn depends_on_deserializes_from_json() {
     let json =
         r#"{"package":[{"name":"cli","path":"cli","dependsOn":["core"],"versionedFiles":[]}]}"#;
     let config: Config = serde_json::from_str(json).unwrap();
-    assert_eq!(config.packages[0].depends_on, vec!["core"]);
+    assert_eq!(config.packages[0].depends_on[0].name(), "core");
 }
 
 #[test]
@@ -1231,7 +1231,7 @@ fn depends_on_deserializes_snake_case() {
     let json =
         r#"{"package":[{"name":"cli","path":"cli","depends_on":["core"],"versionedFiles":[]}]}"#;
     let config: Config = serde_json::from_str(json).unwrap();
-    assert_eq!(config.packages[0].depends_on, vec!["core"]);
+    assert_eq!(config.packages[0].depends_on[0].name(), "core");
 }
 
 #[test]

--- a/src/monorepo/run/cascade.rs
+++ b/src/monorepo/run/cascade.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::Path;
 
 use colored::Colorize;
@@ -25,11 +25,14 @@ pub(super) struct CascadeSink<'a> {
     pub files_per_package: &'a mut HashMap<String, Vec<String>>,
     pub tags_to_create: &'a mut Vec<TagToCreate>,
     pub pkg_outputs: &'a mut Vec<(String, Vec<String>)>,
-    pub bumped_names: &'a mut HashSet<String>,
+    /// Name -> the bump each already-released package received this run. The
+    /// cascade reads it to know what to propagate, and extends it as it goes.
+    pub bumped: &'a mut HashMap<String, BumpType>,
 }
 
-/// Patch-bump every package that depends (transitively) on a package
-/// already bumped this run. Iterates to a fixed point, capped at
+/// Bump every package that depends (transitively) on a package
+/// already bumped this run, propagating the upstream's bump through each
+/// dependency's `PropagatePolicy`. Iterates to a fixed point, capped at
 /// `packages.len()` rounds to break circular dependencies.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn run_dependency_cascade(
@@ -50,21 +53,29 @@ pub(super) fn run_dependency_cascade(
         }
         let mut new_bumps = Vec::new();
         for (pkg_idx, pkg) in config.packages.iter().enumerate() {
-            if sink.bumped_names.contains(&pkg.name) {
+            if sink.bumped.contains_key(&pkg.name) {
                 continue;
             }
-            if pkg
+            // Several dependencies may have moved at once under different
+            // policies; the strongest resulting bump wins, the same way a
+            // package's own commits resolve to their highest bump.
+            let bump = pkg
                 .depends_on
                 .iter()
-                .any(|dep| sink.bumped_names.contains(dep))
-            {
-                new_bumps.push(pkg_idx);
+                .filter_map(|dep| {
+                    let upstream = sink.bumped.get(dep.name())?;
+                    Some(dep.propagate().resolve(*upstream))
+                })
+                .max()
+                .unwrap_or(BumpType::None);
+            if bump != BumpType::None {
+                new_bumps.push((pkg_idx, bump));
             }
         }
         if new_bumps.is_empty() {
             break;
         }
-        for pkg_idx in new_bumps {
+        for (pkg_idx, bump) in new_bumps {
             let pkg = &config.packages[pkg_idx];
             let Some(vf) = pkg.versioned_files.first() else {
                 continue;
@@ -76,8 +87,7 @@ pub(super) fn run_dependency_cascade(
             let strategy = pkg.effective_versioning(&config.workspace, || {
                 tags_for_package(all_tags, &pkg_tag_prefix)
             });
-            let Ok(new_version) = compute_next_version(&current_version, BumpType::Patch, strategy)
-            else {
+            let Ok(new_version) = compute_next_version(&current_version, bump, strategy) else {
                 continue;
             };
             if current_version == new_version {
@@ -87,8 +97,8 @@ pub(super) fn run_dependency_cascade(
             let dep_trigger: Vec<&str> = pkg
                 .depends_on
                 .iter()
-                .filter(|d| sink.bumped_names.contains(*d))
-                .map(|s| s.as_str())
+                .map(|d| d.name())
+                .filter(|name| sink.bumped.contains_key(*name))
                 .collect();
 
             if release_json {
@@ -96,7 +106,7 @@ pub(super) fn run_dependency_cascade(
                     package: pkg.name.clone(),
                     previous_version: current_version.clone(),
                     new_version: new_version.clone(),
-                    bump_type: "patch".to_string(),
+                    bump_type: bump.to_string(),
                     tag: tag.clone(),
                     commit_count: 0,
                     prerelease: false,
@@ -110,7 +120,7 @@ pub(super) fn run_dependency_cascade(
                     name: pkg.name.clone(),
                     current_version: current_version.clone(),
                     next_version: new_version.clone(),
-                    bump_type: "patch".to_string(),
+                    bump_type: bump.to_string(),
                     tag: tag.clone(),
                     channel: channel.map(str::to_string),
                     prerelease: false,
@@ -123,7 +133,7 @@ pub(super) fn run_dependency_cascade(
                     pkg.name.bold(),
                     current_version.dimmed(),
                     new_version.green().bold(),
-                    "patch".cyan(),
+                    bump.to_string().cyan(),
                     dep_trigger.join(", ").cyan()
                 )];
                 if !dry_run {
@@ -145,7 +155,7 @@ pub(super) fn run_dependency_cascade(
                             &pkg.name,
                             &new_version,
                             &[],
-                            BumpType::Patch,
+                            bump,
                             false,
                         )?;
                         sink.files_to_commit.push(changelog_rel.clone());
@@ -178,7 +188,7 @@ pub(super) fn run_dependency_cascade(
                 0,
                 false,
             ));
-            sink.bumped_names.insert(pkg.name.clone());
+            sink.bumped.insert(pkg.name.clone(), bump);
             *sink.any_bumped = true;
         }
     }

--- a/src/monorepo/run/graph.rs
+++ b/src/monorepo/run/graph.rs
@@ -31,7 +31,7 @@ pub(super) fn release_order(packages: &[PackageConfig]) -> Result<Vec<usize>, Cy
         .map(|pkg| {
             pkg.depends_on
                 .iter()
-                .filter_map(|dep| index_of.get(dep.as_str()).copied())
+                .filter_map(|dep| index_of.get(dep.name()).copied())
                 .collect()
         })
         .collect();
@@ -147,7 +147,10 @@ mod tests {
             versioned_files: vec![],
             changelog: None,
             shared_paths: vec![],
-            depends_on: deps.iter().map(|s| s.to_string()).collect(),
+            depends_on: deps
+                .iter()
+                .map(|s| crate::config::Dependency::Name(s.to_string()))
+                .collect(),
             update_lockfiles: None,
             versioning: None,
             tag_template: None,

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -195,7 +195,9 @@ pub(super) fn run_release_logic(
     let mut files_per_package: HashMap<String, Vec<String>> = HashMap::new();
     let mut tags_to_create: Vec<TagToCreate> = Vec::new();
     let mut hook_contexts: Vec<(HookContext, usize)> = Vec::new(); // (ctx, pkg_index)
-    let mut bumped_names: HashSet<String> = HashSet::new();
+    // Name -> bump, so the dependency cascade can propagate the real bump
+    // type instead of assuming a patch.
+    let mut bumped: HashMap<String, BumpType> = HashMap::new();
 
     let mut pkg_outputs: Vec<(String, Vec<String>)> = Vec::new();
     let mut shared_outputs: Vec<String> = Vec::new();
@@ -576,7 +578,7 @@ pub(super) fn run_release_logic(
         }
 
         hook_contexts.push((hook_ctx, pkg_idx));
-        bumped_names.insert(pkg.name.clone());
+        bumped.insert(pkg.name.clone(), bump);
         any_bumped = true;
     }
 
@@ -589,7 +591,7 @@ pub(super) fn run_release_logic(
             files_per_package: &mut files_per_package,
             tags_to_create: &mut tags_to_create,
             pkg_outputs: &mut pkg_outputs,
-            bumped_names: &mut bumped_names,
+            bumped: &mut bumped,
         };
         cascade::run_dependency_cascade(
             config,

--- a/tests/fixtures/definitions/monorepo-depends-on.json
+++ b/tests/fixtures/definitions/monorepo-depends-on.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "name": "monorepo-depends-on",
-    "description": "CLI depends on core; bumping core auto-bumps CLI"
+    "description": "CLI depends on core; bumping core auto-bumps CLI with the same bump type"
   },
   "config": {
     "content": "{\n  \"package\": [\n    {\n      \"name\": \"core\",\n      \"path\": \"core\",\n      \"versioned_files\": [{\"path\": \"core/version.toml\", \"format\": \"toml\"}]\n    },\n    {\n      \"name\": \"cli\",\n      \"path\": \"cli\",\n      \"dependsOn\": [\"core\"],\n      \"versioned_files\": [{\"path\": \"cli/version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
@@ -27,7 +27,7 @@
     }
   ],
   "expect": {
-    "check_contains": ["core", "1.1.0", "cli", "1.0.1", "dependency"],
+    "check_contains": ["core", "1.1.0", "cli", "(minor, dependency: core)"],
     "check_not_contains": ["Nothing to release"]
   }
 }

--- a/tests/fixtures/definitions/monorepo-deps-breaking-cascade.json
+++ b/tests/fixtures/definitions/monorepo-deps-breaking-cascade.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "name": "monorepo-deps-breaking-cascade",
-    "description": "Breaking change in dependency: dependent gets patch bump, not major"
+    "description": "Breaking change in a dependency cascades as a major bump by default"
   },
   "config": {
     "content": "{\n  \"package\": [\n    {\n      \"name\": \"core\",\n      \"path\": \"core\",\n      \"versioned_files\": [{\"path\": \"core/version.toml\", \"format\": \"toml\"}]\n    },\n    {\n      \"name\": \"cli\",\n      \"path\": \"cli\",\n      \"dependsOn\": [\"core\"],\n      \"versioned_files\": [{\"path\": \"cli/version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
@@ -14,7 +14,7 @@
     { "message": "feat!: breaking change in core API", "files": ["core/src/api.rs"] }
   ],
   "expect": {
-    "check_contains": ["core", "2.0.0", "cli", "1.0.1"],
+    "check_contains": ["core", "2.0.0", "cli", "(major, dependency: core)"],
     "check_not_contains": ["Nothing to release"]
   }
 }

--- a/tests/fixtures/definitions/monorepo-deps-propagate-policies.json
+++ b/tests/fixtures/definitions/monorepo-deps-propagate-policies.json
@@ -1,0 +1,53 @@
+{
+  "meta": {
+    "name": "monorepo-deps-propagate-policies",
+    "description": "Each dependent translates the same major bump through its own propagate policy"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"core\",\n      \"path\": \"core\",\n      \"versioned_files\": [\n        {\n          \"path\": \"core/version.toml\",\n          \"format\": \"toml\"\n        }\n      ]\n    },\n    {\n      \"name\": \"cli\",\n      \"path\": \"cli\",\n      \"dependsOn\": [\n        {\n          \"name\": \"core\",\n          \"propagate\": \"patch\"\n        }\n      ],\n      \"versioned_files\": [\n        {\n          \"path\": \"cli/version.toml\",\n          \"format\": \"toml\"\n        }\n      ]\n    },\n    {\n      \"name\": \"sdk\",\n      \"path\": \"sdk\",\n      \"dependsOn\": [\n        {\n          \"name\": \"core\",\n          \"propagate\": \"major-on-major\"\n        }\n      ],\n      \"versioned_files\": [\n        {\n          \"path\": \"sdk/version.toml\",\n          \"format\": \"toml\"\n        }\n      ]\n    },\n    {\n      \"name\": \"docs\",\n      \"path\": \"docs\",\n      \"dependsOn\": [\n        {\n          \"name\": \"core\",\n          \"propagate\": \"none\"\n        }\n      ],\n      \"versioned_files\": [\n        {\n          \"path\": \"docs/version.toml\",\n          \"format\": \"toml\"\n        }\n      ]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "core",
+      "path": "core",
+      "initial_version": "1.0.0",
+      "tag": "core@v1.0.0"
+    },
+    {
+      "name": "cli",
+      "path": "cli",
+      "initial_version": "1.0.0",
+      "tag": "cli@v1.0.0"
+    },
+    {
+      "name": "sdk",
+      "path": "sdk",
+      "initial_version": "1.0.0",
+      "tag": "sdk@v1.0.0"
+    },
+    {
+      "name": "docs",
+      "path": "docs",
+      "initial_version": "1.0.0",
+      "tag": "docs@v1.0.0"
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat!: breaking change in core API",
+      "files": [
+        "core/src/api.rs"
+      ]
+    }
+  ],
+  "expect": {
+    "check_contains": [
+      "core  1.0.0 → 2.0.0",
+      "cli  1.0.0 → 1.0.1",
+      "sdk  1.0.0 → 2.0.0"
+    ],
+    "check_not_contains": [
+      "docs"
+    ]
+  }
+}


### PR DESCRIPTION
Addresses points 1 and 3 of #493. Point 2 (`update_dependents`) is **not** in this PR — see the end.

## The bug

The cascade hardcoded `BumpType::Patch` (`cascade.rs:79`) and wrote `"patch"` into the JSON outputs. So `core` going `1.4.0 → 2.0.0` on a `feat!:` handed its dependent `cli` a **patch**, and consumers upgraded `cli` straight into a breaking API.

Verified on a real fixture before the change: `cli` came out at `2.1.1`. After:

```
core   1.4.0 -> 2.0.0  (major)
cli    2.1.0 -> 3.0.0  (major)
```

## Propagation

`bumped_names: HashSet<String>` becomes `bumped: HashMap<String, BumpType>`, so the cascade knows what each upstream actually got. The dependent's bump is the **strongest** resolved bump across its moved dependencies — the same rule a package's own commits already follow.

The default is `same`: the dependent gets exactly what the upstream got. A breaking upstream makes the dependent breaking, which is the honest signal — it now builds against a breaking API.

## Per-dependency policy

`depends_on` accepts the detailed form alongside the plain name, via an untagged enum, so **every existing config keeps working unchanged**:

```toml
depends_on = ["core"]                                        # same (default)
depends_on = [{ name = "core", propagate = "major-on-major" }]
```

| policy | major upstream | minor | patch |
|---|---|---|---|
| `same` (default) | major | minor | patch |
| `major-on-major` | major | patch | patch |
| `patch` | patch | patch | patch |
| `none` | — | — | — |

`patch` reproduces the pre-PR behaviour for anyone who wants it back; `none` opts a dependency out of the cascade entirely. An upstream that did not move never manufactures a downstream bump, under any policy.

## Verified end to end

Built the binary and ran `ferrflow check --json` on four monorepo fixtures:

- default + minor upstream → dependent minor
- `major-on-major` + minor upstream → dependent patch
- `patch` + major upstream → dependent patch (old behaviour intact)
- `none` + major upstream → dependent absent from the plan entirely

## Also

Schema updated for both spellings (`dependsOn` / `depends_on`) with the `oneOf` string-or-object shape, and the cloud copy re-synced — byte parity verified.

8 new tests on the policy table and both deserialisation forms, including that no policy can invent a bump from an unmoved upstream. Full suite green (1843), `clippy --all-targets -D warnings` clean.

## What is not here: `update_dependents`

Point 2 of the issue — rewriting the dependency ranges in dependents' manifests — is deliberately left for its own PR, and I want to be explicit that I chose this rather than run out of room silently.

It is the riskiest part of the issue: it writes into user manifests, and getting it wrong corrupts a `package.json` or `Cargo.toml`. It also needs real per-format work that does not exist yet — `json.rs` has a hand-rolled span walker that only finds *top-level* string values, and there is an explicit test asserting the version bump must **not** touch `dependencies`. Doing it properly means a nested-span finder for JSON, `toml_edit` handling for both the `dep = "1.2"` and `dep = { version = "1.2" }` shapes, and a decision on constraint preservation (`^`, `~`, `>=`, `workspace:*`, git/path deps) — each of which deserves its own tests and review.

The two parts are independent: propagation is useful on its own and this PR is complete without it. Happy to open the follow-up immediately.
