### PR TITLE
feat(bot): exchange tokens on api.ferrflow.com instead of api.ferrlabs.com

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,9 +32,9 @@ inputs:
     required: false
     default: 'false'
   bot_endpoint:
-    description: 'Override the hosted bot token endpoint. Defaults to https://api.ferrlabs.com/api/v1/ferrflow/token.'
+    description: 'Override the hosted bot token endpoint. Defaults to https://api.ferrflow.com/v1/ferrflow/token.'
     required: false
-    default: 'https://api.ferrlabs.com/api/v1/ferrflow/token'
+    default: 'https://api.ferrflow.com/v1/ferrflow/token'
   bot_audience:
     description: 'OIDC audience requested from the GitHub Actions runner. Must match the server-side expected audience.'
     required: false

--- a/src/bot_token.rs
+++ b/src/bot_token.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result, bail};
 
-const DEFAULT_ENDPOINT: &str = "https://api.ferrlabs.com/api/v1/ferrflow/token";
+const DEFAULT_ENDPOINT: &str = "https://api.ferrflow.com/v1/ferrflow/token";
 const DEFAULT_AUDIENCE: &str = "ferrflow.ferrlabs.com";
 
 pub fn bot_mode_enabled() -> bool {
@@ -287,6 +287,10 @@ mod tests {
         });
     }
 
+    // Asserted against the literals, not the constants: the point is that these
+    // two values are a contract with the deployed service, not that the struct
+    // copies its own defaults. The audience in particular is what the server
+    // checks the OIDC token against, so a change here rejects every runner.
     #[test]
     fn defaults_use_hosted_endpoint_and_audience() {
         with_env(
@@ -296,8 +300,8 @@ mod tests {
             ],
             || {
                 let ex = BotTokenExchange::default();
-                assert_eq!(ex.endpoint, DEFAULT_ENDPOINT);
-                assert_eq!(ex.audience, DEFAULT_AUDIENCE);
+                assert_eq!(ex.endpoint, "https://api.ferrflow.com/v1/ferrflow/token");
+                assert_eq!(ex.audience, "ferrflow.ferrlabs.com");
             },
         );
     }


### PR DESCRIPTION
Points the hosted bot-token exchange at FerrFlow's own API host. `api.ferrflow.com` went live with FerrLabs/Infra#248.

```
- https://api.ferrlabs.com/api/v1/ferrflow/token
+ https://api.ferrflow.com/v1/ferrflow/token
```

Same change to the `bot_endpoint` default in `action.yml`. Also moves off the legacy `/api/v1` path prefix onto the canonical `/v1` one — both are mounted on the same handler tree, `/api/v1` only exists for the SPAs' historical Traefik convention.

**The audience is deliberately unchanged.** `ferrflow.ferrlabs.com` is the identifier the runner asks GitHub to mint the OIDC token for, and the server validates the token's `aud` against exactly that string. It is not a URL and it does not follow the hostname. Changing it would reject every runner. The test now asserts both values against literals rather than against the constants they came from, so a future edit to either has to be deliberate.

### Verified against production

Both hosts, same malformed payload, byte-identical response:

```
POST https://api.ferrlabs.com/api/v1/ferrflow/token  → 400 {"code":"VALIDATION_FAILED","error":"token: Validation error: length …"}
POST https://api.ferrflow.com/v1/ferrflow/token      → 400 {"code":"VALIDATION_FAILED","error":"token: Validation error: length …"}
```

The rest of the surface answers on the new host too — `health` 200, `schema` 200, `latest` 200, `openapi.json` 200.

### Compatibility

`api.ferrlabs.com/api/v1/ferrflow/token` keeps working and always will: every already-released binary has it compiled in, so it is not a deprecation, it is a permanent alias. `FERRFLOW_BOT_ENDPOINT` / `bot_endpoint:` still override it for self-hosted deployments.

One operational note: the new host sits behind Traefik's `edge-throttle-anonymous` (10 req/s, burst 20, per source IP) where `api.ferrlabs.com` had no throttle. A bot-token exchange is one call per release run, so this is far from binding — but a self-hosted runner fleet sharing one egress IP and firing 20+ releases in the same second would now see 429s, and the CLI already maps 429 to a clear "retry shortly or use a PAT" error.

Refs FerrLabs/FerrFlow-Cloud#762
