### PR TITLE
fix(action): verify the downloaded release archive against SHA256SUMS before extracting

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -168,6 +168,25 @@ jobs:
           /tmp/ferrflow completions zsh  > completions/_ferrflow
           /tmp/ferrflow completions fish > completions/ferrflow.fish
           tar -czf artifacts/ferrflow-completions.tar.gz -C completions .
+      - name: Generate SHA256SUMS
+        # The action verifies the archive it downloads against this file
+        # before extracting (#789). Written before provenance + cosign so
+        # the checksum manifest is itself attested and signed.
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          cd artifacts
+          : > SHA256SUMS
+          for f in ferrflow-*.tar.gz ferrflow-*.zip; do
+            [ -f "$f" ] || continue
+            sha256sum "$f" >> SHA256SUMS
+          done
+          if [ ! -s SHA256SUMS ]; then
+            echo "ERROR: no release archives found to checksum" >&2
+            exit 1
+          fi
+          cat SHA256SUMS
+
       - name: Attest build provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
         with:
@@ -214,7 +233,7 @@ jobs:
             echo "cosign signing failed for ${artifact} after 3 attempts" >&2
             return 1
           }
-          for artifact in artifacts/ferrflow-*.tar.gz artifacts/ferrflow-*.zip; do
+          for artifact in artifacts/ferrflow-*.tar.gz artifacts/ferrflow-*.zip artifacts/SHA256SUMS; do
             [ -f "$artifact" ] || continue
             echo "Signing $artifact"
             sign_with_retry "$artifact"

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,7 @@ runs:
       shell: bash
       env:
         INPUT_VERSION: ${{ inputs.version }}
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
 
@@ -77,26 +78,54 @@ runs:
         ARCHIVE="ferrflow-${PLATFORM}-${ARCH_NAME}.${EXT}"
 
         if [ "$INPUT_VERSION" = "latest" ]; then
-          URL="https://github.com/FerrLabs/FerrFlow/releases/latest/download/${ARCHIVE}"
+          BASE="https://github.com/FerrLabs/FerrFlow/releases/latest/download"
         else
-          URL="https://github.com/FerrLabs/FerrFlow/releases/download/v${INPUT_VERSION}/${ARCHIVE}"
+          BASE="https://github.com/FerrLabs/FerrFlow/releases/download/v${INPUT_VERSION}"
         fi
 
         INSTALL_DIR="${RUNNER_TEMP:-$HOME/.local/bin}/ferrflow-bin"
+        DOWNLOAD_DIR="$(mktemp -d)"
         mkdir -p "$INSTALL_DIR"
 
+        curl --fail --location --silent --show-error \
+          --output "${DOWNLOAD_DIR}/${ARCHIVE}" "${BASE}/${ARCHIVE}"
+
+        # Verify the digest before anything is extracted or executed. A
+        # release without SHA256SUMS predates #789; warn rather than break
+        # every consumer pinned to an older version.
+        if curl --fail --location --silent --show-error \
+             --output "${DOWNLOAD_DIR}/SHA256SUMS" "${BASE}/SHA256SUMS"; then
+          grep " \*\?${ARCHIVE}\$" "${DOWNLOAD_DIR}/SHA256SUMS" > "${DOWNLOAD_DIR}/expected.sums" || true
+          if [ ! -s "${DOWNLOAD_DIR}/expected.sums" ]; then
+            echo "SHA256SUMS has no entry for ${ARCHIVE} — refusing to install" >&2
+            exit 1
+          fi
+          ( cd "$DOWNLOAD_DIR" && sha256sum -c expected.sums )
+          echo "Verified ${ARCHIVE} against SHA256SUMS"
+        else
+          echo "::warning::No SHA256SUMS published for this release; skipping checksum verification. Pin a version >= 5.52.0 to get verified installs."
+        fi
+
+        # Provenance is bound to a specific release, so it can only be
+        # checked on a pinned version. gh is preinstalled on GitHub-hosted
+        # runners; skip rather than fail where it isn't available.
+        if [ "$INPUT_VERSION" != "latest" ] && command -v gh >/dev/null 2>&1 && [ -n "${GITHUB_TOKEN:-}" ]; then
+          if gh attestation verify "${DOWNLOAD_DIR}/${ARCHIVE}" --repo FerrLabs/FerrFlow >/dev/null 2>&1; then
+            echo "Verified build provenance for ${ARCHIVE}"
+          else
+            echo "::warning::Could not verify build provenance for ${ARCHIVE} (older release, or gh attestation unavailable)"
+          fi
+        fi
+
         if [ "$PLATFORM" = "windows" ]; then
