### PR TITLE
feat(cli): add ferrflow why to explain a package's release decision

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -116,6 +116,17 @@ pub enum Commands {
         #[arg(long, value_enum, default_value = "text")]
         output: OutputFormat,
     },
+    /// Explain why a package would or would not be released
+    Why {
+        /// Package name (required in monorepos, optional in single repos)
+        package: Option<String>,
+        /// Pre-release channel override (e.g. beta, rc, dev)
+        #[arg(long)]
+        channel: Option<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
     /// Compare two versions of a package: commits, bumps, files, and changelog
     Diff {
         /// `[package] <from>..<to>` — the version range (contains `..`), optionally preceded by a package name
@@ -237,6 +248,7 @@ impl Commands {
             Commands::Changelog => "changelog",
             Commands::Init { .. } => "init",
             Commands::Status { .. } => "status",
+            Commands::Why { .. } => "why",
             Commands::Diff { .. } => "diff",
             Commands::Version { .. } => "version",
             Commands::Tag { .. } => "tag",
@@ -309,6 +321,16 @@ impl Cli {
             Commands::Diff { spec, json } => {
                 crate::version_diff::run(&spec, json, self.config.as_deref())
             }
+            Commands::Why {
+                package,
+                channel,
+                json,
+            } => crate::monorepo::why(
+                self.config.as_deref(),
+                package.as_deref(),
+                channel.as_deref(),
+                json,
+            ),
             Commands::Version { package, json } => {
                 crate::query::version(self.config.as_deref(), package.as_deref(), json)
             }
@@ -497,6 +519,36 @@ mod tests {
                 manifest: false
             }
         ));
+    }
+
+    #[test]
+    fn parse_why_with_package_and_flags() {
+        let cli = parse(&["ferrflow", "why", "api", "--channel", "beta", "--json"]);
+        match cli.command {
+            Commands::Why {
+                package,
+                channel,
+                json,
+            } => {
+                assert_eq!(package.as_deref(), Some("api"));
+                assert_eq!(channel.as_deref(), Some("beta"));
+                assert!(json);
+            }
+            _ => panic!("expected Why"),
+        }
+    }
+
+    // The package is optional so single-package repos need no argument.
+    #[test]
+    fn parse_why_without_a_package() {
+        let cli = parse(&["ferrflow", "why"]);
+        match cli.command {
+            Commands::Why { package, json, .. } => {
+                assert!(package.is_none());
+                assert!(!json);
+            }
+            _ => panic!("expected Why"),
+        }
     }
 
     #[test]

--- a/src/monorepo/mod.rs
+++ b/src/monorepo/mod.rs
@@ -7,6 +7,7 @@ mod util;
 
 pub use check::check;
 pub use release::release;
+pub use run::why;
 
 #[cfg(test)]
 mod tests;

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -35,6 +35,7 @@ mod lock;
 mod plan;
 mod release_json;
 mod summary;
+mod why;
 use checkpoint::Checkpoint;
 use drafts::publish_pending_drafts;
 use execute::{ReleasePlan, execute_release, print_dry_run_hooks};
@@ -43,6 +44,7 @@ use plan::{PackagePlan, PlanInputs, SkipReason, compute_plan};
 use rayon::prelude::*;
 use release_json::{GitInfo, ReleaseJson, ReleasedPackage, SkippedPackage};
 use summary::{TagToCreate, collect_outputs};
+pub use why::why;
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn run_release_logic(

--- a/src/monorepo/run/plan.rs
+++ b/src/monorepo/run/plan.rs
@@ -128,6 +128,102 @@ fn changed_files_since_oid_cached(
     Ok(files)
 }
 
+/// Which file set decided whether a package counts as touched, and what that
+/// decision was. `ferrflow why` reports it, so it lives here rather than being
+/// re-derived — a second implementation would eventually disagree with the one
+/// the release actually uses.
+pub(super) struct TouchOutcome {
+    pub touched: bool,
+    pub recovered: bool,
+    pub files: Arc<Vec<String>>,
+}
+
+pub(super) fn evaluate_touch(
+    repo: &Repository,
+    pkg: &PackageConfig,
+    inputs: &PlanInputs<'_>,
+) -> Result<TouchOutcome> {
+    let config = inputs.config;
+    let is_monorepo = config.is_monorepo();
+
+    if is_package_touched(pkg, inputs.changed_files, is_monorepo) {
+        return Ok(TouchOutcome {
+            touched: true,
+            recovered: false,
+            files: Arc::new(inputs.changed_files.to_vec()),
+        });
+    }
+
+    if !config.workspace.recover_missed_releases || !is_monorepo {
+        return Ok(TouchOutcome {
+            touched: false,
+            recovered: false,
+            files: Arc::new(inputs.changed_files.to_vec()),
+        });
+    }
+
+    let tag_search_prefix = pkg.tag_prefix(&config.workspace, is_monorepo);
+    let strategy = config.workspace.orphaned_tag_strategy;
+    let files_since_tag =
+        if let (Some(idx), OrphanedTagStrategy::Warn) = (inputs.tag_index, strategy) {
+            let last_oid = idx.find_last_tag_commit(&tag_search_prefix, strategy);
+            changed_files_since_oid_cached(repo, last_oid, inputs.changed_files_cache)?
+        } else {
+            Arc::new(get_changed_files_since_tag(
+                repo,
+                &tag_search_prefix,
+                strategy,
+                inputs.head_ancestors,
+            )?)
+        };
+
+    let touched = is_package_touched(pkg, &files_since_tag, true);
+    Ok(TouchOutcome {
+        touched,
+        recovered: touched,
+        files: files_since_tag,
+    })
+}
+
+/// The commits a release would classify for `pkg`: everything back to its last
+/// tag, or to its last *stable* tag when the run is not a prerelease.
+pub(super) fn commits_for_package(
+    repo: &Repository,
+    pkg: &PackageConfig,
+    inputs: &PlanInputs<'_>,
+) -> Result<Vec<GitLog>> {
+    let config = inputs.config;
+    let tag_search_prefix = pkg.tag_prefix(&config.workspace, config.is_monorepo());
+    let strategy = config.workspace.orphaned_tag_strategy;
+    let skip_markers = config.workspace.effective_commit_skip_markers();
+
+    if inputs.prerelease_ctx.is_prerelease() {
+        if let (Some(idx), OrphanedTagStrategy::Warn) = (inputs.tag_index, strategy) {
+            let stop = idx.find_last_tag_commit(&tag_search_prefix, strategy);
+            inputs.commit_walk.commits_since(repo, stop)
+        } else {
+            get_commits_since_last_tag(
+                repo,
+                &tag_search_prefix,
+                strategy,
+                &skip_markers,
+                inputs.head_ancestors,
+            )
+        }
+    } else if let (Some(idx), OrphanedTagStrategy::Warn) = (inputs.tag_index, strategy) {
+        let stop = idx.find_last_stable_tag_commit(&tag_search_prefix, strategy);
+        inputs.commit_walk.commits_since(repo, stop)
+    } else {
+        get_commits_since_last_stable_tag(
+            repo,
+            &tag_search_prefix,
+            strategy,
+            &skip_markers,
+            inputs.head_ancestors,
+        )
+    }
+}
+
 pub(super) fn compute_plan(
     repo: &Repository,
     pkg: &PackageConfig,
@@ -138,30 +234,10 @@ pub(super) fn compute_plan(
     let tag_search_prefix = pkg.tag_prefix(&config.workspace, is_monorepo);
     let forced_ver_for_pkg = forced_version_for(inputs.forced, &pkg.name);
 
-    let mut touched = is_package_touched(pkg, inputs.changed_files, is_monorepo);
-    let mut recovered = false;
+    let touch = evaluate_touch(repo, pkg, inputs)?;
+    let recovered = touch.recovered;
 
-    if !touched && config.workspace.recover_missed_releases && is_monorepo {
-        let strategy = config.workspace.orphaned_tag_strategy;
-        let files_since_tag =
-            if let (Some(idx), OrphanedTagStrategy::Warn) = (inputs.tag_index, strategy) {
-                let last_oid = idx.find_last_tag_commit(&tag_search_prefix, strategy);
-                changed_files_since_oid_cached(repo, last_oid, inputs.changed_files_cache)?
-            } else {
-                Arc::new(get_changed_files_since_tag(
-                    repo,
-                    &tag_search_prefix,
-                    strategy,
-                    inputs.head_ancestors,
-                )?)
-            };
-        if is_package_touched(pkg, &files_since_tag, true) {
-            touched = true;
-            recovered = true;
-        }
-    }
-
-    if !touched && forced_ver_for_pkg.is_none() {
+    if !touch.touched && forced_ver_for_pkg.is_none() {
         return Ok(PackagePlan::Skipped {
             reason: SkipReason::NotTouched,
             recovered,
@@ -196,52 +272,14 @@ pub(super) fn compute_plan(
         (None, None) => crate::versioning::bootstrap_version(pkg_strategy),
     };
 
-    let skip_markers = config.workspace.effective_commit_skip_markers();
-    let commits_since_stable = || -> Result<Vec<GitLog>> {
-        if let (Some(idx), OrphanedTagStrategy::Warn) = (inputs.tag_index, strategy) {
-            let stop = idx.find_last_stable_tag_commit(&tag_search_prefix, strategy);
-            inputs.commit_walk.commits_since(repo, stop)
-        } else {
-            get_commits_since_last_stable_tag(
-                repo,
-                &tag_search_prefix,
-                strategy,
-                &skip_markers,
-                inputs.head_ancestors,
-            )
-        }
-    };
-    let commits_since_any = || -> Result<Vec<GitLog>> {
-        if let (Some(idx), OrphanedTagStrategy::Warn) = (inputs.tag_index, strategy) {
-            let stop = idx.find_last_tag_commit(&tag_search_prefix, strategy);
-            inputs.commit_walk.commits_since(repo, stop)
-        } else {
-            get_commits_since_last_tag(
-                repo,
-                &tag_search_prefix,
-                strategy,
-                &skip_markers,
-                inputs.head_ancestors,
-            )
-        }
-    };
-
     let prerelease = inputs.prerelease_ctx.is_prerelease();
 
     let (new_version, is_prerelease, commits, bump) = if let Some(fv) = forced_ver_for_pkg {
         let clean = fv.strip_prefix('v').unwrap_or(fv);
-        let commits = if !prerelease {
-            commits_since_stable().unwrap_or_default()
-        } else {
-            commits_since_any().unwrap_or_default()
-        };
+        let commits = commits_for_package(repo, pkg, inputs).unwrap_or_default();
         (clean.to_string(), false, commits, BumpType::None)
     } else {
-        let commits = if !prerelease {
-            commits_since_stable()?
-        } else {
-            commits_since_any()?
-        };
+        let commits = commits_for_package(repo, pkg, inputs)?;
 
         if commits.is_empty() {
             return Ok(PackagePlan::Skipped {

--- a/src/monorepo/run/why/mod.rs
+++ b/src/monorepo/run/why/mod.rs
@@ -1,0 +1,439 @@
+use anyhow::Result;
+use serde::Serialize;
+use std::path::Path;
+
+use crate::config::{Config, PackageConfig};
+use crate::conventional_commits::{BumpType, determine_bump};
+use crate::formats::read_version;
+use crate::git::{collect_all_tags, get_changed_files, get_repo_root, open_repo};
+use crate::prerelease::PrereleaseContext;
+use crate::versioning::compute_next_version;
+
+use super::super::util::tags_for_package;
+use super::plan::{
+    ChangedFilesCache, PackagePlan, PlanInputs, commits_for_package, compute_plan, evaluate_touch,
+};
+
+mod render;
+mod tag_info;
+
+#[derive(Serialize)]
+pub(super) struct Explanation {
+    package: String,
+    path: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    shared_paths: Vec<String>,
+    strategy: String,
+    current_version: String,
+    monorepo: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    channel: Option<String>,
+    touch: TouchReport,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_tag: Option<tag_info::TagReport>,
+    commits: Vec<CommitReport>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    dependencies: Vec<DependencyReport>,
+    decision: Decision,
+}
+
+#[derive(Serialize)]
+struct TouchReport {
+    touched: bool,
+    /// The package was pulled in by `recoverMissedReleases`, so the file set
+    /// below spans everything since its last tag rather than just HEAD.
+    recovered: bool,
+    files: Vec<FileMatch>,
+}
+
+#[derive(Serialize)]
+struct FileMatch {
+    path: String,
+    /// The `path` / `sharedPaths` prefix this file matched, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    matched: Option<String>,
+}
+
+#[derive(Serialize)]
+struct CommitReport {
+    hash: String,
+    subject: String,
+    bump: String,
+}
+
+#[derive(Serialize)]
+struct DependencyReport {
+    name: String,
+    propagate: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    upstream_bump: Option<String>,
+    resulting_bump: String,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "outcome", rename_all = "kebab-case")]
+enum Decision {
+    Bump {
+        bump: String,
+        from: String,
+        to: String,
+        tag: String,
+        prerelease: bool,
+        triggered_by: Trigger,
+    },
+    Skipped {
+        reason: String,
+    },
+}
+
+#[derive(Serialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+enum Trigger {
+    Commits,
+    Dependency,
+    Forced,
+}
+
+pub fn why(
+    config_path: Option<&Path>,
+    package: Option<&str>,
+    channel: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    let repo = open_repo(&std::env::current_dir()?)?;
+    let root = get_repo_root(&repo)?;
+    let config = Config::load(&root, config_path)?;
+
+    let pkg = resolve_package(&config, package)?;
+    let explanation = explain(&repo, &root, &config, pkg, channel)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&explanation)?);
+    } else {
+        for line in render::lines(&explanation) {
+            tracing::info!("{line}");
+        }
+    }
+    Ok(())
+}
+
+fn resolve_package<'a>(config: &'a Config, package: Option<&str>) -> Result<&'a PackageConfig> {
+    if let Some(name) = package {
+        return config
+            .packages
+            .iter()
+            .find(|p| p.name == name)
+            .ok_or_else(|| {
+                let known: Vec<&str> = config.packages.iter().map(|p| p.name.as_str()).collect();
+                anyhow::anyhow!(
+                    "unknown package '{name}'. Configured packages: {}",
+                    known.join(", ")
+                )
+            });
+    }
+    match config.packages.as_slice() {
+        [] => Err(anyhow::anyhow!(
+            "No packages configured. Run `ferrflow init` to create a config."
+        )),
+        [only] => Ok(only),
+        many => Err(anyhow::anyhow!(
+            "this repo has {} packages — name the one to explain: {}",
+            many.len(),
+            many.iter()
+                .map(|p| p.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )),
+    }
+}
+
+fn explain(
+    repo: &crate::git::Repository,
+    root: &Path,
+    config: &Config,
+    pkg: &PackageConfig,
+    channel: Option<&str>,
+) -> Result<Explanation> {
+    let is_monorepo = config.is_monorepo();
+    let current_branch = crate::git::resolve_current_branch(repo, &config.workspace.branch);
+    let prerelease_ctx = PrereleaseContext::resolve(
+        channel,
+        &current_branch,
+        config.workspace.branches.as_deref(),
+    )?;
+
+    let all_tags = collect_all_tags(repo);
+    let tag_index = crate::git::TagIndex::build(repo).ok();
+    let fallback_ancestors = match &tag_index {
+        Some(_) => None,
+        None => crate::git::build_head_ancestors(repo).ok(),
+    };
+    let head_ancestors = tag_index
+        .as_ref()
+        .map(|idx| &idx.ancestors)
+        .or(fallback_ancestors.as_ref());
+    let short_hash = repo
+        .head_id()
+        .ok()
+        .map(|id| id.to_string()[..7].to_string())
+        .unwrap_or_default();
+    let changed_files = get_changed_files(repo)?;
+    let changed_files_cache = ChangedFilesCache::default();
+    let commit_walk =
+        crate::git::CommitWalkCache::new(config.workspace.effective_commit_skip_markers());
+
+    let inputs = PlanInputs {
+        config,
+        root,
+        tag_index: tag_index.as_ref(),
+        head_ancestors,
+        all_tags: &all_tags,
+        prerelease_ctx: &prerelease_ctx,
+        forced: &None,
+        changed_files: &changed_files,
+        short_hash: &short_hash,
+        changed_files_cache: &changed_files_cache,
+        commit_walk: &commit_walk,
+    };
+
+    let touch = evaluate_touch(repo, pkg, &inputs)?;
+    let plan = compute_plan(repo, pkg, &inputs)?;
+
+    // The commit list is evidence, not a decision: when the package is skipped
+    // for not being touched there is nothing to classify, and walking the
+    // history anyway would only invite the reader to argue with the verdict.
+    let commits = if touch.touched {
+        commits_for_package(repo, pkg, &inputs)?
+            .into_iter()
+            .map(|c| CommitReport {
+                bump: determine_bump(&c.message).to_string(),
+                subject: c.message.lines().next().unwrap_or_default().to_string(),
+                hash: c.hash,
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    let tag_prefix = pkg.tag_prefix(&config.workspace, is_monorepo);
+    let strategy = pkg.effective_versioning(&config.workspace, || {
+        tags_for_package(&all_tags, &tag_prefix)
+    });
+
+    let cascade = cascade_bumps(repo, root, config, &inputs)?;
+    let dependencies = dependency_reports(pkg, &cascade);
+
+    let current_version = current_version(pkg, root, &plan);
+    let decision = decide(
+        config,
+        pkg,
+        root,
+        strategy,
+        &plan,
+        &cascade,
+        &current_version,
+    )?;
+
+    Ok(Explanation {
+        package: pkg.name.clone(),
+        path: pkg.path.clone(),
+        shared_paths: pkg.shared_paths.clone(),
+        strategy: format!("{strategy:?}").to_lowercase(),
+        current_version,
+        monorepo: is_monorepo,
+        channel: prerelease_ctx.channel.clone(),
+        touch: TouchReport {
+            touched: touch.touched,
+            recovered: touch.recovered,
+            files: touch
+                .files
+                .iter()
+                .map(|f| FileMatch {
+                    matched: matching_rule(pkg, f, is_monorepo),
+                    path: f.clone(),
+                })
+                .collect(),
+        },
+        last_tag: tag_info::for_package(repo, &tag_prefix, config, head_ancestors),
+        commits,
+        dependencies,
+        decision,
+    })
+}
+
+/// The `path` / `sharedPaths` prefix that makes `file` belong to `pkg`, mirroring
+/// [`PackageConfig::is_touched_by`] one file at a time so the report can name the
+/// rule that fired.
+fn matching_rule(pkg: &PackageConfig, file: &str, is_monorepo: bool) -> Option<String> {
+    if !is_monorepo {
+        return Some("single-package repo".to_string());
+    }
+    let pkg_path = pkg.path.trim_start_matches("./").trim_end_matches('/');
+    if pkg_path == "." || pkg_path.is_empty() {
+        return Some("repo root".to_string());
+    }
+    let prefix = format!("{pkg_path}/");
+    if file.starts_with(&prefix) {
+        return Some(prefix);
+    }
+    pkg.shared_paths.iter().find_map(|shared| {
+        let trimmed = shared.trim_end_matches('/');
+        (file.starts_with(trimmed) || file == trimmed).then(|| shared.clone())
+    })
+}
+
+/// Every package the release would bump, and with what. Seeded from each
+/// package's own plan, then propagated through `dependsOn` to a fixed point the
+/// same way the release cascade does.
+fn cascade_bumps(
+    repo: &crate::git::Repository,
+    root: &Path,
+    config: &Config,
+    inputs: &PlanInputs<'_>,
+) -> Result<std::collections::HashMap<String, BumpType>> {
+    let mut bumped = std::collections::HashMap::new();
+    for other in &config.packages {
+        if let PackagePlan::Bump(plan) = compute_plan(repo, other, inputs)? {
+            bumped.insert(other.name.clone(), plan.bump);
+        }
+    }
+
+    for _ in 0..config.packages.len() {
+        let mut added = false;
+        for other in &config.packages {
+            if bumped.contains_key(&other.name) {
+                continue;
+            }
+            let bump = other
+                .depends_on
+                .iter()
+                .filter_map(|dep| Some(dep.propagate().resolve(*bumped.get(dep.name())?)))
+                .max()
+                .unwrap_or(BumpType::None);
+            if bump == BumpType::None {
+                continue;
+            }
+            // The release skips a cascaded package whose version would not move;
+            // mirror that so the explanation cannot promise a bump that never lands.
+            let unchanged = other
+                .versioned_files
+                .first()
+                .and_then(|vf| read_version(vf, root).ok())
+                .is_some_and(|current| {
+                    let strategy = other.effective_versioning(&config.workspace, || {
+                        tags_for_package(
+                            inputs.all_tags,
+                            &other.tag_prefix(&config.workspace, true),
+                        )
+                    });
+                    compute_next_version(&current, bump, strategy).is_ok_and(|next| next == current)
+                });
+            if unchanged {
+                continue;
+            }
+            bumped.insert(other.name.clone(), bump);
+            added = true;
+        }
+        if !added {
+            break;
+        }
+    }
+
+    Ok(bumped)
+}
+
+fn dependency_reports(
+    pkg: &PackageConfig,
+    cascade: &std::collections::HashMap<String, BumpType>,
+) -> Vec<DependencyReport> {
+    pkg.depends_on
+        .iter()
+        .map(|dep| {
+            let upstream = cascade.get(dep.name()).copied();
+            DependencyReport {
+                name: dep.name().to_string(),
+                propagate: serde_json::to_value(dep.propagate())
+                    .ok()
+                    .and_then(|v| v.as_str().map(str::to_string))
+                    .unwrap_or_default(),
+                resulting_bump: upstream
+                    .map(|u| dep.propagate().resolve(u))
+                    .unwrap_or(BumpType::None)
+                    .to_string(),
+                upstream_bump: upstream.map(|u| u.to_string()),
+            }
+        })
+        .collect()
+}
+
+fn current_version(pkg: &PackageConfig, root: &Path, plan: &PackagePlan) -> String {
+    match plan {
+        PackagePlan::Bump(bump) => bump.current_version.clone(),
+        PackagePlan::Skipped { .. } => pkg
+            .versioned_files
+            .first()
+            .and_then(|vf| read_version(vf, root).ok())
+            .unwrap_or_else(|| "unknown".to_string()),
+    }
+}
+
+fn decide(
+    config: &Config,
+    pkg: &PackageConfig,
+    root: &Path,
+    strategy: crate::config::VersioningStrategy,
+    plan: &PackagePlan,
+    cascade: &std::collections::HashMap<String, BumpType>,
+    current_version: &str,
+) -> Result<Decision> {
+    if let PackagePlan::Bump(bump) = plan {
+        return Ok(Decision::Bump {
+            bump: bump.strategy_label.clone(),
+            from: bump.current_version.clone(),
+            to: bump.new_version.clone(),
+            tag: bump.tag.clone(),
+            prerelease: bump.is_prerelease,
+            triggered_by: if bump.strategy_label == "forced" {
+                Trigger::Forced
+            } else {
+                Trigger::Commits
+            },
+        });
+    }
+
+    let PackagePlan::Skipped { reason, .. } = plan else {
+        unreachable!("plan is either a bump or a skip");
+    };
+
+    // A package can be skipped on its own commits and still be released because
+    // something it depends on moved — the report has to say so, or it flatly
+    // contradicts what the next `ferrflow release` does.
+    if let Some(bump) = cascade.get(&pkg.name).copied()
+        && bump != BumpType::None
+        && let Some(next) = read_version_for_cascade(pkg, root)
+            .and_then(|current| compute_next_version(&current, bump, strategy).ok())
+        && next != current_version
+    {
+        return Ok(Decision::Bump {
+            bump: bump.to_string(),
+            from: current_version.to_string(),
+            to: next.clone(),
+            tag: pkg.tag_for_version(&config.workspace, config.is_monorepo(), &next),
+            prerelease: false,
+            triggered_by: Trigger::Dependency,
+        });
+    }
+
+    Ok(Decision::Skipped {
+        reason: reason.json_label().to_string(),
+    })
+}
+
+fn read_version_for_cascade(pkg: &PackageConfig, root: &Path) -> Option<String> {
+    pkg.versioned_files
+        .first()
+        .and_then(|vf| read_version(vf, root).ok())
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/monorepo/run/why/render.rs
+++ b/src/monorepo/run/why/render.rs
@@ -1,0 +1,201 @@
+use colored::Colorize;
+
+use super::{Decision, Explanation, Trigger};
+
+pub(super) fn lines(x: &Explanation) -> Vec<String> {
+    let mut out = vec![
+        format!("{} {}", "Package:".dimmed(), x.package.bold()),
+        format!("  {:<14} {}", "Path:", x.path),
+    ];
+    if !x.shared_paths.is_empty() {
+        out.push(format!(
+            "  {:<14} {}",
+            "Shared paths:",
+            x.shared_paths.join(", ")
+        ));
+    }
+    out.push(format!("  {:<14} {}", "Strategy:", x.strategy));
+    out.push(format!("  {:<14} {}", "Version:", x.current_version));
+    if let Some(channel) = &x.channel {
+        out.push(format!("  {:<14} {}", "Channel:", channel));
+    }
+    out.push(String::new());
+
+    push_tag(&mut out, x);
+    push_touch(&mut out, x);
+    push_commits(&mut out, x);
+    push_dependencies(&mut out, x);
+    push_decision(&mut out, x);
+    out
+}
+
+fn push_tag(out: &mut Vec<String>, x: &Explanation) {
+    match &x.last_tag {
+        Some(tag) => {
+            let mut detail = Vec::new();
+            if let Some(commit) = &tag.commit {
+                detail.push(commit.clone());
+            }
+            if let Some(age) = &tag.age {
+                detail.push(age.clone());
+            }
+            detail.push(if tag.reachable_from_head {
+                "reachable from HEAD".to_string()
+            } else {
+                "NOT reachable from HEAD".to_string()
+            });
+            let line = format!("Last tag: {} ({})", tag.name.cyan(), detail.join(", "));
+            out.push(if tag.reachable_from_head {
+                line
+            } else {
+                line.yellow().to_string()
+            });
+        }
+        None => out.push("Last tag: none — this package has never been released".to_string()),
+    }
+    out.push(String::new());
+}
+
+fn push_touch(out: &mut Vec<String>, x: &Explanation) {
+    let scope = if x.touch.recovered {
+        "changed files since the last tag"
+    } else {
+        "changed files at HEAD"
+    };
+    out.push(format!("Touch check ({scope}):"));
+    if x.touch.files.is_empty() {
+        out.push("  (none)".dimmed().to_string());
+    }
+    for file in &x.touch.files {
+        match &file.matched {
+            Some(rule) => out.push(format!(
+                "  {} {:<46} {}",
+                "✓".green(),
+                file.path,
+                format!("matches {rule}").dimmed()
+            )),
+            None => out.push(format!(
+                "  {} {:<46} {}",
+                "✗".dimmed(),
+                file.path.dimmed(),
+                "no match".dimmed()
+            )),
+        }
+    }
+    out.push(if x.touch.touched {
+        let verdict = "→ touched".green().to_string();
+        if x.touch.recovered {
+            format!("{verdict} (recovered by recoverMissedReleases)")
+        } else {
+            verdict
+        }
+    } else {
+        "→ not touched".yellow().to_string()
+    });
+    out.push(String::new());
+}
+
+fn push_commits(out: &mut Vec<String>, x: &Explanation) {
+    if !x.touch.touched {
+        return;
+    }
+    out.push(format!("Commits considered ({}):", x.commits.len()));
+    if x.commits.is_empty() {
+        out.push("  (none)".dimmed().to_string());
+    }
+    for commit in &x.commits {
+        let label = if commit.bump == "none" {
+            "—".dimmed().to_string()
+        } else {
+            commit.bump.cyan().to_string()
+        };
+        out.push(format!(
+            "  {}  {:<52} {}",
+            commit.hash.dimmed(),
+            truncate(&commit.subject, 52),
+            label
+        ));
+    }
+    out.push(String::new());
+}
+
+fn push_dependencies(out: &mut Vec<String>, x: &Explanation) {
+    if x.dependencies.is_empty() {
+        return;
+    }
+    out.push("Dependencies:".to_string());
+    for dep in &x.dependencies {
+        let upstream = match &dep.upstream_bump {
+            Some(bump) => format!("bumping ({bump})"),
+            None => "not bumping".to_string(),
+        };
+        out.push(format!(
+            "  {:<24} {:<20} {}",
+            dep.name,
+            upstream,
+            format!("propagate: {} → {}", dep.propagate, dep.resulting_bump).dimmed()
+        ));
+    }
+    out.push(String::new());
+}
+
+fn push_decision(out: &mut Vec<String>, x: &Explanation) {
+    match &x.decision {
+        Decision::Bump {
+            bump,
+            from,
+            to,
+            tag,
+            prerelease,
+            triggered_by,
+        } => {
+            let cause = match triggered_by {
+                Trigger::Commits => "from its own commits",
+                Trigger::Dependency => "from the dependency cascade",
+                Trigger::Forced => "forced",
+            };
+            let pre = if *prerelease { " (prerelease)" } else { "" };
+            out.push(format!(
+                "{} {} bump {cause}{pre} — {} → {}, tag {}",
+                "Decision:".bold(),
+                bump.green().bold(),
+                from.dimmed(),
+                to.green().bold(),
+                tag.cyan()
+            ));
+        }
+        Decision::Skipped { reason } => out.push(format!(
+            "{} no release — {}",
+            "Decision:".bold(),
+            reason.yellow()
+        )),
+    }
+}
+
+fn truncate(text: &str, width: usize) -> String {
+    if text.chars().count() <= width {
+        return text.to_string();
+    }
+    let kept: String = text.chars().take(width.saturating_sub(1)).collect();
+    format!("{kept}…")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate;
+
+    #[test]
+    fn truncate_keeps_short_subjects_intact() {
+        assert_eq!(truncate("feat: short", 52), "feat: short");
+    }
+
+    // Commit subjects are arbitrary user text; slicing on bytes would panic on
+    // a multi-byte character straddling the cut.
+    #[test]
+    fn truncate_cuts_on_characters_not_bytes() {
+        let subject = "féat: ".repeat(20);
+        let cut = truncate(&subject, 10);
+        assert_eq!(cut.chars().count(), 10);
+        assert!(cut.ends_with('…'));
+    }
+}

--- a/src/monorepo/run/why/tag_info.rs
+++ b/src/monorepo/run/why/tag_info.rs
@@ -1,0 +1,113 @@
+use gix::ObjectId;
+use serde::Serialize;
+use std::collections::HashSet;
+
+use crate::config::Config;
+use crate::git::Repository;
+
+#[derive(Serialize)]
+pub(super) struct TagReport {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub age: Option<String>,
+    /// A tag on a commit no longer reachable from HEAD (rebased away, force
+    /// pushed) is why a package can look released and still replay its history.
+    pub reachable_from_head: bool,
+}
+
+pub(super) fn for_package(
+    repo: &Repository,
+    tag_prefix: &str,
+    config: &Config,
+    head_ancestors: Option<&HashSet<ObjectId>>,
+) -> Option<TagReport> {
+    let name = crate::git::find_last_tag_name_with_cache(
+        repo,
+        tag_prefix,
+        config.workspace.orphaned_tag_strategy,
+        head_ancestors,
+    )
+    .ok()
+    .flatten()?;
+
+    let oid = crate::git::resolve_tag_name_to_commit(repo, &name);
+    let reachable = match (oid, head_ancestors) {
+        (Some(oid), Some(set)) => set.contains(&oid),
+        (Some(_), None) => true,
+        (None, _) => false,
+    };
+
+    Some(TagReport {
+        commit: oid.map(|o| o.to_string()[..7].to_string()),
+        age: oid.and_then(|o| commit_seconds(repo, o)).map(humanize_age),
+        reachable_from_head: reachable,
+        name,
+    })
+}
+
+fn commit_seconds(repo: &Repository, oid: ObjectId) -> Option<i64> {
+    let commit = repo.find_object(oid).ok()?.try_into_commit().ok()?;
+    commit.time().ok().map(|t| t.seconds)
+}
+
+fn humanize_age(seconds: i64) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(seconds);
+    describe_elapsed(now.saturating_sub(seconds))
+}
+
+fn describe_elapsed(elapsed: i64) -> String {
+    const MINUTE: i64 = 60;
+    const HOUR: i64 = 60 * MINUTE;
+    const DAY: i64 = 24 * HOUR;
+    const MONTH: i64 = 30 * DAY;
+    const YEAR: i64 = 365 * DAY;
+
+    if elapsed < 0 {
+        return "in the future".to_string();
+    }
+    let (count, unit) = match elapsed {
+        e if e < MINUTE => return "just now".to_string(),
+        e if e < HOUR => (e / MINUTE, "minute"),
+        e if e < DAY => (e / HOUR, "hour"),
+        e if e < MONTH => (e / DAY, "day"),
+        e if e < YEAR => (e / MONTH, "month"),
+        e => (e / YEAR, "year"),
+    };
+    let plural = if count == 1 { "" } else { "s" };
+    format!("{count} {unit}{plural} ago")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::describe_elapsed;
+
+    #[test]
+    fn describes_each_unit_and_its_singular() {
+        for (elapsed, expected) in [
+            (0, "just now"),
+            (59, "just now"),
+            (60, "1 minute ago"),
+            (3 * 60, "3 minutes ago"),
+            (3_600, "1 hour ago"),
+            (5 * 3_600, "5 hours ago"),
+            (86_400, "1 day ago"),
+            (2 * 86_400, "2 days ago"),
+            (31 * 86_400, "1 month ago"),
+            (400 * 86_400, "1 year ago"),
+        ] {
+            assert_eq!(describe_elapsed(elapsed), expected, "elapsed={elapsed}");
+        }
+    }
+
+    // Clock skew between the committer and this machine must not render as a
+    // nonsense duration.
+    #[test]
+    fn a_tag_from_the_future_is_labelled_not_negative() {
+        assert_eq!(describe_elapsed(-500), "in the future");
+    }
+}

--- a/src/monorepo/run/why/tests.rs
+++ b/src/monorepo/run/why/tests.rs
@@ -1,0 +1,310 @@
+use super::*;
+use crate::test_utils::{commit_file, git, init_repo};
+use std::path::PathBuf;
+
+static COMMIT_TIME: std::sync::atomic::AtomicI64 = std::sync::atomic::AtomicI64::new(1_960_000_000);
+
+fn next_ts() -> i64 {
+    COMMIT_TIME.fetch_add(10, std::sync::atomic::Ordering::SeqCst)
+}
+
+struct Fixture {
+    _dir: tempfile::TempDir,
+    repo: crate::git::Repository,
+    config: Config,
+    root: PathBuf,
+}
+
+impl Fixture {
+    fn commit(&self, file: &str, message: &str) {
+        if let Some(parent) = std::path::Path::new(file).parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(self.root.join(parent)).unwrap();
+        }
+        commit_file(&self.root, file, "x", message, next_ts());
+    }
+
+    fn tag(&self, name: &str) {
+        git(&self.root, &["tag", name]);
+    }
+
+    fn explain(&self, package: &str) -> Explanation {
+        let pkg = resolve_package(&self.config, Some(package)).unwrap();
+        super::explain(&self.repo, &self.root, &self.config, pkg, None).unwrap()
+    }
+}
+
+/// Three packages: `core` standalone, `api` with a shared path and a default
+/// (`same`) dependency on core, `web` with a `patch` policy on core.
+fn monorepo() -> Fixture {
+    let (dir, repo) = init_repo();
+    let root = dir.path().to_path_buf();
+    for name in ["core", "api", "web"] {
+        std::fs::create_dir_all(root.join(name)).unwrap();
+        std::fs::write(
+            root.join(name).join("Cargo.toml"),
+            format!("[package]\nname = \"{name}\"\nversion = \"1.0.0\"\n"),
+        )
+        .unwrap();
+    }
+    std::fs::create_dir_all(root.join("shared")).unwrap();
+    std::fs::write(
+        root.join("ferrflow.json"),
+        r#"{
+  "package": [
+    { "name": "core", "path": "core", "versionedFiles": [{ "path": "core/Cargo.toml", "format": "toml" }] },
+    { "name": "api", "path": "api", "sharedPaths": ["shared/"], "dependsOn": ["core"],
+      "versionedFiles": [{ "path": "api/Cargo.toml", "format": "toml" }] },
+    { "name": "web", "path": "web", "dependsOn": [{ "name": "core", "propagate": "patch" }],
+      "versionedFiles": [{ "path": "web/Cargo.toml", "format": "toml" }] }
+  ]
+}
+"#,
+    )
+    .unwrap();
+    git(&root, &["add", "-A"]);
+    commit_file(&root, "seed.txt", "x", "chore: seed", next_ts());
+    let config = Config::load(&root, Some(&root.join("ferrflow.json"))).unwrap();
+    let fx = Fixture {
+        _dir: dir,
+        repo,
+        config,
+        root,
+    };
+    for name in ["core", "api", "web"] {
+        fx.tag(&format!("{name}@v1.0.0"));
+    }
+    fx
+}
+
+fn bump_of(explanation: &Explanation) -> &Decision {
+    &explanation.decision
+}
+
+#[test]
+fn a_feat_commit_on_the_package_explains_the_minor_bump() {
+    let fx = monorepo();
+    fx.commit("core/src/lib.rs", "feat: add a thing");
+
+    let x = fx.explain("core");
+
+    assert!(x.touch.touched);
+    assert_eq!(
+        x.commits
+            .iter()
+            .map(|c| c.bump.as_str())
+            .collect::<Vec<_>>(),
+        ["minor"]
+    );
+    match bump_of(&x) {
+        Decision::Bump {
+            bump,
+            from,
+            to,
+            triggered_by,
+            ..
+        } => {
+            assert_eq!(
+                (bump.as_str(), from.as_str(), to.as_str()),
+                ("minor", "1.0.0", "1.1.0")
+            );
+            assert!(matches!(triggered_by, Trigger::Commits));
+        }
+        other => panic!("expected a bump, got {:?}", serde_json::to_string(other)),
+    }
+}
+
+// The whole point of the command: name the files that were examined and say
+// which rule each one failed, instead of a bare "not touched".
+#[test]
+fn an_untouched_package_lists_the_files_that_did_not_match() {
+    let fx = monorepo();
+    fx.commit("api/src/lib.rs", "feat: api change");
+
+    let x = fx.explain("core");
+
+    assert!(!x.touch.touched);
+    assert_eq!(
+        x.touch
+            .files
+            .iter()
+            .map(|f| (f.path.as_str(), f.matched.as_deref()))
+            .collect::<Vec<_>>(),
+        [("api/src/lib.rs", None)]
+    );
+    assert!(
+        x.commits.is_empty(),
+        "an untouched package classifies nothing"
+    );
+    match bump_of(&x) {
+        Decision::Skipped { reason } => assert_eq!(reason, "not touched"),
+        other => panic!("expected a skip, got {:?}", serde_json::to_string(other)),
+    }
+}
+
+#[test]
+fn a_shared_path_hit_names_the_rule_that_matched() {
+    let fx = monorepo();
+    fx.commit("shared/util.rs", "feat: shared change");
+
+    let x = fx.explain("api");
+
+    assert!(x.touch.touched);
+    assert_eq!(
+        x.touch.files.first().and_then(|f| f.matched.as_deref()),
+        Some("shared/")
+    );
+}
+
+// A package skipped on its own commits still releases when an upstream moves.
+// Reporting "not touched" and stopping there would contradict the next release.
+#[test]
+fn a_cascaded_package_reports_the_dependency_as_the_trigger() {
+    let fx = monorepo();
+    fx.commit("core/src/lib.rs", "feat!: rewrite core");
+
+    let web = fx.explain("web");
+    assert!(!web.touch.touched);
+    assert_eq!(
+        web.dependencies
+            .iter()
+            .map(|d| (
+                d.name.as_str(),
+                d.propagate.as_str(),
+                d.upstream_bump.as_deref(),
+                d.resulting_bump.as_str()
+            ))
+            .collect::<Vec<_>>(),
+        [("core", "patch", Some("major"), "patch")]
+    );
+    match bump_of(&web) {
+        Decision::Bump {
+            bump,
+            to,
+            triggered_by,
+            ..
+        } => {
+            assert_eq!((bump.as_str(), to.as_str()), ("patch", "1.0.1"));
+            assert!(matches!(triggered_by, Trigger::Dependency));
+        }
+        other => panic!(
+            "expected a cascade bump, got {:?}",
+            serde_json::to_string(other)
+        ),
+    }
+
+    // Same upstream, default policy: `api` takes the major.
+    let api = fx.explain("api");
+    match bump_of(&api) {
+        Decision::Bump { bump, to, .. } => {
+            assert_eq!((bump.as_str(), to.as_str()), ("major", "2.0.0"))
+        }
+        other => panic!(
+            "expected a cascade bump, got {:?}",
+            serde_json::to_string(other)
+        ),
+    }
+}
+
+// "I committed five times and nothing released" — the commits have to be listed
+// with their classification, or the skip reason is unactionable.
+#[test]
+fn a_chore_only_history_still_lists_the_commits_it_rejected() {
+    let fx = monorepo();
+    fx.commit("core/src/a.rs", "chore: tidy");
+    fx.commit("core/src/b.rs", "docs: notes");
+
+    let x = fx.explain("core");
+
+    assert!(x.touch.touched);
+    assert_eq!(
+        x.commits
+            .iter()
+            .map(|c| (c.subject.as_str(), c.bump.as_str()))
+            .collect::<Vec<_>>(),
+        [("docs: notes", "none"), ("chore: tidy", "none")]
+    );
+    match bump_of(&x) {
+        Decision::Skipped { reason } => assert_eq!(reason, "no releasable commits"),
+        other => panic!("expected a skip, got {:?}", serde_json::to_string(other)),
+    }
+}
+
+#[test]
+fn a_never_released_package_reports_no_tag() {
+    let (dir, repo) = init_repo();
+    let root = dir.path().to_path_buf();
+    std::fs::write(
+        root.join("Cargo.toml"),
+        "[package]\nname = \"app\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("ferrflow.json"),
+        r#"{"package":[{"name":"app","path":".","versionedFiles":[{"path":"Cargo.toml","format":"toml"}]}]}"#,
+    )
+    .unwrap();
+    git(&root, &["add", "-A"]);
+    commit_file(&root, "seed.txt", "x", "feat: first", next_ts());
+    let config = Config::load(&root, Some(&root.join("ferrflow.json"))).unwrap();
+    let fx = Fixture {
+        _dir: dir,
+        repo,
+        config,
+        root,
+    };
+
+    let x = fx.explain("app");
+    assert!(x.last_tag.is_none());
+    assert!(!x.monorepo);
+    assert_eq!(
+        x.touch.files.first().and_then(|f| f.matched.as_deref()),
+        Some("single-package repo")
+    );
+}
+
+// `matching_rule` restates `is_touched_by` one file at a time so the report can
+// name the rule; if the two ever disagree the explanation is a lie.
+#[test]
+fn the_per_file_rule_agrees_with_the_touch_check() {
+    let fx = monorepo();
+    let api = fx.config.packages.iter().find(|p| p.name == "api").unwrap();
+
+    for file in [
+        "api/src/lib.rs",
+        "api/Cargo.toml",
+        "shared/util.rs",
+        "shared",
+        "apiary/src/lib.rs",
+        "core/src/lib.rs",
+        "README.md",
+        "",
+    ] {
+        let files = [file.to_string()];
+        assert_eq!(
+            matching_rule(api, file, true).is_some(),
+            api.is_touched_by(&files, true),
+            "disagreement on {file:?}"
+        );
+    }
+}
+
+#[test]
+fn naming_no_package_in_a_monorepo_lists_the_candidates() {
+    let fx = monorepo();
+    let err = resolve_package(&fx.config, None).unwrap_err().to_string();
+    assert!(
+        err.contains("core") && err.contains("api") && err.contains("web"),
+        "{err}"
+    );
+}
+
+#[test]
+fn an_unknown_package_name_is_rejected_with_the_known_ones() {
+    let fx = monorepo();
+    let err = resolve_package(&fx.config, Some("nope"))
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("nope") && err.contains("core"), "{err}");
+}


### PR DESCRIPTION
Closes #501

`ferrflow why <package>` prints the release decision for one package and the evidence behind it.

```
Package: web
  Path:          web
  Strategy:      semver
  Version:       1.0.0

Last tag: web@v1.0.0 (7dcc20b, 3 days ago, reachable from HEAD)

Touch check (changed files at HEAD):
  ✗ core/src/api.rs                                no match
→ not touched

Dependencies:
  core                     bumping (major)      propagate: patch → patch

Decision: patch bump from the dependency cascade — 1.0.0 → 1.0.1, tag web@v1.0.1
```

`--json` emits the same thing as a structured document. `--channel` explains a prerelease run.

### It calls the release path, it does not re-derive it

The decision comes from `compute_plan` — the same function `release` and `check` use. Two pieces of that function that `why` also needs are now named and shared rather than copied: `evaluate_touch` (which file set decided "touched", and what it decided) and `commits_for_package` (last tag vs last *stable* tag depending on the channel). A second implementation of either would eventually disagree with the one that actually releases, which is worse than no command at all.

`matching_rule` is the one deliberate restatement — it re-runs `is_touched_by`'s rules one file at a time so the report can name *which* prefix fired. A test asserts it agrees with `is_touched_by` on every file it is given, so the two cannot drift apart silently.

### Two corrections to the issue's mock output

The mock shows per-commit path filtering (`fix(deps): bump tokio → no-bump (does not touch services/api)`). That is not how FerrFlow works: the touch check runs once, on HEAD's changed files (or everything since the last tag under `recoverMissedReleases`), and the commit list is repo-wide. Showing a per-commit path verdict would have documented a rule that does not exist. The real shape is a **touch check** section followed by a **commits considered** section, which surfaces the actual surprise — a `feat!:` on a sibling package bumps yours to major, because bump classification is not path-scoped.

The mock also folds the cascade into the commit list. Here it is its own section, showing each declared dependency, whether that upstream is moving this run, its `propagate` policy, and what the policy resolves to.

### Verified

`why`'s verdict was cross-checked against `check` on a three-package monorepo across two scenarios (direct bump + two cascade policies, then a follow-up commit that leaves everything untouched) — it agrees package for package in both. 13 tests cover the touched/untouched/shared-path/cascade/chore-only/never-released cases, the per-file rule agreeing with `is_touched_by`, and the CLI parse.

Docs for the CLI reference live in FerrFlow-Cloud and follow in a separate PR.
