### PR TITLE
feat(bot)!: vise l'endpoint de jeton à la racine

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,9 +32,9 @@ inputs:
     required: false
     default: 'false'
   bot_endpoint:
-    description: 'Override the hosted bot token endpoint. Defaults to https://api.ferrflow.com/v1/ferrflow/token.'
+    description: 'Override the hosted bot token endpoint. Defaults to https://api.ferrflow.com/ferrflow/token.'
     required: false
-    default: 'https://api.ferrflow.com/v1/ferrflow/token'
+    default: 'https://api.ferrflow.com/ferrflow/token'
   bot_audience:
     description: 'OIDC audience requested from the GitHub Actions runner. Must match the server-side expected audience.'
     required: false

--- a/src/bot_token.rs
+++ b/src/bot_token.rs
@@ -1,6 +1,10 @@
 use anyhow::{Context, Result, bail};
 
-const DEFAULT_ENDPOINT: &str = "https://api.ferrflow.com/v1/ferrflow/token";
+// L'API sert ses routes à la racine : le contrat se négocie par l'en-tête
+// `x-ferrflow-api-version`, plus par le chemin (FerrFlow-Cloud#784). Les
+// montages `/v1` y restent servis le temps que les binaires déjà distribués
+// sortent de circulation, mais les nouveaux visent directement la racine.
+const DEFAULT_ENDPOINT: &str = "https://api.ferrflow.com/ferrflow/token";
 const DEFAULT_AUDIENCE: &str = "ferrflow.ferrlabs.com";
 
 pub fn bot_mode_enabled() -> bool {
@@ -304,7 +308,7 @@ mod tests {
             ],
             || {
                 let ex = BotTokenExchange::default();
-                assert_eq!(ex.endpoint, "https://api.ferrflow.com/v1/ferrflow/token");
+                assert_eq!(ex.endpoint, "https://api.ferrflow.com/ferrflow/token");
                 assert_eq!(ex.audience, "ferrflow.ferrlabs.com");
             },
         );


### PR DESCRIPTION
L'API FerrFlow sert désormais ses routes à la racine — le contrat se négocie par l'en-tête `x-ferrflow-api-version` (FerrFlow-Cloud#784). La CLI visait encore `/v1/ferrflow/token`.

| | avant | après |
|---|---|---|
| `bot_token.rs::DEFAULT_ENDPOINT` | `…/v1/ferrflow/token` | `…/ferrflow/token` |
| `action.yml` (défaut + description) | idem | idem |

## Ordre — à ne pas inverser

**Ne merger qu'après le déploiement de FerrFlow-Cloud#784.** Tant que `api:5.3.1` tourne, l'API ne sert *que* `/v1/…` : un binaire construit depuis cette branche appellerait un chemin inexistant et chaque `FERRFLOW_BOT` échouerait.

Une fois #784 déployée, les deux formes répondent — elle conserve les montages `/v1` en compatibilité jusqu'au 2027-02-08 — donc la bascule est sans rupture pour les binaires déjà distribués comme pour les nouveaux.

## Vérifications

`cargo clippy --all-targets -D warnings` sans avertissement, tests `bot_token` au vert (11).