-          # Can't pipe into unzip (needs a seekable file), so download first.
-          TMP_ZIP="${RUNNER_TEMP:-/tmp}/ferrflow.zip"
-          curl --fail --location --silent --show-error --output "$TMP_ZIP" "$URL"
-          unzip -q -o "$TMP_ZIP" -d "$INSTALL_DIR"
-          rm -f "$TMP_ZIP"
+          unzip -q -o "${DOWNLOAD_DIR}/${ARCHIVE}" -d "$INSTALL_DIR"
           # No chmod needed on Windows; the .exe is already executable.
         else
-          curl --fail --location --silent --show-error "$URL" | tar -xz -C "$INSTALL_DIR"
+          tar -xzf "${DOWNLOAD_DIR}/${ARCHIVE}" -C "$INSTALL_DIR"
           chmod +x "$INSTALL_DIR/ferrflow"
         fi
 
+        rm -rf "$DOWNLOAD_DIR"
         echo "$INSTALL_DIR" >> "$GITHUB_PATH"
 
     # Git identity (`user.name` / `user.email`) is now set by the


### PR DESCRIPTION
Closes #789.

Stacked on #810 (shares the install step) — base is `fix/action-input-injection`, retarget to `main` once that merges.

The action piped a release asset straight into `tar` with no digest or signature check, and the binary then runs with a repo-write token in every consumer repo. The release pipeline already produced cosign bundles and a provenance attestation, but nothing verified them and no checksum manifest was published at all.

**Producer** (`publish.yml`): a `SHA256SUMS` covering every platform archive is generated before the attestation and cosign steps, so it is itself attested and signed, and it ships as a release asset alongside `SHA256SUMS.bundle`.

**Consumer** (`action.yml`): the archive is downloaded to a temp dir, verified, and only then extracted. Provenance is additionally checked via `gh attestation verify` when the version is pinned — attestation binds to a specific release, so it cannot be checked against the mutable `latest` URL.

Backward compatibility: releases cut before this change have no `SHA256SUMS`, so a 404 on it warns and continues rather than breaking every consumer pinned to an older version. A missing *entry* in a `SHA256SUMS` that does exist is a hard failure — otherwise stripping one line would be a trivial bypass.

## Verification

Ran the extracted install step against a local HTTP server serving a fake release:

```
happy path                    → verified against SHA256SUMS, exit 0, binary installed
tampered archive              → sha256sum FAILED, exit 1, nothing installed
SHA256SUMS 404 (old release)  → ::warning::, exit 0, installed  (backward compat)
SHA256SUMS without our entry  → "no entry for ... refusing to install", exit 1
```

The third and fourth cases are the ones worth stating plainly: an old release still installs, a stripped-line manifest does not.

One thing the first pass got wrong and this fixes: the no-entry case originally exited 1 with no output, because `set -e` killed the `grep` subshell before the diagnostic could print. It failed closed, but silently. `grep ... || true` plus the emptiness check restores the message.

Also checked: both files parse as YAML, the install step passes `bash -n`, and the `grep " \*\?${ARCHIVE}$"` selector picks `ferrflow-linux-x64.tar.gz` without also matching `ferrflow-linux-arm64.tar.gz`.

Note `5.52.0` in the warning text is the assumed first release carrying `SHA256SUMS` — worth correcting if this lands in a different version.