### PR TITLE
fix(forge): set connect, response and global HTTP timeouts on release-path agents

### DIFF
--- a/src/bot_token.rs
+++ b/src/bot_token.rs
@@ -73,7 +73,13 @@ impl BotTokenExchange {
             encode_query_component(&self.audience)
         );
 
-        let oidc_body: OidcResponse = ureq::get(&oidc_url)
+        // The bare `ureq::get` / `ureq::post` helpers build an agent with
+        // ureq's all-`None` timeout defaults, so a stalled runner or bot
+        // service would block the release indefinitely.
+        let agent = crate::http::agent();
+
+        let oidc_body: OidcResponse = agent
+            .get(&oidc_url)
             .header("Authorization", &format!("Bearer {req_token}"))
             .header("Accept", "application/json")
             .header(
@@ -91,7 +97,8 @@ impl BotTokenExchange {
         }
 
         let payload = serde_json::json!({ "token": oidc_body.value });
-        let mut response = match ureq::post(&self.endpoint)
+        let mut response = match agent
+            .post(&self.endpoint)
             .header("Content-Type", "application/json")
             .header("Accept", "application/json")
             .header(

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -263,7 +263,7 @@ pub fn build_forge(kind: ForgeKind, token: String, slug: String, host: String) -
     // handshake per call. A 50-pkg release does ~150 HTTPS round-trips
     // against api.github.com — reusing the agent saves 2-8 seconds via
     // HTTP keep-alive. See #509.
-    let agent = ureq::Agent::new_with_defaults();
+    let agent = crate::http::agent();
     match kind {
         ForgeKind::Github => {
             let api_base = if host == "github.com" {

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,0 +1,104 @@
+use std::time::Duration;
+
+const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const DEFAULT_RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_GLOBAL_TIMEOUT: Duration = Duration::from_secs(120);
+
+const GLOBAL_TIMEOUT_ENV: &str = "FERRFLOW_HTTP_TIMEOUT";
+
+/// Every timeout in `ureq::Config` defaults to `None`, so an agent built
+/// with `Agent::new_with_defaults()` blocks on a stalled peer until the
+/// OS gives up — minutes to hours, with the release lock held the whole
+/// time and nothing for `retry_transient` to classify. Build release-path
+/// agents here instead.
+pub fn agent() -> ureq::Agent {
+    agent_with_global_timeout(global_timeout())
+}
+
+fn agent_with_global_timeout(global: Duration) -> ureq::Agent {
+    ureq::Agent::config_builder()
+        .timeout_connect(Some(DEFAULT_CONNECT_TIMEOUT))
+        .timeout_recv_response(Some(DEFAULT_RESPONSE_TIMEOUT))
+        .timeout_global(Some(global))
+        .build()
+        .into()
+}
+
+fn global_timeout() -> Duration {
+    std::env::var(GLOBAL_TIMEOUT_ENV)
+        .ok()
+        .and_then(|raw| parse_global_timeout(&raw))
+        .unwrap_or(DEFAULT_GLOBAL_TIMEOUT)
+}
+
+fn parse_global_timeout(raw: &str) -> Option<Duration> {
+    let secs: u64 = raw.trim().parse().ok()?;
+    (secs > 0).then(|| Duration::from_secs(secs))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_global_timeout_accepts_positive_seconds() {
+        assert_eq!(parse_global_timeout("45"), Some(Duration::from_secs(45)));
+        assert_eq!(
+            parse_global_timeout("  600 "),
+            Some(Duration::from_secs(600))
+        );
+    }
+
+    #[test]
+    fn parse_global_timeout_rejects_zero_and_garbage() {
+        // Zero would mean "no timeout" to a reader but ureq treats every
+        // duration as a real deadline, so it must not silently disable the
+        // budget this module exists to enforce.
+        assert_eq!(parse_global_timeout("0"), None);
+        assert_eq!(parse_global_timeout(""), None);
+        assert_eq!(parse_global_timeout("30s"), None);
+        assert_eq!(parse_global_timeout("-5"), None);
+    }
+
+    /// The regression this module exists for: an agent whose config still
+    /// carries ureq's all-`None` defaults will hang a release. Assert the
+    /// three timeouts we care about are actually set.
+    #[test]
+    fn agent_config_has_connect_response_and_global_timeouts() {
+        let agent = agent_with_global_timeout(Duration::from_secs(90));
+        let timeouts = agent.config().timeouts();
+        assert_eq!(timeouts.connect, Some(DEFAULT_CONNECT_TIMEOUT));
+        assert_eq!(timeouts.recv_response, Some(DEFAULT_RESPONSE_TIMEOUT));
+        assert_eq!(timeouts.global, Some(Duration::from_secs(90)));
+    }
+
+    #[test]
+    fn stalled_peer_fails_within_the_global_budget() {
+        use std::io::Read;
+        use std::net::TcpListener;
+
+        // Accept the connection, then never write a response — the exact
+        // shape that hangs forever on ureq's defaults.
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        let handle = std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut sink = [0u8; 1024];
+                let _ = stream.read(&mut sink);
+                std::thread::sleep(Duration::from_secs(30));
+            }
+        });
+
+        let agent = agent_with_global_timeout(Duration::from_secs(2));
+        let started = std::time::Instant::now();
+        let result = agent.get(&format!("http://127.0.0.1:{port}/")).call();
+        let elapsed = started.elapsed();
+
+        assert!(result.is_err(), "a stalled peer must not resolve");
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "call should abort near the 2s budget, took {elapsed:?}"
+        );
+        drop(handle);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ pub mod forge;
 #[cfg(feature = "cli")]
 pub mod git;
 #[cfg(feature = "cli")]
+pub mod http;
+#[cfg(feature = "cli")]
 pub mod manifest;
 #[cfg(feature = "cli")]
 pub mod publishers;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod forge;
 mod formats;
 mod git;
 mod hooks;
+mod http;
 mod logging;
 mod manifest;
 mod monorepo;

--- a/src/publishers/webhook.rs
+++ b/src/publishers/webhook.rs
@@ -9,7 +9,6 @@
 
 use anyhow::{Context, Result, anyhow};
 use std::collections::BTreeMap;
-use ureq::Agent;
 
 use super::{PublishContext, PublishOutcome};
 use crate::error_code::{self, ErrorCodeExt};
@@ -30,7 +29,7 @@ pub fn run(
         None => default_body(ctx),
     };
 
-    let agent = Agent::new_with_defaults();
+    let agent = crate::http::agent();
     let mut req = agent.post(&interpolated_url);
     for (k, v) in headers {
         let resolved = interpolate(v, ctx)?;


### PR DESCRIPTION
Closes #791.

Every HTTP client on the release path was built with `ureq::Agent::new_with_defaults()`. ureq 3's `Timeouts::default()` is `None` for every field — including connect — so a blackholed or half-open peer blocked the process on the OS TCP timeout, with `.git/ferrflow.lock` held for the duration and no error for `retry_transient` to classify.

Adds `src/http.rs` with one constructor for release-path agents (10s connect, 30s response, 120s global), and routes the three call sites through it:

- `forge::build_forge` — the agent shared by every forge call of a release
- `publishers::webhook`
- `bot_token::issue`, which used the bare `ureq::get` / `ureq::post` helpers and so inherited the same defaults

The global budget is overridable via `FERRFLOW_HTTP_TIMEOUT` (seconds) for self-hosted forges on slow links. `0` and non-numeric values fall back to the default rather than silently disabling the budget.

The self-hosted-instance probe in `forge::probe_host` already set `timeout_global` and is unchanged — its 2s budget is deliberately tighter than the release path's.

## Tests

- `stalled_peer_fails_within_the_global_budget` binds a listener that accepts and never responds, then asserts the call aborts near its budget instead of hanging. This is the regression itself, and it fails against the old `new_with_defaults()` agent.
- `agent_config_has_connect_response_and_global_timeouts` pins the three timeouts as actually set, so a future refactor back to a default agent breaks a test rather than shipping.
- `parse_global_timeout` covers the env override, including the zero and garbage cases.

1896 tests pass, clippy clean, `ferrflow-wasm` unaffected (the module is cli-gated).