### PR TITLE
feat(monorepo): rewrite dependent version constraints on release

### DIFF
--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -147,6 +147,11 @@
             ".ferrflow.manifest.json"
           ]
         },
+        "updateDependents": {
+          "type": "boolean",
+          "description": "When true, after `ferrflow release` bumps a package, every dependent listed via `dependsOn` has its version constraint for that package rewritten to the new version in its own manifest, and the manifest is staged in the release commit. Only `json` (package.json) and `toml` (Cargo.toml) manifests are rewritten, and only plain operator + version constraints (`^1.2.3`, `~1.2.3`, `1.2.3`) — a `workspace:*`, `file:`/`git:` spec or a multi-part range is left untouched for a human to handle.",
+          "default": false
+        },
         "updateLockfiles": {
           "type": "boolean",
           "description": "When true, after `ferrflow release` bumps a manifest (Cargo.toml, package.json, pyproject.toml, Gemfile, mix.exs) it refreshes the sibling lockfile (Cargo.lock, package-lock.json / pnpm-lock.yaml / yarn.lock, poetry.lock / uv.lock, Gemfile.lock, mix.lock) with the package manager's offline / lockfile-only mode and stages it in the same release commit. A missing package manager or an unresolvable offline update is warned about, never fatal. Set per-package `updateLockfiles: false` to opt a single package out.",
@@ -356,6 +361,11 @@
         "defer_publish": {
           "type": "boolean",
           "description": "Snake_case form of `deferPublish` — both spellings are accepted. When true, `ferrflow release` does not run the configured publishers inline — it defers them to a separate `ferrflow publish` invocation (e.g. a CI job that carries the docker/helm/npm build toolchain the release job lacks). `ferrflow publish` always runs the publishers regardless of this flag.",
+          "default": false
+        },
+        "update_dependents": {
+          "type": "boolean",
+          "description": "Snake_case form of `updateDependents` — both spellings are accepted. When true, after `ferrflow release` bumps a package, every dependent listed via `dependsOn` has its version constraint for that package rewritten to the new version in its own manifest, and the manifest is staged in the release commit. Only `json` (package.json) and `toml` (Cargo.toml) manifests are rewritten, and only plain operator + version constraints (`^1.2.3`, `~1.2.3`, `1.2.3`) — a `workspace:*`, `file:`/`git:` spec or a multi-part range is left untouched for a human to handle.",
           "default": false
         },
         "update_lockfiles": {

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -81,6 +81,14 @@ pub struct WorkspaceConfig {
     /// `package.updateLockfiles = false` to opt a single package out.
     #[serde(default, alias = "updateLockfiles")]
     pub update_lockfiles: bool,
+    /// Rewrite the version constraint a dependent declares for a package
+    /// that was just bumped, so consumers stop pinning the old range.
+    /// Only `json` (package.json) and `toml` (Cargo.toml) manifests are
+    /// rewritten, and only plain operator + version constraints — a
+    /// `workspace:*`, `file:` or multi-part range is left for a human.
+    /// Default `false`: this writes into manifests, so it is opt-in.
+    #[serde(default, alias = "updateDependents")]
+    pub update_dependents: bool,
     /// Packages that share a version line when co-released. When any
     /// member of a group has a releasable commit, every member is bumped
     /// to the same version (the highest resulting version across the

--- a/src/formats/dependents.rs
+++ b/src/formats/dependents.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::config::{FileFormat, VersionedFile};
 use crate::error_code::{self, ErrorCodeExt};
@@ -15,22 +15,37 @@ const JSON_SECTIONS: &[&str] = &[
 /// Dependency tables rewritten in a `Cargo.toml`.
 const TOML_SECTIONS: &[&str] = &["dependencies", "dev-dependencies", "build-dependencies"];
 
-/// Rewrites `dep_name`'s version constraint to `new_version` in `vf`, keeping
-/// the file's formatting and the constraint's operator.
+/// A manifest rewrite that has been computed but not yet applied, so a dry run
+/// can report exactly what a real run would write.
+pub struct PlannedUpdate {
+    path: PathBuf,
+    content: String,
+}
+
+impl PlannedUpdate {
+    pub fn apply(&self) -> Result<()> {
+        std::fs::write(&self.path, &self.content)
+            .with_context(|| format!("Cannot write {}", self.path.display()))
+            .error_code(error_code::JSON_WRITE)
+    }
+}
+
+/// Computes the rewrite of `dep_name`'s version constraint to `new_version` in
+/// `vf`, keeping the file's formatting and the constraint's operator.
 ///
-/// Returns whether anything was written. A format with no defined notion of a
-/// dependency table, an absent dependency, or a constraint we refuse to touch
-/// all return `Ok(false)` — this never fails a release over a manifest it does
-/// not understand.
-pub fn update_dependency(
+/// `Ok(None)` means there is nothing to do: a format with no defined notion of
+/// a dependency table, a missing or unparseable manifest, an absent dependency,
+/// a constraint we refuse to touch, or one already on `new_version`. This never
+/// fails a release over a manifest it does not understand.
+pub fn plan_dependency_update(
     vf: &VersionedFile,
     repo_root: &Path,
     dep_name: &str,
     new_version: &str,
-) -> Result<bool> {
+) -> Result<Option<PlannedUpdate>> {
     let path = super::join_within_repo(repo_root, &vf.path)?;
     let Ok(content) = std::fs::read_to_string(&path) else {
-        return Ok(false);
+        return Ok(None);
     };
 
     let updated = match vf.format {
@@ -39,15 +54,7 @@ pub fn update_dependency(
         _ => None,
     };
 
-    match updated {
-        Some(text) => {
-            std::fs::write(&path, text)
-                .with_context(|| format!("Cannot write {}", path.display()))
-                .error_code(error_code::JSON_WRITE)?;
-            Ok(true)
-        }
-        None => Ok(false),
-    }
+    Ok(updated.map(|content| PlannedUpdate { path, content }))
 }
 
 /// Whether a format has a dependency table this module knows how to rewrite.
@@ -290,18 +297,22 @@ mod tests {
         }
     }
 
+    // Planning must not touch the file — that is what makes `--dry-run` able to
+    // report the rewrite it would perform.
     #[test]
-    fn writes_the_manifest_and_reports_the_change() {
+    fn planning_reports_the_change_without_writing_it() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("package.json");
-        std::fs::write(
-            &path,
-            "{\n  \"dependencies\": {\n    \"core\": \"^1.0.0\"\n  }\n}\n",
-        )
-        .unwrap();
+        let original = "{\n  \"dependencies\": {\n    \"core\": \"^1.0.0\"\n  }\n}\n";
+        std::fs::write(&path, original).unwrap();
 
         let vf = versioned("package.json", FileFormat::Json);
-        assert!(update_dependency(&vf, dir.path(), "core", "2.0.0").unwrap());
+        let planned = plan_dependency_update(&vf, dir.path(), "core", "2.0.0")
+            .unwrap()
+            .expect("a rewrite is planned");
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+
+        planned.apply().unwrap();
         assert!(
             std::fs::read_to_string(&path)
                 .unwrap()
@@ -309,25 +320,35 @@ mod tests {
         );
     }
 
-    // A second pass over an already-current manifest must not report a change,
-    // or the release commit would carry a file with no diff.
+    // A second pass over an already-current manifest must plan nothing, or the
+    // release commit would carry a file with no diff.
     #[test]
-    fn a_no_op_update_leaves_the_file_untouched() {
+    fn an_already_current_manifest_plans_nothing() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("package.json");
-        let original = "{\n  \"dependencies\": {\n    \"core\": \"^2.0.0\"\n  }\n}\n";
-        std::fs::write(&path, original).unwrap();
+        std::fs::write(
+            &path,
+            "{\n  \"dependencies\": {\n    \"core\": \"^2.0.0\"\n  }\n}\n",
+        )
+        .unwrap();
 
         let vf = versioned("package.json", FileFormat::Json);
-        assert!(!update_dependency(&vf, dir.path(), "core", "2.0.0").unwrap());
-        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+        assert!(
+            plan_dependency_update(&vf, dir.path(), "core", "2.0.0")
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]
     fn a_missing_manifest_is_not_an_error() {
         let dir = tempfile::tempdir().unwrap();
         let vf = versioned("package.json", FileFormat::Json);
-        assert!(!update_dependency(&vf, dir.path(), "core", "2.0.0").unwrap());
+        assert!(
+            plan_dependency_update(&vf, dir.path(), "core", "2.0.0")
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/formats/dependents.rs
+++ b/src/formats/dependents.rs
@@ -1,0 +1,341 @@
+use anyhow::{Context, Result};
+use std::path::Path;
+
+use crate::config::{FileFormat, VersionedFile};
+use crate::error_code::{self, ErrorCodeExt};
+
+/// Dependency tables rewritten in a `package.json`.
+const JSON_SECTIONS: &[&str] = &[
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+    "optionalDependencies",
+];
+
+/// Dependency tables rewritten in a `Cargo.toml`.
+const TOML_SECTIONS: &[&str] = &["dependencies", "dev-dependencies", "build-dependencies"];
+
+/// Rewrites `dep_name`'s version constraint to `new_version` in `vf`, keeping
+/// the file's formatting and the constraint's operator.
+///
+/// Returns whether anything was written. A format with no defined notion of a
+/// dependency table, an absent dependency, or a constraint we refuse to touch
+/// all return `Ok(false)` — this never fails a release over a manifest it does
+/// not understand.
+pub fn update_dependency(
+    vf: &VersionedFile,
+    repo_root: &Path,
+    dep_name: &str,
+    new_version: &str,
+) -> Result<bool> {
+    let path = super::join_within_repo(repo_root, &vf.path)?;
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return Ok(false);
+    };
+
+    let updated = match vf.format {
+        FileFormat::Json => rewrite_json(&content, dep_name, new_version),
+        FileFormat::Toml => rewrite_toml(&content, dep_name, new_version),
+        _ => None,
+    };
+
+    match updated {
+        Some(text) => {
+            std::fs::write(&path, text)
+                .with_context(|| format!("Cannot write {}", path.display()))
+                .error_code(error_code::JSON_WRITE)?;
+            Ok(true)
+        }
+        None => Ok(false),
+    }
+}
+
+/// Whether a format has a dependency table this module knows how to rewrite.
+pub fn supports_dependency_updates(format: &FileFormat) -> bool {
+    matches!(format, FileFormat::Json | FileFormat::Toml)
+}
+
+/// Replaces the version inside a constraint while keeping its operator, so
+/// `^1.2.3` becomes `^2.0.0` rather than a bare pin.
+///
+/// Returns `None` for anything that is not a plain operator + version:
+/// wildcards, `workspace:*`, `file:`/`git:` specs, multi-part ranges. Those
+/// carry intent we cannot preserve, and silently rewriting them would be worse
+/// than leaving them for a human.
+fn rewrite_constraint(existing: &str, new_version: &str) -> Option<String> {
+    let trimmed = existing.trim();
+    if trimmed.is_empty()
+        || trimmed.contains(char::is_whitespace)
+        || trimmed.contains(':')
+        || trimmed.contains(',')
+        || trimmed.contains("||")
+    {
+        return None;
+    }
+
+    let digit_at = trimmed.find(|c: char| c.is_ascii_digit())?;
+    let (prefix, version) = trimmed.split_at(digit_at);
+
+    if !prefix
+        .chars()
+        .all(|c| matches!(c, '^' | '~' | '>' | '<' | '=' | 'v'))
+    {
+        return None;
+    }
+    // `1.x` / `1.*` are ranges, not pins — the same reasoning as above.
+    if version
+        .chars()
+        .any(|c| matches!(c, 'x' | 'X' | '*' | '|' | ' '))
+    {
+        return None;
+    }
+    if !version
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '+'))
+    {
+        return None;
+    }
+
+    Some(format!("{prefix}{new_version}"))
+}
+
+fn rewrite_json(content: &str, dep_name: &str, new_version: &str) -> Option<String> {
+    if serde_json::from_str::<serde_json::Value>(content).is_err() {
+        return None;
+    }
+
+    let mut out = content.to_string();
+    let mut changed = false;
+    // Walk sections back to front: every splice shifts the offsets after it,
+    // and later sections sit later in the file.
+    let mut spans: Vec<(usize, usize)> = JSON_SECTIONS
+        .iter()
+        .filter_map(|section| {
+            super::json::find_nested_string_value_span(content, section, dep_name)
+        })
+        .collect();
+    spans.sort_unstable();
+    spans.dedup();
+
+    for (start, end) in spans.into_iter().rev() {
+        let existing = &content[start..end];
+        let Some(replacement) = rewrite_constraint(existing, new_version) else {
+            continue;
+        };
+        if replacement == existing {
+            continue;
+        }
+        out.replace_range(start..end, &replacement);
+        changed = true;
+    }
+
+    changed.then_some(out)
+}
+
+fn rewrite_toml(content: &str, dep_name: &str, new_version: &str) -> Option<String> {
+    let mut doc = content.parse::<toml_edit::DocumentMut>().ok()?;
+    let mut changed = false;
+
+    for section in TOML_SECTIONS {
+        let Some(table) = doc.get_mut(section).and_then(|i| i.as_table_like_mut()) else {
+            continue;
+        };
+        let Some(entry) = table.get_mut(dep_name) else {
+            continue;
+        };
+
+        // `dep = "1.2"` and `dep = { version = "1.2", path = ".." }` are both
+        // common; a path/git-only entry has no version to rewrite.
+        if let Some(existing) = entry.as_str() {
+            if let Some(replacement) = rewrite_constraint(existing, new_version)
+                && replacement != existing
+            {
+                *entry = toml_edit::value(replacement);
+                changed = true;
+            }
+        } else if let Some(inline) = entry.as_table_like_mut()
+            && let Some(version) = inline.get_mut("version")
+            && let Some(existing) = version.as_str()
+            && let Some(replacement) = rewrite_constraint(existing, new_version)
+            && replacement != existing
+        {
+            *version = toml_edit::value(replacement);
+            changed = true;
+        }
+    }
+
+    changed.then(|| doc.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keeps_the_caret_and_replaces_the_version() {
+        assert_eq!(rewrite_constraint("^1.2.3", "2.0.0").unwrap(), "^2.0.0");
+    }
+
+    #[test]
+    fn keeps_other_operators() {
+        for (existing, expected) in [
+            ("~1.2.3", "~2.0.0"),
+            (">=1.2.3", ">=2.0.0"),
+            ("=1.2.3", "=2.0.0"),
+            ("v1.2.3", "v2.0.0"),
+            ("1.2.3", "2.0.0"),
+        ] {
+            assert_eq!(rewrite_constraint(existing, "2.0.0").unwrap(), expected);
+        }
+    }
+
+    // Everything below carries intent a version pin would destroy. Leaving
+    // them alone is the whole safety story of this module.
+    #[test]
+    fn refuses_specs_it_cannot_preserve() {
+        for existing in [
+            "*",
+            "workspace:*",
+            "workspace:^1.2.3",
+            "file:../core",
+            "git:git@github.com:a/b.git",
+            "npm:core@1.2.3",
+            ">=1.0.0 <2.0.0",
+            "^1.0.0 || ^2.0.0",
+            "1.x",
+            "1.*",
+            "latest",
+            "",
+        ] {
+            assert!(
+                rewrite_constraint(existing, "2.0.0").is_none(),
+                "{existing:?} must be left untouched"
+            );
+        }
+    }
+
+    #[test]
+    fn rewrites_a_package_json_dependency_in_place() {
+        let original = "{\n  \"name\": \"cli\",\n  \"version\": \"2.1.0\",\n  \"dependencies\": {\n    \"core\": \"^1.4.0\",\n    \"other\": \"^9.9.9\"\n  }\n}\n";
+        let out = rewrite_json(original, "core", "2.0.0").expect("rewrites");
+        assert!(out.contains("\"core\": \"^2.0.0\""));
+        assert!(
+            out.contains("\"other\": \"^9.9.9\""),
+            "unrelated dependencies must not move"
+        );
+        assert!(
+            out.contains("\"version\": \"2.1.0\""),
+            "the package's own version is not this module's job"
+        );
+    }
+
+    // A name appearing in several tables must be updated in all of them, and
+    // the offsets must survive multiple splices in one pass.
+    #[test]
+    fn rewrites_every_section_that_mentions_the_dependency() {
+        let original = "{\n  \"dependencies\": {\n    \"core\": \"^1.4.0\"\n  },\n  \"devDependencies\": {\n    \"core\": \"~1.4.0\"\n  },\n  \"peerDependencies\": {\n    \"core\": \"1.4.0\"\n  }\n}\n";
+        let out = rewrite_json(original, "core", "2.0.0").expect("rewrites");
+        assert!(out.contains("\"core\": \"^2.0.0\""));
+        assert!(out.contains("\"core\": \"~2.0.0\""));
+        assert!(out.contains("\"core\": \"2.0.0\""));
+    }
+
+    #[test]
+    fn a_missing_json_dependency_changes_nothing() {
+        let original = "{\n  \"dependencies\": {\n    \"other\": \"^1.0.0\"\n  }\n}\n";
+        assert!(rewrite_json(original, "core", "2.0.0").is_none());
+    }
+
+    #[test]
+    fn rewrites_a_cargo_string_dependency() {
+        let original = "[package]\nname = \"cli\"\nversion = \"2.1.0\"\n\n[dependencies]\ncore = \"1.4\"\nserde = \"1\"\n";
+        let out = rewrite_toml(original, "core", "2.0.0").expect("rewrites");
+        assert!(out.contains("core = \"2.0.0\""));
+        assert!(out.contains("serde = \"1\""), "unrelated deps stay put");
+        assert!(out.contains("version = \"2.1.0\""), "own version untouched");
+    }
+
+    #[test]
+    fn rewrites_the_version_inside_an_inline_table() {
+        let original = "[dependencies]\ncore = { version = \"1.4\", path = \"../core\", features = [\"a\"] }\n";
+        let out = rewrite_toml(original, "core", "2.0.0").expect("rewrites");
+        assert!(out.contains("version = \"2.0.0\""));
+        assert!(
+            out.contains("path = \"../core\"") && out.contains("features = [\"a\"]"),
+            "the rest of the entry must survive: {out}"
+        );
+    }
+
+    // A path-only or git-only dependency has no version to move.
+    #[test]
+    fn leaves_a_dependency_with_no_version_alone() {
+        let original = "[dependencies]\ncore = { path = \"../core\" }\n";
+        assert!(rewrite_toml(original, "core", "2.0.0").is_none());
+    }
+
+    #[test]
+    fn rewrites_dev_and_build_dependencies_too() {
+        let original =
+            "[dev-dependencies]\ncore = \"1.4\"\n\n[build-dependencies]\ncore = \"~1.4\"\n";
+        let out = rewrite_toml(original, "core", "2.0.0").expect("rewrites");
+        assert!(out.contains("core = \"2.0.0\""));
+        assert!(out.contains("core = \"~2.0.0\""));
+    }
+
+    fn versioned(path: &str, format: FileFormat) -> VersionedFile {
+        VersionedFile {
+            path: path.to_string(),
+            format,
+            selector: None,
+        }
+    }
+
+    #[test]
+    fn writes_the_manifest_and_reports_the_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("package.json");
+        std::fs::write(
+            &path,
+            "{\n  \"dependencies\": {\n    \"core\": \"^1.0.0\"\n  }\n}\n",
+        )
+        .unwrap();
+
+        let vf = versioned("package.json", FileFormat::Json);
+        assert!(update_dependency(&vf, dir.path(), "core", "2.0.0").unwrap());
+        assert!(
+            std::fs::read_to_string(&path)
+                .unwrap()
+                .contains("\"core\": \"^2.0.0\"")
+        );
+    }
+
+    // A second pass over an already-current manifest must not report a change,
+    // or the release commit would carry a file with no diff.
+    #[test]
+    fn a_no_op_update_leaves_the_file_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("package.json");
+        let original = "{\n  \"dependencies\": {\n    \"core\": \"^2.0.0\"\n  }\n}\n";
+        std::fs::write(&path, original).unwrap();
+
+        let vf = versioned("package.json", FileFormat::Json);
+        assert!(!update_dependency(&vf, dir.path(), "core", "2.0.0").unwrap());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn a_missing_manifest_is_not_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let vf = versioned("package.json", FileFormat::Json);
+        assert!(!update_dependency(&vf, dir.path(), "core", "2.0.0").unwrap());
+    }
+
+    #[test]
+    fn only_json_and_toml_are_supported() {
+        assert!(supports_dependency_updates(&FileFormat::Json));
+        assert!(supports_dependency_updates(&FileFormat::Toml));
+        for other in [FileFormat::Gradle, FileFormat::Xml, FileFormat::Txt] {
+            assert!(!supports_dependency_updates(&other));
+        }
+    }
+}

--- a/src/formats/json.rs
+++ b/src/formats/json.rs
@@ -75,6 +75,61 @@ fn find_top_level_string_value_span(content: &str, target_key: &str) -> Option<(
 
 /// Returns the byte index of the first non-whitespace byte at or after
 /// `start`, or `bytes.len()` if all remaining bytes are whitespace.
+/// Span of the string value at `section.key`, e.g. `dependencies.core`.
+///
+/// Same contract as [`find_top_level_string_value_span`] — the caller has
+/// already validated the JSON — but descends one level so a dependency
+/// constraint can be spliced without reformatting the file.
+pub(super) fn find_nested_string_value_span(
+    content: &str,
+    section: &str,
+    key: &str,
+) -> Option<(usize, usize)> {
+    let bytes = content.as_bytes();
+    let section_start = find_object_value_start(bytes, 0, section)?;
+    let (start, end) = find_object_value_start(bytes, section_start, key)
+        .and_then(|value_start| read_string(bytes, value_start).map(|(s, e, _)| (s, e)))?;
+    Some((start, end))
+}
+
+/// Offset of the value for `target_key` in the object beginning at `from`.
+fn find_object_value_start(bytes: &[u8], from: usize, target_key: &str) -> Option<usize> {
+    let n = bytes.len();
+    let mut i = skip_ws(bytes, from);
+    if i >= n || bytes[i] != b'{' {
+        return None;
+    }
+    i += 1;
+
+    loop {
+        i = skip_ws(bytes, i);
+        if i >= n || bytes[i] == b'}' {
+            return None;
+        }
+        if bytes[i] == b',' {
+            i += 1;
+            continue;
+        }
+        if bytes[i] != b'"' {
+            return None;
+        }
+        let (key_start, key_end, after_key) = read_string(bytes, i)?;
+        let key = std::str::from_utf8(&bytes[key_start..key_end]).ok()?;
+        i = skip_ws(bytes, after_key);
+        if i >= n || bytes[i] != b':' {
+            return None;
+        }
+        i = skip_ws(bytes, i + 1);
+        if i >= n {
+            return None;
+        }
+        if key == target_key {
+            return Some(i);
+        }
+        i = skip_value(bytes, i)?;
+    }
+}
+
 fn skip_ws(bytes: &[u8], mut i: usize) -> usize {
     while i < bytes.len() && bytes[i].is_ascii_whitespace() {
         i += 1;

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -2,6 +2,8 @@ pub mod cabal;
 pub mod chart_yaml;
 pub mod cmake;
 pub mod csproj;
+#[cfg(feature = "cli")]
+pub mod dependents;
 pub mod gemspec;
 pub mod gomod;
 pub mod gradle;

--- a/src/monorepo/run/cascade.rs
+++ b/src/monorepo/run/cascade.rs
@@ -3,9 +3,9 @@ use std::path::Path;
 
 use colored::Colorize;
 
-use crate::config::Config;
+use crate::config::{Config, PropagatePolicy};
 use crate::conventional_commits::BumpType;
-use crate::formats::dependents::{supports_dependency_updates, update_dependency};
+use crate::formats::dependents::{plan_dependency_update, supports_dependency_updates};
 use crate::formats::{get_handler, read_version, write_version};
 use crate::versioning::compute_next_version;
 
@@ -205,11 +205,12 @@ pub(super) fn run_dependency_cascade(
 /// Gated on `workspace.update_dependents` by the caller. Only manifests the
 /// rewriter understands are touched; anything else is silently left alone, so
 /// enabling this can never fail a release over a manifest shape we do not
-/// model.
+/// model. A dry run plans and reports the same rewrites without writing them.
 pub(super) fn update_dependent_manifests(
     config: &Config,
     root: &Path,
     bumped_versions: &HashMap<String, String>,
+    dry_run: bool,
     files_to_commit: &mut Vec<String>,
     files_per_package: &mut HashMap<String, Vec<String>>,
 ) -> anyhow::Result<Vec<String>> {
@@ -217,6 +218,11 @@ pub(super) fn update_dependent_manifests(
 
     for pkg in &config.packages {
         for dep in &pkg.depends_on {
+            // A `none` dependent is deliberately held back from the cascade, so
+            // its manifest must stay on the constraint it declares today.
+            if dep.propagate() == PropagatePolicy::None {
+                continue;
+            }
             let Some(new_version) = bumped_versions.get(dep.name()) else {
                 continue;
             };
@@ -224,25 +230,128 @@ pub(super) fn update_dependent_manifests(
                 if !supports_dependency_updates(&vf.format) {
                     continue;
                 }
-                if update_dependency(vf, root, dep.name(), new_version)? {
-                    lines.push(format!(
-                        "  {} {} → {} in {}",
-                        "↳".dimmed(),
-                        dep.name().cyan(),
-                        new_version.green(),
-                        vf.path.dimmed()
-                    ));
-                    if !files_to_commit.contains(&vf.path) {
-                        files_to_commit.push(vf.path.clone());
-                    }
-                    let owned = files_per_package.entry(pkg.name.clone()).or_default();
-                    if !owned.contains(&vf.path) {
-                        owned.push(vf.path.clone());
-                    }
+                let Some(planned) = plan_dependency_update(vf, root, dep.name(), new_version)?
+                else {
+                    continue;
+                };
+                lines.push(format!(
+                    "  {} {} → {} in {}",
+                    "↳".dimmed(),
+                    dep.name().cyan(),
+                    new_version.green(),
+                    vf.path.dimmed()
+                ));
+                if dry_run {
+                    continue;
+                }
+                planned.apply()?;
+                if !files_to_commit.contains(&vf.path) {
+                    files_to_commit.push(vf.path.clone());
+                }
+                let owned = files_per_package.entry(pkg.name.clone()).or_default();
+                if !owned.contains(&vf.path) {
+                    owned.push(vf.path.clone());
                 }
             }
         }
     }
 
     Ok(lines)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // core is bumped; cli propagates it, docs opts out with `none`.
+    fn workspace() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        for name in ["core", "cli", "docs"] {
+            std::fs::create_dir(root.join(name)).unwrap();
+        }
+        std::fs::write(
+            root.join("core/package.json"),
+            "{\n  \"name\": \"core\",\n  \"version\": \"1.0.0\"\n}\n",
+        )
+        .unwrap();
+        for name in ["cli", "docs"] {
+            std::fs::write(
+                root.join(name).join("package.json"),
+                format!(
+                    "{{\n  \"name\": \"{name}\",\n  \"version\": \"1.0.0\",\n  \"dependencies\": {{\n    \"core\": \"^1.0.0\"\n  }}\n}}\n"
+                ),
+            )
+            .unwrap();
+        }
+        std::fs::write(
+            root.join("ferrflow.json"),
+            r#"{
+  "package": [
+    { "name": "core", "path": "core", "versionedFiles": [{ "path": "core/package.json", "format": "json" }] },
+    { "name": "cli", "path": "cli", "dependsOn": ["core"],
+      "versionedFiles": [{ "path": "cli/package.json", "format": "json" }] },
+    { "name": "docs", "path": "docs", "dependsOn": [{ "name": "core", "propagate": "none" }],
+      "versionedFiles": [{ "path": "docs/package.json", "format": "json" }] }
+  ]
+}
+"#,
+        )
+        .unwrap();
+        dir
+    }
+
+    fn rewrite(root: &Path, dry_run: bool) -> (Vec<String>, Vec<String>) {
+        let config = Config::load(root, None).unwrap();
+        let bumped_versions = HashMap::from([("core".to_string(), "2.0.0".to_string())]);
+        let mut files_to_commit = Vec::new();
+        let mut files_per_package = HashMap::new();
+        let lines = update_dependent_manifests(
+            &config,
+            root,
+            &bumped_versions,
+            dry_run,
+            &mut files_to_commit,
+            &mut files_per_package,
+        )
+        .unwrap();
+        (lines, files_to_commit)
+    }
+
+    // `propagate: "none"` holds the package back from the cascade, so its
+    // manifest must keep declaring the version it was built against.
+    #[test]
+    fn a_dependent_that_opts_out_of_the_cascade_keeps_its_constraint() {
+        let dir = workspace();
+        let (lines, files) = rewrite(dir.path(), false);
+
+        assert_eq!(files, vec!["cli/package.json".to_string()]);
+        assert!(lines.iter().all(|l| !l.contains("docs")), "{lines:?}");
+        assert!(
+            std::fs::read_to_string(dir.path().join("docs/package.json"))
+                .unwrap()
+                .contains("\"core\": \"^1.0.0\"")
+        );
+        assert!(
+            std::fs::read_to_string(dir.path().join("cli/package.json"))
+                .unwrap()
+                .contains("\"core\": \"^2.0.0\"")
+        );
+    }
+
+    #[test]
+    fn a_dry_run_reports_the_rewrite_without_performing_it() {
+        let dir = workspace();
+        let (lines, files) = rewrite(dir.path(), true);
+
+        assert_eq!(lines.len(), 1, "{lines:?}");
+        assert!(lines[0].contains("cli/package.json"), "{lines:?}");
+        assert!(files.is_empty(), "a dry run stages nothing: {files:?}");
+        assert!(
+            std::fs::read_to_string(dir.path().join("cli/package.json"))
+                .unwrap()
+                .contains("\"core\": \"^1.0.0\""),
+            "the manifest must be left alone"
+        );
+    }
 }

--- a/src/monorepo/run/cascade.rs
+++ b/src/monorepo/run/cascade.rs
@@ -5,6 +5,7 @@ use colored::Colorize;
 
 use crate::config::Config;
 use crate::conventional_commits::BumpType;
+use crate::formats::dependents::{supports_dependency_updates, update_dependency};
 use crate::formats::{get_handler, read_version, write_version};
 use crate::versioning::compute_next_version;
 
@@ -28,6 +29,9 @@ pub(super) struct CascadeSink<'a> {
     /// Name -> the bump each already-released package received this run. The
     /// cascade reads it to know what to propagate, and extends it as it goes.
     pub bumped: &'a mut HashMap<String, BumpType>,
+    /// Name -> the version each package landed on, consumed by the
+    /// dependent-manifest rewrite once every bump is known.
+    pub bumped_versions: &'a mut HashMap<String, String>,
 }
 
 /// Bump every package that depends (transitively) on a package
@@ -184,13 +188,61 @@ pub(super) fn run_dependency_cascade(
                 ),
                 body,
                 pkg.name.clone(),
-                new_version,
+                new_version.clone(),
                 0,
                 false,
             ));
             sink.bumped.insert(pkg.name.clone(), bump);
+            sink.bumped_versions.insert(pkg.name.clone(), new_version);
             *sink.any_bumped = true;
         }
     }
     Ok(())
+}
+
+/// Rewrites the constraints dependents declare for packages bumped this run.
+///
+/// Gated on `workspace.update_dependents` by the caller. Only manifests the
+/// rewriter understands are touched; anything else is silently left alone, so
+/// enabling this can never fail a release over a manifest shape we do not
+/// model.
+pub(super) fn update_dependent_manifests(
+    config: &Config,
+    root: &Path,
+    bumped_versions: &HashMap<String, String>,
+    files_to_commit: &mut Vec<String>,
+    files_per_package: &mut HashMap<String, Vec<String>>,
+) -> anyhow::Result<Vec<String>> {
+    let mut lines = Vec::new();
+
+    for pkg in &config.packages {
+        for dep in &pkg.depends_on {
+            let Some(new_version) = bumped_versions.get(dep.name()) else {
+                continue;
+            };
+            for vf in &pkg.versioned_files {
+                if !supports_dependency_updates(&vf.format) {
+                    continue;
+                }
+                if update_dependency(vf, root, dep.name(), new_version)? {
+                    lines.push(format!(
+                        "  {} {} → {} in {}",
+                        "↳".dimmed(),
+                        dep.name().cyan(),
+                        new_version.green(),
+                        vf.path.dimmed()
+                    ));
+                    if !files_to_commit.contains(&vf.path) {
+                        files_to_commit.push(vf.path.clone());
+                    }
+                    let owned = files_per_package.entry(pkg.name.clone()).or_default();
+                    if !owned.contains(&vf.path) {
+                        owned.push(vf.path.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(lines)
 }

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -613,11 +613,12 @@ pub(super) fn run_release_logic(
     // Runs after the cascade so every package's final version is known — a
     // dependent's constraint must land on the version its upstream actually
     // ended up at, not an intermediate one.
-    if config.workspace.update_dependents && !dry_run {
+    if config.workspace.update_dependents {
         let rewritten = cascade::update_dependent_manifests(
             config,
             root,
             &bumped_versions,
+            dry_run,
             &mut files_to_commit,
             &mut files_per_package,
         )?;

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -198,6 +198,9 @@ pub(super) fn run_release_logic(
     // Name -> bump, so the dependency cascade can propagate the real bump
     // type instead of assuming a patch.
     let mut bumped: HashMap<String, BumpType> = HashMap::new();
+    // Name -> the version each package landed on, for rewriting the
+    // constraints its dependents declare.
+    let mut bumped_versions: HashMap<String, String> = HashMap::new();
 
     let mut pkg_outputs: Vec<(String, Vec<String>)> = Vec::new();
     let mut shared_outputs: Vec<String> = Vec::new();
@@ -579,6 +582,7 @@ pub(super) fn run_release_logic(
 
         hook_contexts.push((hook_ctx, pkg_idx));
         bumped.insert(pkg.name.clone(), bump);
+        bumped_versions.insert(pkg.name.clone(), new_version.clone());
         any_bumped = true;
     }
 
@@ -592,6 +596,7 @@ pub(super) fn run_release_logic(
             tags_to_create: &mut tags_to_create,
             pkg_outputs: &mut pkg_outputs,
             bumped: &mut bumped,
+            bumped_versions: &mut bumped_versions,
         };
         cascade::run_dependency_cascade(
             config,
@@ -603,6 +608,22 @@ pub(super) fn run_release_logic(
             dry_run,
             &mut sink,
         )?;
+    }
+
+    // Runs after the cascade so every package's final version is known — a
+    // dependent's constraint must land on the version its upstream actually
+    // ended up at, not an intermediate one.
+    if config.workspace.update_dependents && !dry_run {
+        let rewritten = cascade::update_dependent_manifests(
+            config,
+            root,
+            &bumped_versions,
+            &mut files_to_commit,
+            &mut files_per_package,
+        )?;
+        for line in rewritten {
+            shared_outputs.push(line);
+        }
     }
 
     timing.record("per-package compute", compute_start.elapsed());


### PR DESCRIPTION
Part 2 of #493. Stacked on #782 (the propagation policy) — merge that first, this PR's diff is only the manifest rewrite.

When a package is bumped, every dependent that declares it via `dependsOn` still pins the old range. This adds `workspace.updateDependents` (default `false`): after the cascade settles, each dependent's manifest has its constraint for the bumped package rewritten to the new version, and the file is staged in the same release commit.

```json
{
  "workspace": { "updateDependents": true },
  "package": [
    { "name": "core", "path": "core", "versionedFiles": [{ "path": "core/package.json", "format": "json" }] },
    { "name": "cli", "path": "cli", "dependsOn": ["core"], "versionedFiles": [{ "path": "cli/package.json", "format": "json" }] }
  ]
}
```

```
● core  1.0.0 → 1.1.0  (minor)
● cli   2.3.0 → 2.4.0  (minor, dependency: core)
  ↳ core → 1.1.0 in cli/package.json
```

`cli/package.json` goes from `"core": "^1.0.0"` to `"core": "^1.1.0"` in the release commit.

### What gets rewritten

`json` (`dependencies`, `devDependencies`, `peerDependencies`, `optionalDependencies`) and `toml` (`dependencies`, `dev-dependencies`, `build-dependencies`, including the `{ version = "…", path = "…" }` inline form). Every other format is skipped.

Only a plain operator + version is touched, and the operator is preserved — `^1.2.3` → `^2.0.0`, not a bare pin. Anything carrying intent a pin would destroy is left for a human: `workspace:*`, `file:`/`git:`/`npm:` specs, `1.x`, `*`, `latest`, `>=1.0.0 <2.0.0`, `^1.0.0 || ^2.0.0`. A missing manifest, an unparseable one, or an absent dependency is a no-op, never a failed release.

The rewrite runs after the cascade so a constraint always lands on the version its upstream actually ended up at. It writes only when the bytes change, so a re-run adds nothing to the commit.

### Notes

- `find_nested_string_value_span` in `formats/json.rs` is new — the existing walker only found top-level keys, and dependency tables are nested.
- Verified end-to-end on a real monorepo with a bare remote: correct output line, the rewritten manifest staged in the release commit, `workspace:*` untouched, and a `propagate: "none"` dependent neither bumped nor rewritten.

Part of #493
