### PR TITLE
fix(publish): point npm at the scoped .npmrc so private-registry publishes authenticate

### DIFF
--- a/src/publishers/npm.rs
+++ b/src/publishers/npm.rs
@@ -4,10 +4,10 @@
 //! - Validates the registry's `tokenEnv` is exported before spawning
 //!   npm — fails fast with a clearer message than npm's "401
 //!   Unauthorized" deep inside the publish flow.
-//! - Writes a transient `.npmrc` line into the package directory that
-//!   maps `<registry-host>` to the token, so existing user `.npmrc`
-//!   files (project + global) are not modified. Removed on exit even
-//!   on failure.
+//! - Writes a transient `.npmrc` into a temp dir and points npm at it
+//!   via `NPM_CONFIG_USERCONFIG`, so existing user `.npmrc` files
+//!   (project + global) are neither read for auth nor modified.
+//!   Removed when the publish returns.
 //! - Idempotent: npm registries reject re-publishing a version with a
 //!   distinct error ("cannot publish over the previously published
 //!   versions") that we recognize and return as a successful skip.
@@ -58,31 +58,20 @@ pub fn run(
         return Ok(PublishOutcome::DryRun);
     }
 
-    // Drop a scoped `.npmrc` so the auth token is picked up without
-    // touching the user's `~/.npmrc`. RAII guard removes it on scope
-    // exit — including on the panic path — so we don't leave a token
-    // line on disk if anything blows up mid-publish.
-    let _npmrc_guard = match (resolved_registry, registry) {
-        (Some(r), Some(name)) if r.token_env.is_some() => {
-            Some(write_scoped_npmrc(ctx.package_path, r, name)?)
-        }
+    let npmrc = match (resolved_registry, registry) {
+        (Some(r), Some(name)) if r.token_env.is_some() => Some(write_scoped_npmrc(r, name)?),
         _ => None,
     };
 
-    let mut cmd = Command::new("npm");
-    cmd.current_dir(ctx.package_path).arg("publish");
-    if let Some(name) = registry
-        && let Some(url) = resolved_registry.and_then(|r| r.url.as_deref())
-    {
-        cmd.arg(format!("--registry={url}"));
-        let _ = name;
-    }
-    let resolved_tag = tag.unwrap_or("latest");
-    cmd.arg(format!("--tag={resolved_tag}"));
-    if let Some(a) = access {
-        cmd.arg(format!("--access={a}"));
-    }
-    cmd.args(extra_args);
+    let mut cmd = build_publish_command(
+        npmrc.as_ref(),
+        resolved_registry,
+        registry,
+        tag,
+        access,
+        extra_args,
+        ctx,
+    );
 
     let output = cmd.output().with_context(|| {
         format!(
@@ -117,26 +106,50 @@ pub fn run(
     .error_code(error_code::CONFIG_INVALID_PATH)
 }
 
-/// RAII handle that owns a temporary `.npmrc` file inside the package
-/// directory. Drop deletes it (best-effort — we don't surface the
-/// remove error if the publish already failed and the user is about
-/// to see a real error). Avoids leaving registry tokens on disk.
+#[allow(clippy::too_many_arguments)]
+fn build_publish_command(
+    npmrc: Option<&NpmrcGuard>,
+    resolved_registry: Option<&crate::config::RegistryConfig>,
+    registry: Option<&str>,
+    tag: Option<&str>,
+    access: Option<&str>,
+    extra_args: &[String],
+    ctx: &PublishContext<'_>,
+) -> Command {
+    let mut cmd = Command::new("npm");
+    cmd.current_dir(ctx.package_path).arg("publish");
+    if let Some(npmrc) = npmrc {
+        cmd.env("NPM_CONFIG_USERCONFIG", npmrc.path());
+    }
+    if registry.is_some()
+        && let Some(url) = resolved_registry.and_then(|r| r.url.as_deref())
+    {
+        cmd.arg(format!("--registry={url}"));
+    }
+    cmd.arg(format!("--tag={}", tag.unwrap_or("latest")));
+    if let Some(a) = access {
+        cmd.arg(format!("--access={a}"));
+    }
+    cmd.args(extra_args);
+    cmd
+}
+
+#[derive(Debug)]
 struct NpmrcGuard {
+    _dir: tempfile::TempDir,
     path: std::path::PathBuf,
 }
 
-impl Drop for NpmrcGuard {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.path);
+impl NpmrcGuard {
+    fn path(&self) -> &Path {
+        &self.path
     }
 }
 
 fn write_scoped_npmrc(
-    package_path: &Path,
     registry: &crate::config::RegistryConfig,
     registry_name: &str,
 ) -> Result<NpmrcGuard> {
-    let path = package_path.join(".npmrc.ferrflow");
     let url = registry.url.as_deref().ok_or_else(|| {
         anyhow!(
             "publisher npm:{registry_name}: registry has a tokenEnv but no url — \
@@ -149,9 +162,30 @@ fn write_scoped_npmrc(
         .expect("called only when token_env is Some");
     let token = std::env::var(env_name).expect("validated by caller");
     let host = url_host(url).unwrap_or("registry.npmjs.org");
+
+    let dir = tempfile::tempdir().context("create temp dir for the scoped npm config")?;
+    let path = dir.path().join(".npmrc");
     let line = format!("//{host}/:_authToken={token}\n");
-    std::fs::write(&path, line).with_context(|| format!("write {}", path.display()))?;
-    Ok(NpmrcGuard { path })
+    write_private(&path, &line).with_context(|| format!("write {}", path.display()))?;
+    Ok(NpmrcGuard { _dir: dir, path })
+}
+
+#[cfg(unix)]
+fn write_private(path: &Path, contents: &str) -> std::io::Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)?;
+    file.write_all(contents.as_bytes())
+}
+
+#[cfg(not(unix))]
+fn write_private(path: &Path, contents: &str) -> std::io::Result<()> {
+    std::fs::write(path, contents)
 }
 
 fn url_host(url: &str) -> Option<&str> {
@@ -280,6 +314,120 @@ mod tests {
         assert!(classify_already_published("Version already exists"));
         assert!(!classify_already_published("npm ERR! 401 Unauthorized"));
         assert!(!classify_already_published(""));
+    }
+
+    fn scoped_registry() -> RegistryConfig {
+        RegistryConfig {
+            url: Some("https://npm.pkg.github.com".into()),
+            token_env: Some("FERRFLOW_TEST_NPM_TOKEN".into()),
+        }
+    }
+
+    fn with_token<T>(f: impl FnOnce() -> T) -> T {
+        // SAFETY: a test-only var name used by these tests alone; the
+        // publisher reads it synchronously on this thread.
+        unsafe { std::env::set_var("FERRFLOW_TEST_NPM_TOKEN", "npm-secret-xyz") };
+        let out = f();
+        unsafe { std::env::remove_var("FERRFLOW_TEST_NPM_TOKEN") };
+        out
+    }
+
+    #[test]
+    fn publish_command_points_npm_at_the_scoped_npmrc() {
+        with_token(|| {
+            let registry = scoped_registry();
+            let guard = write_scoped_npmrc(&registry, "gh-packages").expect("write npmrc");
+            let registries = BTreeMap::new();
+            let cmd = build_publish_command(
+                Some(&guard),
+                Some(&registry),
+                Some("gh-packages"),
+                None,
+                None,
+                &[],
+                &ctx(&registries, false),
+            );
+
+            let userconfig = cmd
+                .get_envs()
+                .find(|(k, _)| *k == "NPM_CONFIG_USERCONFIG")
+                .and_then(|(_, v)| v)
+                .expect("NPM_CONFIG_USERCONFIG must be set, or npm ignores the token");
+            let path = std::path::Path::new(userconfig);
+
+            assert_eq!(
+                path.file_name().and_then(|n| n.to_str()),
+                Some(".npmrc"),
+                "npm only reads files named `.npmrc`"
+            );
+            let contents = std::fs::read_to_string(path).expect("npmrc readable");
+            assert_eq!(
+                contents.trim(),
+                "//npm.pkg.github.com/:_authToken=npm-secret-xyz"
+            );
+        });
+    }
+
+    #[test]
+    fn scoped_npmrc_lives_outside_the_package_directory() {
+        with_token(|| {
+            let guard = write_scoped_npmrc(&scoped_registry(), "gh-packages").expect("write");
+            let pkg_dir = std::path::Path::new(".").canonicalize().unwrap();
+            assert!(
+                !guard.path().starts_with(&pkg_dir),
+                "the token file must not sit in the package dir — a later docker \
+                 publisher would build it into an image layer: {}",
+                guard.path().display()
+            );
+        });
+    }
+
+    #[test]
+    fn scoped_npmrc_is_removed_when_the_guard_drops() {
+        with_token(|| {
+            let path = {
+                let guard = write_scoped_npmrc(&scoped_registry(), "gh-packages").expect("write");
+                guard.path().to_path_buf()
+            };
+            assert!(!path.exists(), "token file survived the guard");
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scoped_npmrc_is_not_world_readable() {
+        use std::os::unix::fs::PermissionsExt;
+        with_token(|| {
+            let guard = write_scoped_npmrc(&scoped_registry(), "gh-packages").expect("write");
+            let mode = std::fs::metadata(guard.path())
+                .unwrap()
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o077, 0, "registry token readable by group/other");
+        });
+    }
+
+    #[test]
+    fn scoped_npmrc_requires_a_registry_url() {
+        with_token(|| {
+            let registry = RegistryConfig {
+                url: None,
+                token_env: Some("FERRFLOW_TEST_NPM_TOKEN".into()),
+            };
+            let err = write_scoped_npmrc(&registry, "gh-packages").expect_err("must error");
+            assert!(format!("{err:?}").contains("no url"));
+        });
+    }
+
+    #[test]
+    fn public_npm_publish_sets_no_userconfig() {
+        let registries = BTreeMap::new();
+        let cmd =
+            build_publish_command(None, None, None, None, None, &[], &ctx(&registries, false));
+        assert!(
+            cmd.get_envs().all(|(k, _)| k != "NPM_CONFIG_USERCONFIG"),
+            "unscoped publish must not shadow the user's own npm config"
+        );
     }
 
     #[test]

--- a/src/publishers/npm.rs
+++ b/src/publishers/npm.rs
@@ -323,9 +323,12 @@ mod tests {
         }
     }
 
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     fn with_token<T>(f: impl FnOnce() -> T) -> T {
-        // SAFETY: a test-only var name used by these tests alone; the
-        // publisher reads it synchronously on this thread.
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY: a test-only var name used by these tests alone, and
+        // ENV_LOCK serialises every reader and writer of it.
         unsafe { std::env::set_var("FERRFLOW_TEST_NPM_TOKEN", "npm-secret-xyz") };
         let out = f();
         unsafe { std::env::remove_var("FERRFLOW_TEST_NPM_TOKEN") };


### PR DESCRIPTION
Closes #790.

`write_scoped_npmrc` wrote the registry token to `.npmrc.ferrflow` in the package directory. npm only reads files literally named `.npmrc`, and nothing pointed npm at the file — no `--userconfig`, no `NPM_CONFIG_USERCONFIG`. So for any package with a `tokenEnv` registry the token was written, ignored, and `npm publish` went out unauthenticated: 401 from the registry, after tags had already been pushed.

Changes:

- The scoped config is now written as `.npmrc` inside a `tempfile::tempdir()`, and `NPM_CONFIG_USERCONFIG` points npm at it. Moving it out of the package directory also removes two side effects of the old location: collision with an `.npmrc` the package already ships, and the token landing in a docker build context if a later publisher builds from that directory.
- The token file is created `0600` on Unix via `OpenOptions::mode`, rather than inheriting the 0644 default.
- Command construction is extracted into `build_publish_command`, which is the seam the old code lacked — there was no way to assert what npm was actually invoked with, which is why this went unnoticed.

The module doc comment described the intended behaviour correctly; only the implementation was wrong. It has been updated to match what now happens, including dropping the claim that cleanup survives a panic — it does not, since the release profile sets `panic = "abort"` (#800).

## Tests

- `publish_command_points_npm_at_the_scoped_npmrc` asserts `NPM_CONFIG_USERCONFIG` is set, that it names a file called `.npmrc`, and that the file contains the expected `//host/:_authToken=` line. This is the regression, and it fails against the old code on the first assertion.
- `public_npm_publish_sets_no_userconfig` pins the other direction — an unscoped publish must not shadow the user's own npm config.
- `scoped_npmrc_lives_outside_the_package_directory` guards the docker-build-context case.
- `scoped_npmrc_is_removed_when_the_guard_drops` and `scoped_npmrc_is_not_world_readable` (Unix) cover cleanup and permissions.

1898 tests pass, clippy clean.