### PR TITLE
fix(action): pass caller inputs through env instead of interpolating them into run scripts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,8 +45,15 @@ runs:
   steps:
     - name: Install FerrFlow
       shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
       run: |
         set -euo pipefail
+
+        if [ "$INPUT_VERSION" != "latest" ] && ! printf '%s' "$INPUT_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-+][A-Za-z0-9._-]+)*$'; then
+          echo "Invalid version: '$INPUT_VERSION' (expected 'latest' or X.Y.Z)" >&2
+          exit 1
+        fi
 
         OS=$(uname -s | tr '[:upper:]' '[:lower:]')
         ARCH=$(uname -m)
@@ -69,10 +76,10 @@ runs:
 
         ARCHIVE="ferrflow-${PLATFORM}-${ARCH_NAME}.${EXT}"
 
-        if [ "${{ inputs.version }}" = "latest" ]; then
+        if [ "$INPUT_VERSION" = "latest" ]; then
           URL="https://github.com/FerrLabs/FerrFlow/releases/latest/download/${ARCHIVE}"
         else
-          URL="https://github.com/FerrLabs/FerrFlow/releases/download/v${{ inputs.version }}/${ARCHIVE}"
+          URL="https://github.com/FerrLabs/FerrFlow/releases/download/v${INPUT_VERSION}/${ARCHIVE}"
         fi
 
         INSTALL_DIR="${RUNNER_TEMP:-$HOME/.local/bin}/ferrflow-bin"
@@ -119,9 +126,48 @@ runs:
         FERRFLOW_BOT: ${{ inputs.bot }}
         FERRFLOW_BOT_ENDPOINT: ${{ inputs.bot_endpoint }}
         FERRFLOW_BOT_AUDIENCE: ${{ inputs.bot_audience }}
-      run: ferrflow ${{ inputs.dry_run == 'true' && '--dry-run' || '' }} release ${{ inputs.force_version != '' && format('--force-version {0}', inputs.force_version) || '' }}
+        INPUT_DRY_RUN: ${{ inputs.dry_run }}
+        INPUT_FORCE_VERSION: ${{ inputs.force_version }}
+      run: |
+        set -euo pipefail
+
+        args=()
+        [ "$INPUT_DRY_RUN" = "true" ] && args+=(--dry-run)
+        args+=(release)
+
+        if [ -n "$INPUT_FORCE_VERSION" ]; then
+          if ! printf '%s' "$INPUT_FORCE_VERSION" | grep -Eq '^([A-Za-z0-9._@/-]+@)?[0-9]+\.[0-9]+\.[0-9]+([-+][A-Za-z0-9._-]+)*$'; then
+            echo "Invalid force_version: '$INPUT_FORCE_VERSION' (expected VERSION or NAME@VERSION)" >&2
+            exit 1
+          fi
+          args+=(--force-version "$INPUT_FORCE_VERSION")
+        fi
+
+        ferrflow "${args[@]}"
 
     - name: Run FerrFlow publishers
       if: inputs.mode == 'publish'
       shell: bash
-      run: ferrflow ${{ inputs.dry_run == 'true' && '--dry-run' || '' }} publish ${{ inputs.package }}
+      env:
+        FERRFLOW_BOT: ${{ inputs.bot }}
+        FERRFLOW_BOT_ENDPOINT: ${{ inputs.bot_endpoint }}
+        FERRFLOW_BOT_AUDIENCE: ${{ inputs.bot_audience }}
+        INPUT_DRY_RUN: ${{ inputs.dry_run }}
+        INPUT_PACKAGE: ${{ inputs.package }}
+      run: |
+        set -euo pipefail
+
+        args=()
+        [ "$INPUT_DRY_RUN" = "true" ] && args+=(--dry-run)
+        args+=(publish)
+
+        read -ra packages <<< "$INPUT_PACKAGE"
+        for pkg in ${packages[@]+"${packages[@]}"}; do
+          if ! printf '%s' "$pkg" | grep -Eq '^[A-Za-z0-9._@/-]+$'; then
+            echo "Invalid package name: '$pkg'" >&2
+            exit 1
+          fi
+          args+=("$pkg")
+        done
+
+        ferrflow "${args[@]}"


### PR DESCRIPTION
Closes #788. Also closes #806.

`${{ }}` expansion happens before the shell parses the script, so an interpolated input is spliced in as raw shell source. Three inputs reached `run:` bodies that way:

- `inputs.force_version` and `inputs.package` in the release/publish steps (#788)
- `inputs.version` in the install step — same flaw, same file, not in the original report but not something to leave behind

All three now arrive as `env:` vars and are quoted at use. Every `${{ }}` in the file is confined to an `env:` block; none reach a script body.

Arguments are built into a bash array and passed as `ferrflow "${args[@]}"`, so a value containing spaces or shell metacharacters is one inert argv element rather than parsed source. On top of that each input is validated before use:

- `version` — `latest` or `X.Y.Z` with an optional prerelease/build suffix
- `force_version` — `VERSION` or `NAME@VERSION`
- `package` — split with `read -ra` (deliberate, rather than relying on accidental word-splitting), each element checked against `[A-Za-z0-9._@/-]+`

Rejection is a hard failure with a clear message, not a silent skip.

**#806 rides along**: the publish step is fully rewritten here, and it was missing the `FERRFLOW_BOT*` env block that the preview and release steps have — so `bot: true` with `mode: publish` silently did nothing. Adding it is three lines inside a step this PR already replaces; splitting it into its own PR would mean touching the same block twice.

## Verification

No unit-test harness exists for the composite action, so I extracted each `run:` body and exercised it against a `ferrflow` stub that prints its argv:

```
release  benign     INPUT_FORCE_VERSION="api@2.1.0"
                    → ARGV: [--dry-run] [release] [--force-version] [api@2.1.0]
release  injection  INPUT_FORCE_VERSION="1.0.0; touch $SD/PWNED"
                    → Invalid force_version: ... / exit=1
publish  benign     INPUT_PACKAGE="api web"
                    → ARGV: [publish] [api] [web]
publish  injection  INPUT_PACKAGE="api; touch $SD/PWNED"
                    → Invalid package name: 'api;' / exit=1
publish  empty      INPUT_PACKAGE=""
                    → ARGV: [--dry-run] [publish]
```

The marker file was never created. Also checked: every `run:` block passes `bash -n`, the file parses as YAML, `set -euo pipefail` does not trip on the `[ ... ] && args+=(...)` form or on `read -ra` against an empty string (both verified, both are easy to get wrong here), and the valid semver forms `1.2.3`, `api@1.2.3`, `@scope/pkg@1.2.3`, `1.2.3-beta.1`, `1.2.3-rc.1+build.5` all pass validation.

Worth adding a workflow-level regression test for this so it is enforced rather than hand-checked — happy to do it as a follow-up if you want it in CI.