### PR TITLE
fix(ci): retire la notification cross-repo après release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -646,17 +646,3 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Notify FerrFlow-Cloud of new release
-        if: steps.append-bench.outputs.tag != '' && inputs.dry_run != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.FERRFLOW_DISPATCH_TOKEN }}
-          TAG: ${{ steps.append-bench.outputs.tag }}
-        run: |
-          if [[ -z "${GH_TOKEN:-}" ]]; then
-            echo "::warning::FERRFLOW_DISPATCH_TOKEN not set — skipping cross-repo dispatch. Site sync will fire on its 6h schedule instead."
-            exit 0
-          fi
-          gh api -X POST repos/FerrLabs/FerrFlow-Cloud/dispatches \
-            -f event_type="ferrflow-released" \
-            -F client_payload[tag]="$TAG"
-          echo "Dispatched ferrflow-released ($TAG) to FerrLabs/FerrFlow-Cloud"


### PR DESCRIPTION
La release **v6.1.0 a réussi** — taguée, publiée, binaires compilés. Le job était pourtant rouge, sur une étape qui s'exécute *après* :

```
gh: Bad credentials (HTTP 401)
```

`FERRFLOW_DISPATCH_TOKEN` est un PAT de dépôt créé le **2026-06-26**, jamais renouvelé. Expiré ou révoqué.

## Suppression plutôt que réparation

J'avais d'abord rendu l'étape non bloquante. C'était traiter le symptôme : le raccourci restait, avec son jeton à faire tourner indéfiniment, pour gagner au mieux quelques heures sur une synchro que FerrFlow-Cloud fait de toute façon toutes les 6 h.

L'étape part donc entièrement, et avec elle la dépendance à un PAT inter-dépôts — c'est-à-dire un point de panne qui échouait en silence jusqu'à ce qu'il fasse rougir une release valide.

## Ce qui remplace

Côté FerrLabs/FerrFlow-Cloud#789 :

- `sync-ferrflow.yml` garde son cycle de 6 h et son déclenchement manuel ;
- `rebuild-on-changelog.yml` gagne un `workflow_dispatch` — il n'avait que des dispatches externes et n'était donc pas relançable à la main ;
- le type `ferrflow-released` est retiré de ses abonnés, puisque plus rien ne l'émet.

Ces deux PR vont ensemble : merger celle-ci seule laisserait un déclencheur orphelin en face.

## Vérifié

Le YAML parse et les **16 jobs sont intacts** — comparé avant/après, la coupure n'a emporté que les 14 lignes de l'étape.

`FERRFLOW_DISPATCH_TOKEN` devient inutilisé dans ce dépôt : il peut être supprimé des secrets, plutôt que renouvelé.