### PR TITLE
feat(release): add workspace.releaseCommitBody to embed the changelog in release commits

### DIFF
--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -82,6 +82,16 @@
           ],
           "default": "grouped"
         },
+        "releaseCommitBody": {
+          "type": "string",
+          "description": "What to put in the body of the release commit message, below the subject line. 'none' keeps the single-line subject. 'summary' lists one line per released package with its commit count. 'full' embeds the changelog section written for each package.",
+          "enum": [
+            "none",
+            "summary",
+            "full"
+          ],
+          "default": "none"
+        },
         "autoMergeReleases": {
           "type": "boolean",
           "description": "Automatically merge release PRs when releaseCommitMode is 'pr'.",

--- a/src/config/format.rs
+++ b/src/config/format.rs
@@ -47,6 +47,7 @@ const CAMEL_CASE_KEYS: &[&str] = &[
     "recover_missed_releases",
     "release_commit_mode",
     "release_commit_scope",
+    "release_commit_body",
     "auto_merge_releases",
     "skip_ci",
     "commit_skip_markers",

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -32,8 +32,8 @@ pub use package::{
 #[allow(unused_imports)]
 pub use types::{
     BranchChannelConfig, ChannelValue, DockerSign, ForgeKind, HooksConfig, OnFailure,
-    OrphanedTagStrategy, PrereleaseIdentifier, PublisherConfig, RegistryConfig, ReleaseCommitMode,
-    ReleaseCommitScope,
+    OrphanedTagStrategy, PrereleaseIdentifier, PublisherConfig, RegistryConfig, ReleaseCommitBody,
+    ReleaseCommitMode, ReleaseCommitScope,
 };
 #[allow(unused_imports)]
 pub use workspace::{

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -109,6 +109,15 @@ pub enum ReleaseCommitScope {
     PerPackage,
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum ReleaseCommitBody {
+    #[default]
+    None,
+    Summary,
+    Full,
+}
+
 /// Declarative registry-credential map shared across every publisher
 /// kind. Lets users say "the Kellnr registry's token is in
 /// CARGO_REGISTRIES_KELLNR_TOKEN" once at the workspace level instead

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use super::package::{FloatingTagLevel, VersioningStrategy};
 use super::types::{
     BranchChannelConfig, ForgeKind, HooksConfig, OrphanedTagStrategy, RegistryConfig,
-    ReleaseCommitMode, ReleaseCommitScope,
+    ReleaseCommitBody, ReleaseCommitMode, ReleaseCommitScope,
 };
 use std::collections::BTreeMap;
 
@@ -27,6 +27,8 @@ pub struct WorkspaceConfig {
     pub release_commit_mode: ReleaseCommitMode,
     #[serde(default, alias = "releaseCommitScope")]
     pub release_commit_scope: ReleaseCommitScope,
+    #[serde(default, alias = "releaseCommitBody")]
+    pub release_commit_body: ReleaseCommitBody,
     #[serde(default = "default_auto_merge", alias = "autoMergeReleases")]
     pub auto_merge_releases: bool,
     #[serde(default, alias = "skipCi")]

--- a/src/monorepo/run/commit_body.rs
+++ b/src/monorepo/run/commit_body.rs
@@ -1,0 +1,174 @@
+use crate::config::ReleaseCommitBody;
+
+use super::summary::TagToCreate;
+
+pub(super) fn build_commit_message(
+    subject: &str,
+    tags: &[TagToCreate],
+    mode: ReleaseCommitBody,
+) -> String {
+    match render_body(tags, mode) {
+        Some(body) => format!("{subject}\n\n{body}"),
+        None => subject.to_string(),
+    }
+}
+
+fn render_body(tags: &[TagToCreate], mode: ReleaseCommitBody) -> Option<String> {
+    match mode {
+        ReleaseCommitBody::None => None,
+        ReleaseCommitBody::Summary => render_summary(tags),
+        ReleaseCommitBody::Full => render_full(tags),
+    }
+}
+
+fn render_summary(tags: &[TagToCreate]) -> Option<String> {
+    let lines: Vec<String> = tags
+        .iter()
+        .map(|(_, _, _, name, version, commits, _)| {
+            let plural = if *commits == 1 { "commit" } else { "commits" };
+            format!("- {name} {version} ({commits} {plural})")
+        })
+        .collect();
+    (!lines.is_empty()).then(|| lines.join("\n"))
+}
+
+fn render_full(tags: &[TagToCreate]) -> Option<String> {
+    let multi = tags.len() > 1;
+    let sections: Vec<String> = tags
+        .iter()
+        .filter_map(|(_, _, body, name, version, _, _)| {
+            let trimmed = body.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+            Some(if multi {
+                format!("## {name} {version}\n\n{trimmed}")
+            } else {
+                trimmed.to_string()
+            })
+        })
+        .collect();
+    (!sections.is_empty()).then(|| sections.join("\n\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tag(name: &str, version: &str, body: &str, commits: i32) -> TagToCreate {
+        (
+            format!("{name}@v{version}"),
+            format!("Release {name}@v{version}"),
+            body.to_string(),
+            name.to_string(),
+            version.to_string(),
+            commits,
+            false,
+        )
+    }
+
+    const SUBJECT: &str = "chore(release): api v1.2.0";
+
+    #[test]
+    fn none_is_byte_identical_to_the_bare_subject() {
+        let tags = vec![tag("api", "1.2.0", "### Features\n\n- thing", 3)];
+        assert_eq!(
+            build_commit_message(SUBJECT, &tags, ReleaseCommitBody::None),
+            SUBJECT
+        );
+    }
+
+    #[test]
+    fn full_appends_the_changelog_after_a_blank_line() {
+        let tags = vec![tag("api", "1.2.0", "### Features\n\n- thing", 3)];
+        let msg = build_commit_message(SUBJECT, &tags, ReleaseCommitBody::Full);
+        assert_eq!(msg, format!("{SUBJECT}\n\n### Features\n\n- thing"));
+    }
+
+    #[test]
+    fn full_single_package_omits_the_package_header() {
+        let tags = vec![tag("api", "1.2.0", "- one", 1)];
+        let msg = build_commit_message(SUBJECT, &tags, ReleaseCommitBody::Full);
+        assert!(!msg.contains("## api"), "single package needs no header");
+    }
+
+    #[test]
+    fn full_multi_package_labels_each_section() {
+        let tags = vec![
+            tag("api", "1.2.0", "- api change", 1),
+            tag("web", "2.0.0", "- web change", 1),
+        ];
+        let msg = build_commit_message(SUBJECT, &tags, ReleaseCommitBody::Full);
+        assert!(msg.contains("## api 1.2.0"));
+        assert!(msg.contains("## web 2.0.0"));
+        assert!(msg.find("## api").unwrap() < msg.find("## web").unwrap());
+    }
+
+    #[test]
+    fn full_skips_packages_with_an_empty_changelog() {
+        let tags = vec![
+            tag("api", "1.2.0", "- real change", 1),
+            tag("web", "2.0.0", "   \n  ", 1),
+        ];
+        let msg = build_commit_message(SUBJECT, &tags, ReleaseCommitBody::Full);
+        assert!(msg.contains("api"));
+        assert!(!msg.contains("## web"));
+    }
+
+    #[test]
+    fn full_with_every_body_empty_falls_back_to_the_bare_subject() {
+        let tags = vec![tag("api", "1.2.0", "", 1), tag("web", "2.0.0", "  ", 1)];
+        assert_eq!(
+            build_commit_message(SUBJECT, &tags, ReleaseCommitBody::Full),
+            SUBJECT
+        );
+    }
+
+    #[test]
+    fn summary_is_one_bounded_line_per_package() {
+        let tags: Vec<TagToCreate> = (0..50)
+            .map(|i| {
+                tag(
+                    &format!("pkg{i}"),
+                    "1.0.0",
+                    "### Features\n\n- a\n- b\n- c",
+                    9,
+                )
+            })
+            .collect();
+        let msg = build_commit_message(SUBJECT, &tags, ReleaseCommitBody::Summary);
+        let body_lines = msg.lines().skip(2).count();
+        assert_eq!(body_lines, 50, "summary must not scale with changelog size");
+        assert!(msg.contains("- pkg0 1.0.0 (9 commits)"));
+    }
+
+    #[test]
+    fn summary_singularises_a_single_commit() {
+        let tags = vec![tag("api", "1.2.0", "- x", 1)];
+        let msg = build_commit_message(SUBJECT, &tags, ReleaseCommitBody::Summary);
+        assert!(msg.ends_with("- api 1.2.0 (1 commit)"), "got: {msg}");
+    }
+
+    #[test]
+    fn no_tags_yields_the_bare_subject_in_every_mode() {
+        for mode in [
+            ReleaseCommitBody::None,
+            ReleaseCommitBody::Summary,
+            ReleaseCommitBody::Full,
+        ] {
+            assert_eq!(build_commit_message(SUBJECT, &[], mode), SUBJECT);
+        }
+    }
+
+    #[test]
+    fn skip_ci_marker_stays_on_the_subject_line() {
+        let subject = "chore(release): api v1.2.0 [skip ci]";
+        let tags = vec![tag("api", "1.2.0", "- thing", 1)];
+        let msg = build_commit_message(subject, &tags, ReleaseCommitBody::Full);
+        assert_eq!(
+            msg.lines().next().unwrap(),
+            subject,
+            "CI providers only scan the subject line"
+        );
+    }
+}

--- a/src/monorepo/run/execute.rs
+++ b/src/monorepo/run/execute.rs
@@ -83,7 +83,11 @@ pub(super) fn execute_release(plan: &mut ReleasePlan<'_>) -> Result<()> {
     } else {
         ""
     };
-    let commit_msg = format!("chore(release): {}{skip_ci}", release_parts.join(", "));
+    let commit_msg = super::commit_body::build_commit_message(
+        &format!("chore(release): {}{skip_ci}", release_parts.join(", ")),
+        plan.tags_to_create,
+        plan.config.workspace.release_commit_body,
+    );
     let mut floating_tag_names: Vec<String> = Vec::new();
 
     if !plan.dry_run {
@@ -211,10 +215,15 @@ fn run_commit_or_pr(
     match mode {
         ReleaseCommitMode::Commit => {
             if scope == ReleaseCommitScope::PerPackage && plan.tags_to_create.len() > 1 {
-                for (_, _, _, pkg_name, ver, _, _) in plan.tags_to_create {
+                for tag in plan.tags_to_create.iter() {
+                    let (_, _, _, pkg_name, ver, _, _) = tag;
                     if let Some(pkg_files) = plan.files_per_package.get(pkg_name) {
                         let refs: Vec<&str> = pkg_files.iter().map(String::as_str).collect();
-                        let msg = format!("chore(release): {pkg_name} v{ver}{skip_ci}");
+                        let msg = super::commit_body::build_commit_message(
+                            &format!("chore(release): {pkg_name} v{ver}{skip_ci}"),
+                            std::slice::from_ref(tag),
+                            plan.config.workspace.release_commit_body,
+                        );
                         create_commit(plan.repo, &refs, &msg)?;
                     }
                 }
@@ -258,10 +267,15 @@ fn run_commit_or_pr(
                 let commit_list: Vec<(Vec<&str>, String)> = plan
                     .tags_to_create
                     .iter()
-                    .filter_map(|(_, _, _, pkg_name, ver, _, _)| {
+                    .filter_map(|tag| {
+                        let (_, _, _, pkg_name, ver, _, _) = tag;
                         plan.files_per_package.get(pkg_name).map(|pf| {
                             let refs: Vec<&str> = pf.iter().map(String::as_str).collect();
-                            let msg = format!("chore(release): {pkg_name} v{ver}{skip_ci}");
+                            let msg = super::commit_body::build_commit_message(
+                                &format!("chore(release): {pkg_name} v{ver}{skip_ci}"),
+                                std::slice::from_ref(tag),
+                                plan.config.workspace.release_commit_body,
+                            );
                             (refs, msg)
                         })
                     })

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -24,6 +24,7 @@ use super::util::{auto_stage_new_files, collect_dirty_files};
 
 mod cascade;
 pub(super) mod checkpoint;
+mod commit_body;
 mod drafts;
 mod execute;
 #[cfg(test)]


### PR DESCRIPTION
Closes #814.

The release commit message was a hard-coded single line (`execute.rs:86`), so `git show` on a release told you which versions were cut and nothing about what changed. The changelog body was already in scope — `plan.tags_to_create` carries it as the third tuple element — and was simply discarded.

New `workspace.releaseCommitBody`, **defaulting to `none`** so existing repos are byte-for-byte unaffected:

| value | body |
|---|---|
| `none` (default) | nothing — current behaviour |
| `summary` | one line per package: `- api 1.2.0 (9 commits)` |
| `full` | the changelog section written for each package |

Under `full`, a single-package release gets the changelog bare; a multi-package release gets a `## <pkg> <version>` header per section, so a grouped commit stays readable. Packages whose changelog is empty are skipped, and if every body is empty the message falls back to the bare subject rather than emitting a trailing blank line.

Applies to all three commit paths — the grouped commit and both `releaseCommitScope: per-package` sites. Under `per-package` each commit gets only its own package's body, via `slice::from_ref`, so bodies do not leak across commits.

## On the monorepo-size concern from the issue

`summary` exists precisely for it: `grouped` + 50 packages under `full` would produce a commit message of several hundred lines. `summary` is one line per package regardless of changelog size, which `summary_is_one_bounded_line_per_package` pins.

I did **not** implement the scope-aware variant floated in the issue (full under `per-package`, summary under `grouped`). Making the message format depend on an unrelated setting is the kind of surprise that is hard to debug later; an explicit opt-in is easier to reason about.

## Not done here

The issue also noted that the **annotated tag** does not carry the changelog either (`git tag -l --format='%(contents)' v5.51.0` → just `Release v5.51.0`). That is arguably the more valuable half, since `git show v6.0.0` is where people look. Left out to keep this reviewable — happy to do it as a follow-up if you want it.

## Convention note

The workspace `CLAUDE.md` mandates single-line commits with no body. A generated release commit is plausibly an exception, but it should be written down rather than implied — worth a line in `CLAUDE.md` if you enable this anywhere.

## Tests

10 new tests in `commit_body.rs`. The load-bearing ones:

- `none_is_byte_identical_to_the_bare_subject` — proves the default path is untouched
- `skip_ci_marker_stays_on_the_subject_line` — CI providers only scan the subject, so a body must not push `[skip ci]` out of it
- `summary_is_one_bounded_line_per_package` — 50 packages with multi-line changelogs still yield 50 body lines
- `full_with_every_body_empty_falls_back_to_the_bare_subject`

1916 tests pass, clippy clean. Schema updated; the ferrflow.com copy ships in a FerrFlow-Cloud PR alongside the docs, since the two files must stay byte-identical and cross-repo changes do not share a PR.