### PR TITLE
chore(release): emit the changelog in release commits

### DIFF
--- a/.ferrflow
+++ b/.ferrflow
@@ -1,6 +1,7 @@
 {
   "$schema": "https://ferrflow.com/schema/ferrflow.json",
   "workspace": {
+    "releaseCommitBody": "full",
     "tagTemplate": "v{version}",
     "floatingTags": ["major"],
     "updateLockfiles": true,


### PR DESCRIPTION
Sets `workspace.releaseCommitBody: "full"`, so the release commit carries the changelog for the versions it cuts instead of just naming them.

Adds the option and nothing else — every other key is untouched, verified by parsing before and after and diffing the `workspace` and `package` blocks.

Requires the CLI support added in [FerrFlow#822](https://github.com/FerrLabs/FerrFlow/pull/822). Until this repo runs a FerrFlow that has it, the key is silently ignored — FerrFlow does not reject unknown config keys — so this can merge in any order.

Part of an org-wide rollout across the 15 repos that carry a `.ferrflow`.