### PR TITLE
feat(commits)!: configurable commit formats via workspace.commitFormats

### DIFF
--- a/benches/ferrflow_benchmarks.rs
+++ b/benches/ferrflow_benchmarks.rs
@@ -33,7 +33,7 @@ fn bench_commit_parsing(c: &mut Criterion) {
         c.bench_function(&format!("commit_parsing/{size}"), |b| {
             b.iter(|| {
                 for msg in &messages {
-                    black_box(determine_bump(msg));
+                    black_box(determine_bump(msg, &Default::default()));
                 }
             });
         });
@@ -429,7 +429,10 @@ fn bench_full_check_flow(c: &mut Criterion) {
                 )
                 .unwrap();
                 for commit in &commits {
-                    black_box(determine_bump(&commit.message));
+                    black_box(determine_bump(
+                        &commit.message,
+                        &config.workspace.commit_formats,
+                    ));
                 }
                 black_box((&config, commits.len()));
             });

--- a/ferrflow-wasm/src/lib.rs
+++ b/ferrflow-wasm/src/lib.rs
@@ -6,8 +6,14 @@ use ferrflow::conventional_commits;
 use ferrflow::versioning;
 
 #[wasm_bindgen]
-pub fn determine_bump(message: &str) -> String {
-    conventional_commits::determine_bump(message).to_string()
+pub fn determine_bump(message: &str, formats_json: Option<String>) -> Result<String, JsError> {
+    let formats = match formats_json.as_deref().map(str::trim) {
+        Some(raw) if !raw.is_empty() => {
+            serde_json::from_str(raw).map_err(|e| JsError::new(&e.to_string()))?
+        }
+        _ => config::CommitFormats::default(),
+    };
+    Ok(conventional_commits::determine_bump(message, &formats).to_string())
 }
 
 #[wasm_bindgen]

--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -92,6 +92,39 @@
           ],
           "default": "none"
         },
+        "commitFormats": {
+          "type": "object",
+          "description": "Which commit subjects map to which bump level. Resolution is major > minor > patch, first match wins. Breaking markers (feat!:, fix(api)!:, a BREAKING CHANGE: footer) are always detected structurally, whatever is configured here.",
+          "properties": {
+            "major": {
+              "description": "Extra patterns that force a major bump. Empty by default — structural breaking markers already cover the conventional forms.",
+              "oneOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+              ]
+            },
+            "minor": {
+              "description": "Patterns that select a minor bump. Defaults cover feat:, feat(scope):, feature:, and the Title-case and branch-style (Feat/) variants.",
+              "oneOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+              ]
+            },
+            "patch": {
+              "description": "Patterns that select a patch bump. Defaults cover fix:, perf:, refactor: and their Title-case and branch-style variants.",
+              "oneOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+              ]
+            },
+            "caseSensitive": {
+              "type": "boolean",
+              "description": "Match patterns exactly as written. Set false to lowercase both pattern and subject before matching. The 'all' catch-all keyword is recognised in any casing regardless.",
+              "default": true
+            }
+          },
+          "additionalProperties": false
+        },
         "autoMergeReleases": {
           "type": "boolean",
           "description": "Automatically merge release PRs when releaseCommitMode is 'pr'.",
@@ -402,60 +435,6 @@
               "type": "string"
             }
           }
-        },
-        "commitFormats": {
-          "type": "object",
-          "description": "Which commit subjects map to which bump level. Resolution is major > minor > patch, first match wins. Breaking markers (`feat!:`, `fix(api)!:`, a `BREAKING CHANGE:` footer) are always detected structurally, whatever is configured here.",
-          "properties": {
-            "major": {
-              "description": "Extra patterns that force a major bump. Empty by default — structural breaking markers already cover the conventional forms.",
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              ]
-            },
-            "minor": {
-              "description": "Patterns that select a minor bump. Defaults cover `feat:`, `feat(scope):`, `feature:`, and the Title-case and branch-style (`Feat/`) variants.",
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              ]
-            },
-            "patch": {
-              "description": "Patterns that select a patch bump. Defaults cover `fix:`, `perf:`, `refactor:` and their Title-case and branch-style variants.",
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              ]
-            },
-            "caseSensitive": {
-              "type": "boolean",
-              "description": "Match patterns exactly as written. Set false to lowercase both pattern and subject before matching.",
-              "default": true
-            }
-          },
-          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -540,26 +519,15 @@
             "description": "Packages this package depends on. When one is bumped, this package is bumped too — by default with the same bump type. Each entry is either a package name or an object with a `propagate` policy.",
             "items": {
               "oneOf": [
-                {
-                  "type": "string"
-                },
+                { "type": "string" },
                 {
                   "type": "object",
-                  "required": [
-                    "name"
-                  ],
+                  "required": ["name"],
                   "properties": {
-                    "name": {
-                      "type": "string"
-                    },
+                    "name": { "type": "string" },
                     "propagate": {
                       "type": "string",
-                      "enum": [
-                        "same",
-                        "major-on-major",
-                        "patch",
-                        "none"
-                      ],
+                      "enum": ["same", "major-on-major", "patch", "none"],
                       "default": "same",
                       "description": "How this dependency's bump becomes a bump here. same: identical bump (a breaking upstream makes this package breaking too). major-on-major: major stays major, anything lower becomes a patch. patch: always a patch. none: no cascade from this dependency."
                     }
@@ -670,26 +638,15 @@
             "description": "Snake_case form of `dependsOn` — both spellings are accepted. Packages this package depends on. When one is bumped, this package is bumped too — by default with the same bump type. Each entry is either a package name or an object with a `propagate` policy.",
             "items": {
               "oneOf": [
-                {
-                  "type": "string"
-                },
+                { "type": "string" },
                 {
                   "type": "object",
-                  "required": [
-                    "name"
-                  ],
+                  "required": ["name"],
                   "properties": {
-                    "name": {
-                      "type": "string"
-                    },
+                    "name": { "type": "string" },
                     "propagate": {
                       "type": "string",
-                      "enum": [
-                        "same",
-                        "major-on-major",
-                        "patch",
-                        "none"
-                      ],
+                      "enum": ["same", "major-on-major", "patch", "none"],
                       "default": "same",
                       "description": "How this dependency's bump becomes a bump here. same: identical bump (a breaking upstream makes this package breaking too). major-on-major: major stays major, anything lower becomes a patch. patch: always a patch. none: no cascade from this dependency."
                     }

--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -402,6 +402,60 @@
               "type": "string"
             }
           }
+        },
+        "commitFormats": {
+          "type": "object",
+          "description": "Which commit subjects map to which bump level. Resolution is major > minor > patch, first match wins. Breaking markers (`feat!:`, `fix(api)!:`, a `BREAKING CHANGE:` footer) are always detected structurally, whatever is configured here.",
+          "properties": {
+            "major": {
+              "description": "Extra patterns that force a major bump. Empty by default — structural breaking markers already cover the conventional forms.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "minor": {
+              "description": "Patterns that select a minor bump. Defaults cover `feat:`, `feat(scope):`, `feature:`, and the Title-case and branch-style (`Feat/`) variants.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "patch": {
+              "description": "Patterns that select a patch bump. Defaults cover `fix:`, `perf:`, `refactor:` and their Title-case and branch-style variants.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "caseSensitive": {
+              "type": "boolean",
+              "description": "Match patterns exactly as written. Set false to lowercase both pattern and subject before matching.",
+              "default": true
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -486,15 +540,26 @@
             "description": "Packages this package depends on. When one is bumped, this package is bumped too — by default with the same bump type. Each entry is either a package name or an object with a `propagate` policy.",
             "items": {
               "oneOf": [
-                { "type": "string" },
+                {
+                  "type": "string"
+                },
                 {
                   "type": "object",
-                  "required": ["name"],
+                  "required": [
+                    "name"
+                  ],
                   "properties": {
-                    "name": { "type": "string" },
+                    "name": {
+                      "type": "string"
+                    },
                     "propagate": {
                       "type": "string",
-                      "enum": ["same", "major-on-major", "patch", "none"],
+                      "enum": [
+                        "same",
+                        "major-on-major",
+                        "patch",
+                        "none"
+                      ],
                       "default": "same",
                       "description": "How this dependency's bump becomes a bump here. same: identical bump (a breaking upstream makes this package breaking too). major-on-major: major stays major, anything lower becomes a patch. patch: always a patch. none: no cascade from this dependency."
                     }
@@ -605,15 +670,26 @@
             "description": "Snake_case form of `dependsOn` — both spellings are accepted. Packages this package depends on. When one is bumped, this package is bumped too — by default with the same bump type. Each entry is either a package name or an object with a `propagate` policy.",
             "items": {
               "oneOf": [
-                { "type": "string" },
+                {
+                  "type": "string"
+                },
                 {
                   "type": "object",
-                  "required": ["name"],
+                  "required": [
+                    "name"
+                  ],
                   "properties": {
-                    "name": { "type": "string" },
+                    "name": {
+                      "type": "string"
+                    },
                     "propagate": {
                       "type": "string",
-                      "enum": ["same", "major-on-major", "patch", "none"],
+                      "enum": [
+                        "same",
+                        "major-on-major",
+                        "patch",
+                        "none"
+                      ],
                       "default": "same",
                       "description": "How this dependency's bump becomes a bump here. same: identical bump (a breaking upstream makes this package breaking too). major-on-major: major stays major, anything lower becomes a patch. patch: always a patch. none: no cascade from this dependency."
                     }

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -204,23 +204,37 @@ fn build_classic_section(new_version: &str, commits: &[GitLog], formats: &Commit
 const BREAKING_KEY: &str = "breaking";
 
 fn render_section_key(message: &str, formats: &CommitFormats) -> Option<&'static str> {
-    if is_breaking(message, formats) {
-        return Some(BREAKING_KEY);
+    let header = parse_header(message);
+
+    // `perf`, `security` and `docs` get their own section but have no
+    // `commitFormats` level of their own, so they are still resolved from the
+    // conventional prefix. `docs` in particular never bumps yet is offered as
+    // an opt-in section.
+    if let Some(h) = header.as_ref() {
+        match h.commit_type {
+            "perf" => return Some("perf"),
+            "security" => return Some("security"),
+            "docs" => return Some("docs"),
+            _ => {}
+        }
     }
-    let header = parse_header(message)?;
+
     let is_security_scope = header
-        .scope
-        .map(|s| s.eq_ignore_ascii_case("security"))
-        .unwrap_or(false);
-    match header.commit_type {
-        "feat" => Some("feat"),
-        "fix" if is_security_scope => Some("security"),
-        "fix" => Some("fix"),
-        "perf" => Some("perf"),
-        "security" => Some("security"),
-        "docs" => Some("docs"),
-        "refactor" => Some("refactor"),
-        _ => None,
+        .as_ref()
+        .and_then(|h| h.scope)
+        .is_some_and(|s| s.eq_ignore_ascii_case("security"));
+
+    // Everything else follows `classify_commit`, so the section a commit lands
+    // in and the bump it produces are decided by the same rules. Resolving it
+    // from `parse_header` instead dropped every subject the header regex
+    // cannot parse — `Feat:`, `Fix/…` — while still letting it bump (#247).
+    match classify_commit(message, formats) {
+        CommitCategory::Breaking => Some(BREAKING_KEY),
+        CommitCategory::Feature => Some("feat"),
+        CommitCategory::Fix if is_security_scope => Some("security"),
+        CommitCategory::Fix => Some("fix"),
+        CommitCategory::Refactor => Some("refactor"),
+        CommitCategory::Other => None,
     }
 }
 
@@ -778,6 +792,53 @@ mod tests {
         assert_eq!(
             build_section_with("1.0.0", &commits, &render),
             build_classic_section("1.0.0", &commits, &Default::default())
+        );
+    }
+
+    /// The rich path resolved its section from `parse_header`, whose regex
+    /// requires a lowercase `^[a-z]+` type. Every shape #247 added — `Feat:`,
+    /// `Fix/`, `feature:` — therefore bumped the version and was then dropped
+    /// from the changelog, which is exactly the disagreement #525 removed.
+    #[test]
+    fn rich_render_keeps_permissive_commits_the_bump_counted() {
+        let cfg = ChangelogConfig {
+            sections: Some(sections(&[
+                ("feat", enabled()),
+                ("fix", enabled()),
+                ("refactor", enabled()),
+            ])),
+            ..Default::default()
+        };
+        let commits = make_commits(&[
+            "Feat: title-case feature",
+            "feature: aliased feature",
+            "Fix/branch-style-fix",
+            "Refactor/branch-style-refactor",
+        ]);
+        let formats = CommitFormats::default();
+        let render = ChangelogRender {
+            formats: Some(&formats),
+            config: Some(&cfg),
+            ..Default::default()
+        };
+        let s = build_section_with("1.1.0", &commits, &render);
+
+        for expected in [
+            "title-case feature",
+            "aliased feature",
+            "branch-style-fix",
+            "branch-style-refactor",
+        ] {
+            assert!(
+                s.contains(expected),
+                "{expected:?} bumped the version but never reached the changelog:\n{s}"
+            );
+        }
+        assert!(s.contains("### Features"));
+        assert!(s.contains("### Bug Fixes"));
+        assert!(
+            s.contains("### Code Refactoring"),
+            "branch-style refactor should keep its own section:\n{s}"
         );
     }
 

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -204,12 +204,13 @@ fn build_classic_section(new_version: &str, commits: &[GitLog], formats: &Commit
 const BREAKING_KEY: &str = "breaking";
 
 fn render_section_key(message: &str, formats: &CommitFormats) -> Option<&'static str> {
+    let category = classify_commit(message, formats);
+    if category == CommitCategory::Breaking {
+        return Some(BREAKING_KEY);
+    }
+
     let header = parse_header(message);
 
-    // `perf`, `security` and `docs` get their own section but have no
-    // `commitFormats` level of their own, so they are still resolved from the
-    // conventional prefix. `docs` in particular never bumps yet is offered as
-    // an opt-in section.
     if let Some(h) = header.as_ref() {
         match h.commit_type {
             "perf" => return Some("perf"),
@@ -224,17 +225,12 @@ fn render_section_key(message: &str, formats: &CommitFormats) -> Option<&'static
         .and_then(|h| h.scope)
         .is_some_and(|s| s.eq_ignore_ascii_case("security"));
 
-    // Everything else follows `classify_commit`, so the section a commit lands
-    // in and the bump it produces are decided by the same rules. Resolving it
-    // from `parse_header` instead dropped every subject the header regex
-    // cannot parse — `Feat:`, `Fix/…` — while still letting it bump (#247).
-    match classify_commit(message, formats) {
-        CommitCategory::Breaking => Some(BREAKING_KEY),
+    match category {
         CommitCategory::Feature => Some("feat"),
         CommitCategory::Fix if is_security_scope => Some("security"),
         CommitCategory::Fix => Some("fix"),
         CommitCategory::Refactor => Some("refactor"),
-        CommitCategory::Other => None,
+        CommitCategory::Breaking | CommitCategory::Other => None,
     }
 }
 
@@ -673,8 +669,6 @@ mod tests {
 
     #[test]
     fn build_section_treats_feature_as_a_feature_but_not_a_bare_feat() {
-        // `feature:` is a documented default alias since #247. `feat add`
-        // has no colon and matches nothing, so it stays out.
         let commits = make_commits(&["feature: renamed type", "feat add no colon"]);
         let section = build_section("1.0.1", &commits);
         assert!(section.contains("### Features"));
@@ -795,10 +789,24 @@ mod tests {
         );
     }
 
-    /// The rich path resolved its section from `parse_header`, whose regex
-    /// requires a lowercase `^[a-z]+` type. Every shape #247 added — `Feat:`,
-    /// `Fix/`, `feature:` — therefore bumped the version and was then dropped
-    /// from the changelog, which is exactly the disagreement #525 removed.
+    #[test]
+    fn rich_render_files_breaking_perf_and_docs_under_breaking_changes() {
+        let formats = CommitFormats::default();
+        for subject in ["perf!: drop legacy API", "docs!: remove the v1 guide"] {
+            assert_eq!(
+                render_section_key(subject, &formats),
+                Some(BREAKING_KEY),
+                "{subject:?} bumps major and must render as breaking"
+            );
+        }
+        assert_eq!(render_section_key("perf: cache", &formats), Some("perf"));
+        assert_eq!(render_section_key("docs: typo", &formats), Some("docs"));
+        assert_eq!(
+            render_section_key("security: patch", &formats),
+            Some("security")
+        );
+    }
+
     #[test]
     fn rich_render_keeps_permissive_commits_the_bump_counted() {
         let cfg = ChangelogConfig {

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -1,5 +1,6 @@
-use crate::config::ChangelogConfig;
-#[cfg(feature = "cli")]
+use std::sync::OnceLock;
+
+use crate::config::{ChangelogConfig, CommitFormats};
 use crate::conventional_commits::determine_bump;
 use crate::conventional_commits::{
     BumpType, CommitCategory, breaking_footer_body, classify_commit, is_breaking, parse_header,
@@ -18,9 +19,18 @@ pub struct GitLog {
 #[derive(Default)]
 pub struct ChangelogRender<'a> {
     pub config: Option<&'a ChangelogConfig>,
+    pub formats: Option<&'a CommitFormats>,
     pub forge_base: Option<String>,
     pub last_tag: Option<String>,
     pub new_tag: Option<String>,
+}
+
+impl<'a> ChangelogRender<'a> {
+    fn formats(&self) -> &CommitFormats {
+        static FALLBACK: OnceLock<CommitFormats> = OnceLock::new();
+        self.formats
+            .unwrap_or_else(|| FALLBACK.get_or_init(CommitFormats::default))
+    }
 }
 
 #[cfg(feature = "cli")]
@@ -71,7 +81,7 @@ pub fn generate_only(config_path: Option<&Path>, dry_run: bool) -> Result<()> {
 
         let bump = commits
             .iter()
-            .map(|c| determine_bump(&c.message))
+            .map(|c| determine_bump(&c.message, &config.workspace.commit_formats))
             .max()
             .unwrap_or(BumpType::None);
 
@@ -115,6 +125,7 @@ pub fn generate_only(config_path: Option<&Path>, dry_run: bool) -> Result<()> {
         };
 
         let render = ChangelogRender {
+            formats: None,
             config: config.workspace.changelog.as_ref(),
             forge_base: forge_base.clone(),
             last_tag,
@@ -142,11 +153,11 @@ pub fn build_section_with(
 ) -> String {
     match render.config {
         Some(config) => build_rich_section(new_version, commits, config, render),
-        None => build_classic_section(new_version, commits),
+        None => build_classic_section(new_version, commits, render.formats()),
     }
 }
 
-fn build_classic_section(new_version: &str, commits: &[GitLog]) -> String {
+fn build_classic_section(new_version: &str, commits: &[GitLog], formats: &CommitFormats) -> String {
     let date = Local::now().format("%Y-%m-%d").to_string();
     let mut breaking = Vec::new();
     let mut features = Vec::new();
@@ -155,7 +166,7 @@ fn build_classic_section(new_version: &str, commits: &[GitLog]) -> String {
 
     for commit in commits {
         let subject = parse_subject(&commit.message);
-        match classify_commit(&commit.message) {
+        match classify_commit(&commit.message, formats) {
             CommitCategory::Breaking => breaking.push(format!("- {subject}")),
             CommitCategory::Feature => features.push(format!("- {subject}")),
             CommitCategory::Fix => fixes.push(format!("- {subject}")),
@@ -192,8 +203,8 @@ fn build_classic_section(new_version: &str, commits: &[GitLog]) -> String {
 
 const BREAKING_KEY: &str = "breaking";
 
-fn render_section_key(message: &str) -> Option<&'static str> {
-    if is_breaking(message) {
+fn render_section_key(message: &str, formats: &CommitFormats) -> Option<&'static str> {
+    if is_breaking(message, formats) {
         return Some(BREAKING_KEY);
     }
     let header = parse_header(message)?;
@@ -285,7 +296,7 @@ fn build_rich_section(
         std::collections::BTreeMap::new();
 
     for commit in commits {
-        let Some(key) = render_section_key(&commit.message) else {
+        let Some(key) = render_section_key(&commit.message, render.formats()) else {
             continue;
         };
         let entry = build_entry(commit, config, render);
@@ -330,7 +341,7 @@ fn build_entry(commit: &GitLog, config: &ChangelogConfig, render: &ChangelogRend
     let header = parse_header(&commit.message);
     let scope = header.as_ref().and_then(|h| h.scope.map(|s| s.to_string()));
 
-    let breaking = is_breaking(&commit.message);
+    let breaking = is_breaking(&commit.message, render.formats());
     let body = if breaking {
         let desc = breaking_footer_body(&commit.message);
         match (desc, header.as_ref()) {
@@ -647,14 +658,13 @@ mod tests {
     }
 
     #[test]
-    fn build_section_does_not_misclassify_feature_word() {
-        // `feature:` (no colon-delimited type) and `feat add` (no colon)
-        // are not the conventional `feat:` type and must not appear as
-        // features.
-        let commits = make_commits(&["feature: misnamed type", "feat add no colon"]);
+    fn build_section_treats_feature_as_a_feature_but_not_a_bare_feat() {
+        // `feature:` is a documented default alias since #247. `feat add`
+        // has no colon and matches nothing, so it stays out.
+        let commits = make_commits(&["feature: renamed type", "feat add no colon"]);
         let section = build_section("1.0.1", &commits);
-        assert!(!section.contains("### Features"));
-        assert!(!section.contains("misnamed type"));
+        assert!(section.contains("### Features"));
+        assert!(section.contains("renamed type"));
         assert!(!section.contains("no colon"));
     }
 
@@ -753,7 +763,7 @@ mod tests {
             "chore: noise",
         ]);
         let with_default = build_section_with("1.2.3", &commits, &ChangelogRender::default());
-        let classic = build_classic_section("1.2.3", &commits);
+        let classic = build_classic_section("1.2.3", &commits, &Default::default());
         assert_eq!(with_default, classic);
     }
 
@@ -761,12 +771,13 @@ mod tests {
     fn rich_render_with_no_config_field_matches_classic() {
         let commits = make_commits(&["feat: a", "fix: b"]);
         let render = ChangelogRender {
+            formats: None,
             config: None,
             ..Default::default()
         };
         assert_eq!(
             build_section_with("1.0.0", &commits, &render),
-            build_classic_section("1.0.0", &commits)
+            build_classic_section("1.0.0", &commits, &Default::default())
         );
     }
 
@@ -788,6 +799,7 @@ mod tests {
             "fix: small bug",
         ]);
         let render = ChangelogRender {
+            formats: None,
             config: Some(&cfg),
             ..Default::default()
         };
@@ -813,6 +825,7 @@ mod tests {
         };
         let commits = make_commits(&["fix(security): sanitize input"]);
         let render = ChangelogRender {
+            formats: None,
             config: Some(&cfg),
             ..Default::default()
         };
@@ -830,6 +843,7 @@ mod tests {
         };
         let commits = make_commits(&["docs: explain config"]);
         let r = ChangelogRender {
+            formats: None,
             config: Some(&with_docs),
             ..Default::default()
         };
@@ -840,6 +854,7 @@ mod tests {
             ..Default::default()
         };
         let r2 = ChangelogRender {
+            formats: None,
             config: Some(&hidden),
             ..Default::default()
         };
@@ -857,6 +872,7 @@ mod tests {
         };
         let commits = make_commits(&["feat: x"]);
         let r = ChangelogRender {
+            formats: None,
             config: Some(&cfg),
             ..Default::default()
         };
@@ -874,6 +890,7 @@ mod tests {
                 .to_string(),
         }];
         let r = ChangelogRender {
+            formats: None,
             config: Some(&cfg),
             ..Default::default()
         };
@@ -887,6 +904,7 @@ mod tests {
         let cfg = ChangelogConfig::default();
         let commits = make_commits(&["feat!: drop legacy flag"]);
         let r = ChangelogRender {
+            formats: None,
             config: Some(&cfg),
             ..Default::default()
         };
@@ -908,6 +926,7 @@ mod tests {
             "feat: top-level change",
         ]);
         let r = ChangelogRender {
+            formats: None,
             config: Some(&cfg),
             ..Default::default()
         };
@@ -933,6 +952,7 @@ mod tests {
             message: "feat: add endpoint".to_string(),
         }];
         let r = ChangelogRender {
+            formats: None,
             config: Some(&cfg),
             forge_base: Some("https://github.com/owner/repo".to_string()),
             ..Default::default()
@@ -952,6 +972,7 @@ mod tests {
         };
         let commits = make_commits(&["feat: add endpoint"]);
         let r = ChangelogRender {
+            formats: None,
             config: Some(&cfg),
             forge_base: None,
             ..Default::default()
@@ -970,6 +991,7 @@ mod tests {
         };
         let commits = make_commits(&["feat: x"]);
         let r = ChangelogRender {
+            formats: None,
             config: Some(&cfg),
             forge_base: Some("https://github.com/owner/repo".to_string()),
             last_tag: Some("v1.2.2".to_string()),
@@ -988,6 +1010,7 @@ mod tests {
         };
         let commits = make_commits(&["feat: x"]);
         let r = ChangelogRender {
+            formats: None,
             config: Some(&cfg),
             forge_base: Some("https://github.com/owner/repo".to_string()),
             last_tag: None,
@@ -1005,6 +1028,7 @@ mod tests {
         };
         let commits = make_commits(&["feat: kept", "perf: dropped", "fix: dropped"]);
         let r = ChangelogRender {
+            formats: None,
             config: Some(&cfg),
             ..Default::default()
         };
@@ -1020,6 +1044,7 @@ mod tests {
         let cfg = ChangelogConfig::default();
         let commits = make_commits(&["feat: f", "fix: b", "perf: p", "docs: d"]);
         let r = ChangelogRender {
+            formats: None,
             config: Some(&cfg),
             ..Default::default()
         };

--- a/src/config/commit_formats.rs
+++ b/src/config/commit_formats.rs
@@ -17,10 +17,6 @@ impl PatternSet {
         }
     }
 
-    // `all` is a keyword, not a pattern, so it is recognised whatever the
-    // casing — `case_sensitive` governs how subjects are matched, and letting
-    // it turn `"All"` into a literal that matches only the subject "all"
-    // would be a trap.
     fn is_catch_all(&self) -> bool {
         self.patterns()
             .iter()
@@ -47,14 +43,6 @@ impl PatternSet {
     }
 }
 
-/// `*` (any run, possibly empty) and `?` (exactly one char) over a commit
-/// subject.
-///
-/// Deliberately not `glob_match`, which the rest of the codebase uses for
-/// branch names: there `/` is a real separator and `*` must not cross it.
-/// A commit subject is prose — `fix: update src/foo.rs` and
-/// `feat(api/auth/jwt): x` both contain slashes — so path semantics would
-/// make `fix:*` fail on the majority of real messages (#247).
 fn wildcard_match(pattern: &str, text: &str) -> bool {
     let p: Vec<char> = pattern.chars().collect();
     let t: Vec<char> = text.chars().collect();
@@ -105,13 +93,6 @@ fn default_case_sensitive() -> bool {
     true
 }
 
-/// Empty on purpose. Every real breaking marker — `feat!:`, `fix(api)!:`,
-/// the `feat(api!):` typo, and a `BREAKING CHANGE:` footer — is detected
-/// structurally in `classify_commit`, whatever is configured here. A glob
-/// cannot express those precisely: `*!:*` matches any subject containing
-/// `!:` anywhere, which turns `fix: handle the !: token in the parser`
-/// into a major release. This level exists for teams whose breaking
-/// convention is something else entirely, e.g. `"major": "Breaking/*"`.
 fn default_major() -> PatternSet {
     PatternSet::Many(Vec::new())
 }

--- a/src/config/commit_formats.rs
+++ b/src/config/commit_formats.rs
@@ -1,0 +1,256 @@
+use serde::{Deserialize, Serialize};
+
+pub const CATCH_ALL: &str = "all";
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum PatternSet {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl PatternSet {
+    fn patterns(&self) -> &[String] {
+        match self {
+            PatternSet::One(p) => std::slice::from_ref(p),
+            PatternSet::Many(p) => p,
+        }
+    }
+
+    fn is_catch_all(&self) -> bool {
+        self.patterns().iter().any(|p| p == CATCH_ALL)
+    }
+
+    pub fn matches(&self, subject: &str, case_sensitive: bool) -> bool {
+        if self.is_catch_all() {
+            return true;
+        }
+        let haystack = if case_sensitive {
+            subject.to_string()
+        } else {
+            subject.to_lowercase()
+        };
+        self.patterns().iter().any(|p| {
+            let pattern = if case_sensitive {
+                p.clone()
+            } else {
+                p.to_lowercase()
+            };
+            wildcard_match(&pattern, &haystack)
+        })
+    }
+}
+
+/// `*` (any run, possibly empty) and `?` (exactly one char) over a commit
+/// subject.
+///
+/// Deliberately not `glob_match`, which the rest of the codebase uses for
+/// branch names: there `/` is a real separator and `*` must not cross it.
+/// A commit subject is prose — `fix: update src/foo.rs` and
+/// `feat(api/auth/jwt): x` both contain slashes — so path semantics would
+/// make `fix:*` fail on the majority of real messages (#247).
+fn wildcard_match(pattern: &str, text: &str) -> bool {
+    let p: Vec<char> = pattern.chars().collect();
+    let t: Vec<char> = text.chars().collect();
+    let (mut pi, mut ti) = (0usize, 0usize);
+    let (mut star, mut backtrack) = (None, 0usize);
+
+    while ti < t.len() {
+        if pi < p.len() && (p[pi] == '?' || p[pi] == t[ti]) {
+            pi += 1;
+            ti += 1;
+        } else if pi < p.len() && p[pi] == '*' {
+            star = Some(pi);
+            backtrack = ti;
+            pi += 1;
+        } else if let Some(s) = star {
+            pi = s + 1;
+            backtrack += 1;
+            ti = backtrack;
+        } else {
+            return false;
+        }
+    }
+    while pi < p.len() && p[pi] == '*' {
+        pi += 1;
+    }
+    pi == p.len()
+}
+
+impl From<Vec<&str>> for PatternSet {
+    fn from(v: Vec<&str>) -> Self {
+        PatternSet::Many(v.into_iter().map(String::from).collect())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct CommitFormats {
+    #[serde(default = "default_major")]
+    pub major: PatternSet,
+    #[serde(default = "default_minor")]
+    pub minor: PatternSet,
+    #[serde(default = "default_patch")]
+    pub patch: PatternSet,
+    #[serde(default = "default_case_sensitive", alias = "caseSensitive")]
+    pub case_sensitive: bool,
+}
+
+fn default_case_sensitive() -> bool {
+    true
+}
+
+/// Empty on purpose. Every real breaking marker — `feat!:`, `fix(api)!:`,
+/// the `feat(api!):` typo, and a `BREAKING CHANGE:` footer — is detected
+/// structurally in `classify_commit`, whatever is configured here. A glob
+/// cannot express those precisely: `*!:*` matches any subject containing
+/// `!:` anywhere, which turns `fix: handle the !: token in the parser`
+/// into a major release. This level exists for teams whose breaking
+/// convention is something else entirely, e.g. `"major": "Breaking/*"`.
+fn default_major() -> PatternSet {
+    PatternSet::Many(Vec::new())
+}
+
+fn default_minor() -> PatternSet {
+    vec![
+        "feat:*",
+        "feat(?*):*",
+        "Feat:*",
+        "Feat(?*):*",
+        "Feat/*",
+        "feat/*",
+        "feature:*",
+        "feature(?*):*",
+        "Feature/*",
+        "feature/*",
+    ]
+    .into()
+}
+
+fn default_patch() -> PatternSet {
+    vec![
+        "fix:*",
+        "fix(?*):*",
+        "Fix:*",
+        "Fix(?*):*",
+        "Fix/*",
+        "fix/*",
+        "perf:*",
+        "perf(?*):*",
+        "Perf:*",
+        "Perf(?*):*",
+        "refactor:*",
+        "refactor(?*):*",
+        "Refactor:*",
+        "Refactor(?*):*",
+        "Refactor/*",
+        "refactor/*",
+    ]
+    .into()
+}
+
+impl Default for CommitFormats {
+    fn default() -> Self {
+        Self {
+            major: default_major(),
+            minor: default_minor(),
+            patch: default_patch(),
+            case_sensitive: default_case_sensitive(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn defaults() -> CommitFormats {
+        CommitFormats::default()
+    }
+
+    #[test]
+    fn single_string_pattern_is_accepted() {
+        let p: PatternSet = serde_json::from_str(r#""feat:*""#).unwrap();
+        assert!(p.matches("feat: add login", true));
+        assert!(!p.matches("fix: crash", true));
+    }
+
+    #[test]
+    fn list_of_patterns_is_accepted() {
+        let p: PatternSet = serde_json::from_str(r#"["feat:*", "Feat/*"]"#).unwrap();
+        assert!(p.matches("feat: x", true));
+        assert!(p.matches("Feat/add-login", true));
+        assert!(!p.matches("chore: x", true));
+    }
+
+    #[test]
+    fn catch_all_matches_anything() {
+        let p: PatternSet = serde_json::from_str(r#""all""#).unwrap();
+        assert!(p.matches("literally anything", true));
+        assert!(p.matches("", true));
+    }
+
+    #[test]
+    fn catch_all_inside_a_list_still_catches_all() {
+        let p: PatternSet = serde_json::from_str(r#"["feat:*", "all"]"#).unwrap();
+        assert!(p.matches("chore: whatever", true));
+    }
+
+    #[test]
+    fn case_sensitive_by_default_rejects_wrong_casing() {
+        let p: PatternSet = serde_json::from_str(r#""feat:*""#).unwrap();
+        assert!(!p.matches("FEAT: shouting", true));
+        assert!(p.matches("FEAT: shouting", false));
+    }
+
+    #[test]
+    fn case_insensitive_lowercases_both_sides() {
+        let p: PatternSet = serde_json::from_str(r#""Feat/*""#).unwrap();
+        assert!(p.matches("FEAT/add-login", false));
+        assert!(p.matches("feat/add-login", false));
+    }
+
+    #[test]
+    fn defaults_cover_the_branch_style_prefixes_the_issue_asked_for() {
+        let f = defaults();
+        for subject in [
+            "Feat/add-login",
+            "Fix/resolve-crash",
+            "Refactor/cleanup",
+            "Feat: add login",
+            "Fix: resolve crash",
+            "feature: add login",
+        ] {
+            let hit = f.major.matches(subject, f.case_sensitive)
+                || f.minor.matches(subject, f.case_sensitive)
+                || f.patch.matches(subject, f.case_sensitive);
+            assert!(hit, "default patterns should match {subject:?}");
+        }
+    }
+
+    #[test]
+    fn defaults_still_ignore_non_release_conventional_types() {
+        let f = defaults();
+        for subject in ["chore: deps", "docs: typo", "ci: cache", "test: add case"] {
+            let hit = f.major.matches(subject, f.case_sensitive)
+                || f.minor.matches(subject, f.case_sensitive)
+                || f.patch.matches(subject, f.case_sensitive);
+            assert!(!hit, "{subject:?} must not trigger a release");
+        }
+    }
+
+    #[test]
+    fn partial_config_falls_back_to_defaults_per_level() {
+        let f: CommitFormats = serde_json::from_str(r#"{"minor": "all"}"#).unwrap();
+        assert!(f.minor.matches("anything", true));
+        assert!(f.patch.matches("fix: x", true), "patch keeps its default");
+        assert!(f.case_sensitive, "case_sensitive defaults to true");
+    }
+
+    #[test]
+    fn case_sensitive_accepts_both_snake_and_camel_spelling() {
+        let a: CommitFormats = serde_json::from_str(r#"{"case_sensitive": false}"#).unwrap();
+        let b: CommitFormats = serde_json::from_str(r#"{"caseSensitive": false}"#).unwrap();
+        assert!(!a.case_sensitive);
+        assert!(!b.case_sensitive);
+    }
+}

--- a/src/config/commit_formats.rs
+++ b/src/config/commit_formats.rs
@@ -17,8 +17,14 @@ impl PatternSet {
         }
     }
 
+    // `all` is a keyword, not a pattern, so it is recognised whatever the
+    // casing — `case_sensitive` governs how subjects are matched, and letting
+    // it turn `"All"` into a literal that matches only the subject "all"
+    // would be a trap.
     fn is_catch_all(&self) -> bool {
-        self.patterns().iter().any(|p| p == CATCH_ALL)
+        self.patterns()
+            .iter()
+            .any(|p| p.eq_ignore_ascii_case(CATCH_ALL))
     }
 
     pub fn matches(&self, subject: &str, case_sensitive: bool) -> bool {
@@ -187,6 +193,18 @@ mod tests {
         let p: PatternSet = serde_json::from_str(r#""all""#).unwrap();
         assert!(p.matches("literally anything", true));
         assert!(p.matches("", true));
+    }
+
+    #[test]
+    fn catch_all_is_a_keyword_not_a_pattern_so_casing_is_irrelevant() {
+        for raw in [r#""All""#, r#""ALL""#, r#""all""#] {
+            let p: PatternSet = serde_json::from_str(raw).unwrap();
+            assert!(p.matches("chore: whatever", true), "{raw} should catch all");
+            assert!(
+                p.matches("chore: whatever", false),
+                "{raw} should catch all"
+            );
+        }
     }
 
     #[test]

--- a/src/config/format.rs
+++ b/src/config/format.rs
@@ -48,6 +48,8 @@ const CAMEL_CASE_KEYS: &[&str] = &[
     "release_commit_mode",
     "release_commit_scope",
     "release_commit_body",
+    "commit_formats",
+    "case_sensitive",
     "auto_merge_releases",
     "skip_ci",
     "commit_skip_markers",

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 use crate::error_code::{self, ErrorCodeExt};
 
+mod commit_formats;
 mod format;
 mod groups;
 #[cfg(feature = "cli")]
@@ -16,6 +17,8 @@ mod package;
 mod types;
 mod workspace;
 
+#[allow(unused_imports)]
+pub use commit_formats::{CATCH_ALL, CommitFormats, PatternSet};
 #[allow(unused_imports)]
 pub use format::{ConfigFileFormat, ConfigFormatHandler, format_handler};
 #[allow(unused_imports)]

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+use super::commit_formats::CommitFormats;
 use super::package::{FloatingTagLevel, VersioningStrategy};
 use super::types::{
     BranchChannelConfig, ForgeKind, HooksConfig, OrphanedTagStrategy, RegistryConfig,
@@ -29,6 +30,8 @@ pub struct WorkspaceConfig {
     pub release_commit_scope: ReleaseCommitScope,
     #[serde(default, alias = "releaseCommitBody")]
     pub release_commit_body: ReleaseCommitBody,
+    #[serde(default, alias = "commitFormats")]
+    pub commit_formats: CommitFormats,
     #[serde(default = "default_auto_merge", alias = "autoMergeReleases")]
     pub auto_merge_releases: bool,
     #[serde(default, alias = "skipCi")]

--- a/src/conventional_commits.rs
+++ b/src/conventional_commits.rs
@@ -117,8 +117,12 @@ pub fn classify_commit(message: &str, formats: &CommitFormats) -> CommitCategory
 
 static REFACTOR_RE: OnceLock<Regex> = OnceLock::new();
 
+// Case-insensitive and accepting `/` as well as `:` so the Title-case and
+// branch-style spellings the default patterns bump (`Refactor:`, `Refactor/`,
+// `refactor/`) reach the Refactoring section too, rather than being filed
+// under Bug Fixes because only the lowercase colon form was recognised.
 fn refactor_header_re() -> &'static Regex {
-    REFACTOR_RE.get_or_init(|| Regex::new(r"^refactor(\(.+\))?:").unwrap())
+    REFACTOR_RE.get_or_init(|| Regex::new(r"(?i)^refactor(\([^()]*\))?[:/]").unwrap())
 }
 
 pub fn parse_subject(message: &str) -> &str {

--- a/src/conventional_commits.rs
+++ b/src/conventional_commits.rs
@@ -1,6 +1,8 @@
 use regex::Regex;
 use std::sync::OnceLock;
 
+use crate::config::CommitFormats;
+
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub enum BumpType {
     None,
@@ -21,16 +23,11 @@ impl std::fmt::Display for BumpType {
 }
 
 static BREAKING_RE: OnceLock<Regex> = OnceLock::new();
-static FEAT_RE: OnceLock<Regex> = OnceLock::new();
 
 fn breaking_header_re() -> &'static Regex {
     BREAKING_RE.get_or_init(|| {
         Regex::new(r"^(feat|fix|refactor|perf|build|chore|docs|style|test|ci)(\(.+\))?!:").unwrap()
     })
-}
-
-fn feat_header_re() -> &'static Regex {
-    FEAT_RE.get_or_init(|| Regex::new(r"^feat(\(.+\))?:").unwrap())
 }
 
 static BREAKING_FOOTER_RE: OnceLock<Regex> = OnceLock::new();
@@ -56,8 +53,8 @@ fn breaking_scope_bang_re() -> &'static Regex {
     })
 }
 
-pub fn determine_bump(message: &str) -> BumpType {
-    match classify_commit(message) {
+pub fn determine_bump(message: &str, formats: &CommitFormats) -> BumpType {
+    match classify_commit(message, formats) {
         CommitCategory::Breaking => BumpType::Major,
         CommitCategory::Feature => BumpType::Minor,
         CommitCategory::Fix | CommitCategory::Refactor => BumpType::Patch,
@@ -87,33 +84,38 @@ pub enum CommitCategory {
     Other,
 }
 
-pub fn classify_commit(message: &str) -> CommitCategory {
-    let header = parse_subject(message);
+pub fn classify_commit(message: &str, formats: &CommitFormats) -> CommitCategory {
+    let subject = parse_subject(message);
+    let cs = formats.case_sensitive;
 
-    if breaking_header_re().is_match(header)
-        || breaking_scope_bang_re().is_match(header)
+    // Structural breaking markers are recognised whatever the configured
+    // patterns say. A `BREAKING CHANGE:` footer lives in the body, which
+    // subject globs cannot see, and `feat(api!):` puts the bang where a
+    // `*!:*` glob does not reach.
+    if breaking_header_re().is_match(subject)
+        || breaking_scope_bang_re().is_match(subject)
         || breaking_footer_re().is_match(message)
+        || formats.major.matches(subject, cs)
     {
         return CommitCategory::Breaking;
     }
-    if feat_header_re().is_match(header) {
+    if formats.minor.matches(subject, cs) {
         return CommitCategory::Feature;
     }
-    if fix_perf_header_re().is_match(header) {
-        return CommitCategory::Fix;
-    }
-    if refactor_header_re().is_match(header) {
-        return CommitCategory::Refactor;
+    if formats.patch.matches(subject, cs) {
+        // Patch splits into two changelog sections. The configured patterns
+        // only carry a bump level, so the section is resolved from the
+        // conventional prefix when there is one, and falls back to Fix.
+        return if refactor_header_re().is_match(subject) {
+            CommitCategory::Refactor
+        } else {
+            CommitCategory::Fix
+        };
     }
     CommitCategory::Other
 }
 
-static FIX_PERF_RE: OnceLock<Regex> = OnceLock::new();
 static REFACTOR_RE: OnceLock<Regex> = OnceLock::new();
-
-fn fix_perf_header_re() -> &'static Regex {
-    FIX_PERF_RE.get_or_init(|| Regex::new(r"^(fix|perf)(\(.+\))?:").unwrap())
-}
 
 fn refactor_header_re() -> &'static Regex {
     REFACTOR_RE.get_or_init(|| Regex::new(r"^refactor(\(.+\))?:").unwrap())
@@ -159,8 +161,8 @@ pub fn parse_header(message: &str) -> Option<ParsedHeader<'_>> {
     })
 }
 
-pub fn is_breaking(message: &str) -> bool {
-    matches!(classify_commit(message), CommitCategory::Breaking)
+pub fn is_breaking(message: &str, formats: &CommitFormats) -> bool {
+    matches!(classify_commit(message, formats), CommitCategory::Breaking)
 }
 
 pub fn breaking_footer_body(message: &str) -> Option<String> {
@@ -177,38 +179,199 @@ pub fn breaking_footer_body(message: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{CATCH_ALL, PatternSet};
+
+    /// The permissive defaults are a deliberate behaviour change (#247), so
+    /// the documented escape hatch has to actually work: with strict
+    /// patterns every branch-style and capitalised variant goes back to
+    /// being ignored, and plain conventional commits are unaffected.
+    #[test]
+    fn strict_patterns_restore_the_pre_247_behaviour() {
+        let strict = CommitFormats {
+            major: PatternSet::Many(Vec::new()),
+            minor: vec!["feat:*", "feat(?*):*"].into(),
+            patch: vec![
+                "fix:*",
+                "fix(?*):*",
+                "perf:*",
+                "perf(?*):*",
+                "refactor:*",
+                "refactor(?*):*",
+            ]
+            .into(),
+            case_sensitive: true,
+        };
+        for ignored in [
+            "Feat/add-login",
+            "Fix/resolve-crash",
+            "Refactor/cleanup",
+            "Feat: add login",
+            "Fix: resolve crash",
+            "feature: add login",
+        ] {
+            assert_eq!(
+                determine_bump(ignored, &strict),
+                BumpType::None,
+                "{ignored:?} must not bump under the strict preset"
+            );
+        }
+        assert_eq!(determine_bump("feat: x", &strict), BumpType::Minor);
+        assert_eq!(determine_bump("fix(db): x", &strict), BumpType::Patch);
+        assert_eq!(determine_bump("refactor: x", &strict), BumpType::Patch);
+        assert_eq!(determine_bump("chore: x", &strict), BumpType::None);
+        assert_eq!(determine_bump("feat!: x", &strict), BumpType::Major);
+        assert_eq!(
+            determine_bump("fix: x\n\nBREAKING CHANGE: gone", &strict),
+            BumpType::Major
+        );
+    }
+
+    /// The structural breaking markers must survive whatever patterns are
+    /// configured — a `BREAKING CHANGE:` footer lives in the body, which a
+    /// subject glob cannot see, and `feat(api!):` puts the bang where
+    /// `*!:*` does not reach.
+    #[test]
+    fn structural_breaking_markers_survive_a_config_that_omits_them() {
+        let no_major = CommitFormats {
+            major: PatternSet::Many(Vec::new()),
+            minor: vec!["feat:*"].into(),
+            patch: vec!["fix:*"].into(),
+            case_sensitive: true,
+        };
+        assert_eq!(
+            determine_bump("fix: x\n\nBREAKING CHANGE: gone", &no_major),
+            BumpType::Major,
+            "footer must still win"
+        );
+        assert_eq!(
+            determine_bump("feat(api!): typo bang", &no_major),
+            BumpType::Major,
+            "scope-bang typo must still win"
+        );
+        assert_eq!(determine_bump("feat!: x", &no_major), BumpType::Major);
+    }
+
+    #[test]
+    fn permissive_defaults_pick_up_branch_style_prefixes() {
+        let d = CommitFormats::default();
+        assert_eq!(determine_bump("Feat/add-login", &d), BumpType::Minor);
+        assert_eq!(determine_bump("Fix/resolve-crash", &d), BumpType::Patch);
+        assert_eq!(determine_bump("Refactor/cleanup", &d), BumpType::Patch);
+        assert_eq!(determine_bump("Feat: add login", &d), BumpType::Minor);
+        assert_eq!(determine_bump("feature: add login", &d), BumpType::Minor);
+        assert_eq!(determine_bump("chore: deps", &d), BumpType::None);
+    }
+
+    #[test]
+    fn catch_all_patch_makes_every_commit_release() {
+        let f = CommitFormats {
+            major: PatternSet::Many(Vec::new()),
+            minor: vec!["feat:*"].into(),
+            patch: PatternSet::One(CATCH_ALL.to_string()),
+            case_sensitive: true,
+        };
+        assert_eq!(determine_bump("anything at all", &f), BumpType::Patch);
+        assert_eq!(determine_bump("chore: deps", &f), BumpType::Patch);
+        assert_eq!(determine_bump("feat: x", &f), BumpType::Minor);
+        assert_eq!(determine_bump("feat!: x", &f), BumpType::Major);
+    }
+
+    #[test]
+    fn priority_is_major_over_minor_over_patch() {
+        let f = CommitFormats {
+            major: PatternSet::One(CATCH_ALL.to_string()),
+            minor: PatternSet::One(CATCH_ALL.to_string()),
+            patch: PatternSet::One(CATCH_ALL.to_string()),
+            case_sensitive: true,
+        };
+        assert_eq!(determine_bump("whatever", &f), BumpType::Major);
+    }
+
+    #[test]
+    fn case_insensitive_config_accepts_any_casing() {
+        let f = CommitFormats {
+            major: PatternSet::Many(Vec::new()),
+            minor: vec!["feat:*", "feat(?*):*"].into(),
+            patch: vec!["fix:*", "fix(?*):*"].into(),
+            case_sensitive: false,
+        };
+        assert_eq!(determine_bump("FEAT: shouting", &f), BumpType::Minor);
+        assert_eq!(determine_bump("Fix(db): leak", &f), BumpType::Patch);
+    }
+
+    /// Configured patterns carry a bump level, not a changelog section, so
+    /// a patch-level match still has to land in the right section.
+    #[test]
+    fn patch_level_splits_into_fix_and_refactor_sections() {
+        let d = CommitFormats::default();
+        assert_eq!(classify_commit("refactor: x", &d), CommitCategory::Refactor);
+        assert_eq!(classify_commit("fix: x", &d), CommitCategory::Fix);
+        assert_eq!(classify_commit("perf: x", &d), CommitCategory::Fix);
+        assert_eq!(
+            classify_commit("Fix/branch-style", &d),
+            CommitCategory::Fix,
+            "non-conventional patch matches fall back to Fix"
+        );
+    }
 
     #[test]
     fn test_patch() {
-        assert_eq!(determine_bump("fix: correct typo"), BumpType::Patch);
-        assert_eq!(determine_bump("perf: faster query"), BumpType::Patch);
-        assert_eq!(determine_bump("refactor: clean up"), BumpType::Patch);
+        assert_eq!(
+            determine_bump("fix: correct typo", &Default::default()),
+            BumpType::Patch
+        );
+        assert_eq!(
+            determine_bump("perf: faster query", &Default::default()),
+            BumpType::Patch
+        );
+        assert_eq!(
+            determine_bump("refactor: clean up", &Default::default()),
+            BumpType::Patch
+        );
     }
 
     #[test]
     fn test_minor() {
-        assert_eq!(determine_bump("feat: add login"), BumpType::Minor);
-        assert_eq!(determine_bump("feat(auth): add JWT"), BumpType::Minor);
+        assert_eq!(
+            determine_bump("feat: add login", &Default::default()),
+            BumpType::Minor
+        );
+        assert_eq!(
+            determine_bump("feat(auth): add JWT", &Default::default()),
+            BumpType::Minor
+        );
     }
 
     #[test]
     fn test_major() {
-        assert_eq!(determine_bump("feat!: breaking change"), BumpType::Major);
         assert_eq!(
-            determine_bump("fix(api)!: remove endpoint"),
+            determine_bump("feat!: breaking change", &Default::default()),
             BumpType::Major
         );
         assert_eq!(
-            determine_bump("BREAKING CHANGE: removed X"),
+            determine_bump("fix(api)!: remove endpoint", &Default::default()),
+            BumpType::Major
+        );
+        assert_eq!(
+            determine_bump("BREAKING CHANGE: removed X", &Default::default()),
             BumpType::Major
         );
     }
 
     #[test]
     fn test_none() {
-        assert_eq!(determine_bump("chore: update deps"), BumpType::None);
-        assert_eq!(determine_bump("docs: update readme"), BumpType::None);
-        assert_eq!(determine_bump("ci: fix pipeline"), BumpType::None);
+        assert_eq!(
+            determine_bump("chore: update deps", &Default::default()),
+            BumpType::None
+        );
+        assert_eq!(
+            determine_bump("docs: update readme", &Default::default()),
+            BumpType::None
+        );
+        assert_eq!(
+            determine_bump("ci: fix pipeline", &Default::default()),
+            BumpType::None
+        );
     }
 
     #[test]
@@ -224,39 +387,51 @@ mod tests {
 
     #[test]
     fn test_scoped_commits() {
-        assert_eq!(determine_bump("fix(api): null check"), BumpType::Patch);
-        assert_eq!(determine_bump("feat(ui): new button"), BumpType::Minor);
-        assert_eq!(determine_bump("refactor(db): simplify"), BumpType::Patch);
+        assert_eq!(
+            determine_bump("fix(api): null check", &Default::default()),
+            BumpType::Patch
+        );
+        assert_eq!(
+            determine_bump("feat(ui): new button", &Default::default()),
+            BumpType::Minor
+        );
+        assert_eq!(
+            determine_bump("refactor(db): simplify", &Default::default()),
+            BumpType::Patch
+        );
     }
 
     #[test]
     fn test_breaking_change_in_body() {
         let msg = "feat: something\n\nBREAKING CHANGE: removed old API";
-        assert_eq!(determine_bump(msg), BumpType::Major);
+        assert_eq!(determine_bump(msg, &Default::default()), BumpType::Major);
     }
 
     #[test]
     fn test_breaking_change_hyphen_footer() {
         let msg = "feat: something\n\nBREAKING-CHANGE: removed old API";
-        assert_eq!(determine_bump(msg), BumpType::Major);
+        assert_eq!(determine_bump(msg, &Default::default()), BumpType::Major);
     }
 
     #[test]
     fn test_breaking_change_prose_is_not_major() {
         assert_eq!(
-            determine_bump("docs: note that BREAKING CHANGES are coming in v2"),
+            determine_bump(
+                "docs: note that BREAKING CHANGES are coming in v2",
+                &Default::default()
+            ),
             BumpType::None
         );
         let body = "feat: add flag\n\nBREAKING CHANGE will be handled later, not yet";
-        assert_eq!(determine_bump(body), BumpType::Minor);
+        assert_eq!(determine_bump(body, &Default::default()), BumpType::Minor);
         let plural = "chore: cleanup\n\nBREAKING CHANGES: none in this one";
-        assert_eq!(determine_bump(plural), BumpType::None);
+        assert_eq!(determine_bump(plural, &Default::default()), BumpType::None);
     }
 
     #[test]
     fn test_breaking_change_footer_missing_space_after_colon() {
         let msg = "feat: x\n\nBREAKING CHANGE:no-space-description";
-        assert_eq!(determine_bump(msg), BumpType::Minor);
+        assert_eq!(determine_bump(msg, &Default::default()), BumpType::Minor);
     }
 
     #[test]
@@ -268,61 +443,130 @@ mod tests {
 
     #[test]
     fn test_empty_message() {
-        assert_eq!(determine_bump(""), BumpType::None);
+        assert_eq!(determine_bump("", &Default::default()), BumpType::None);
     }
 
     #[test]
     fn test_whitespace_only_message() {
-        assert_eq!(determine_bump("   \n\n  "), BumpType::None);
+        assert_eq!(
+            determine_bump("   \n\n  ", &Default::default()),
+            BumpType::None
+        );
     }
 
     #[test]
     fn test_non_conventional_message() {
-        assert_eq!(determine_bump("update readme"), BumpType::None);
-        assert_eq!(determine_bump("fixed the thing"), BumpType::None);
-        assert_eq!(determine_bump("WIP"), BumpType::None);
+        assert_eq!(
+            determine_bump("update readme", &Default::default()),
+            BumpType::None
+        );
+        assert_eq!(
+            determine_bump("fixed the thing", &Default::default()),
+            BumpType::None
+        );
+        assert_eq!(determine_bump("WIP", &Default::default()), BumpType::None);
     }
 
     #[test]
     fn test_all_patch_types() {
-        assert_eq!(determine_bump("fix: something"), BumpType::Patch);
-        assert_eq!(determine_bump("perf: something"), BumpType::Patch);
-        assert_eq!(determine_bump("refactor: something"), BumpType::Patch);
+        assert_eq!(
+            determine_bump("fix: something", &Default::default()),
+            BumpType::Patch
+        );
+        assert_eq!(
+            determine_bump("perf: something", &Default::default()),
+            BumpType::Patch
+        );
+        assert_eq!(
+            determine_bump("refactor: something", &Default::default()),
+            BumpType::Patch
+        );
     }
 
     #[test]
     fn test_all_none_types() {
-        assert_eq!(determine_bump("chore: something"), BumpType::None);
-        assert_eq!(determine_bump("docs: something"), BumpType::None);
-        assert_eq!(determine_bump("ci: something"), BumpType::None);
-        assert_eq!(determine_bump("style: something"), BumpType::None);
-        assert_eq!(determine_bump("test: something"), BumpType::None);
-        assert_eq!(determine_bump("build: something"), BumpType::None);
+        assert_eq!(
+            determine_bump("chore: something", &Default::default()),
+            BumpType::None
+        );
+        assert_eq!(
+            determine_bump("docs: something", &Default::default()),
+            BumpType::None
+        );
+        assert_eq!(
+            determine_bump("ci: something", &Default::default()),
+            BumpType::None
+        );
+        assert_eq!(
+            determine_bump("style: something", &Default::default()),
+            BumpType::None
+        );
+        assert_eq!(
+            determine_bump("test: something", &Default::default()),
+            BumpType::None
+        );
+        assert_eq!(
+            determine_bump("build: something", &Default::default()),
+            BumpType::None
+        );
     }
 
     #[test]
     fn test_breaking_all_types() {
-        assert_eq!(determine_bump("fix!: breaking fix"), BumpType::Major);
-        assert_eq!(determine_bump("refactor!: breaking"), BumpType::Major);
-        assert_eq!(determine_bump("perf!: breaking"), BumpType::Major);
-        assert_eq!(determine_bump("chore!: breaking"), BumpType::Major);
-        assert_eq!(determine_bump("docs!: breaking"), BumpType::Major);
-        assert_eq!(determine_bump("style!: breaking"), BumpType::Major);
-        assert_eq!(determine_bump("test!: breaking"), BumpType::Major);
-        assert_eq!(determine_bump("build!: breaking"), BumpType::Major);
-        assert_eq!(determine_bump("ci!: breaking"), BumpType::Major);
+        assert_eq!(
+            determine_bump("fix!: breaking fix", &Default::default()),
+            BumpType::Major
+        );
+        assert_eq!(
+            determine_bump("refactor!: breaking", &Default::default()),
+            BumpType::Major
+        );
+        assert_eq!(
+            determine_bump("perf!: breaking", &Default::default()),
+            BumpType::Major
+        );
+        assert_eq!(
+            determine_bump("chore!: breaking", &Default::default()),
+            BumpType::Major
+        );
+        assert_eq!(
+            determine_bump("docs!: breaking", &Default::default()),
+            BumpType::Major
+        );
+        assert_eq!(
+            determine_bump("style!: breaking", &Default::default()),
+            BumpType::Major
+        );
+        assert_eq!(
+            determine_bump("test!: breaking", &Default::default()),
+            BumpType::Major
+        );
+        assert_eq!(
+            determine_bump("build!: breaking", &Default::default()),
+            BumpType::Major
+        );
+        assert_eq!(
+            determine_bump("ci!: breaking", &Default::default()),
+            BumpType::Major
+        );
     }
 
     #[test]
     fn test_breaking_with_scope() {
-        assert_eq!(determine_bump("chore(deps)!: breaking"), BumpType::Major);
-        assert_eq!(determine_bump("build(npm)!: breaking"), BumpType::Major);
+        assert_eq!(
+            determine_bump("chore(deps)!: breaking", &Default::default()),
+            BumpType::Major
+        );
+        assert_eq!(
+            determine_bump("build(npm)!: breaking", &Default::default()),
+            BumpType::Major
+        );
     }
 
     #[test]
     fn test_breaking_change_in_body_multiline() {
         let msg = "feat: add feature\n\nSome description.\n\nBREAKING CHANGE: removed old API";
-        assert_eq!(determine_bump(msg), BumpType::Major);
+        assert_eq!(determine_bump(msg, &Default::default()), BumpType::Major);
     }
 
     #[test]
@@ -348,49 +592,78 @@ mod tests {
 
     #[test]
     fn test_feat_not_in_middle_of_word() {
-        assert_eq!(determine_bump("featured something"), BumpType::None);
+        assert_eq!(
+            determine_bump("featured something", &Default::default()),
+            BumpType::None
+        );
     }
 
     #[test]
     fn test_deep_nested_scope() {
         assert_eq!(
-            determine_bump("feat(api/auth/jwt): add token"),
+            determine_bump("feat(api/auth/jwt): add token", &Default::default()),
             BumpType::Minor
         );
         assert_eq!(
-            determine_bump("fix(ui/modal): close on escape"),
+            determine_bump("fix(ui/modal): close on escape", &Default::default()),
             BumpType::Patch
         );
     }
 
+    /// All-caps stays unmatched under the default patterns; only the
+    /// Title-case variants were added by #247.
     #[test]
     fn test_uppercase_types_not_matched() {
-        assert_eq!(determine_bump("FEAT: add login"), BumpType::None);
-        assert_eq!(determine_bump("FIX: bug"), BumpType::None);
-        assert_eq!(determine_bump("Feat: add login"), BumpType::None);
+        assert_eq!(
+            determine_bump("FEAT: add login", &Default::default()),
+            BumpType::None
+        );
+        assert_eq!(
+            determine_bump("FIX: bug", &Default::default()),
+            BumpType::None
+        );
+        assert_eq!(
+            determine_bump("Feat: add login", &Default::default()),
+            BumpType::Minor
+        );
     }
 
     #[test]
     fn test_missing_colon() {
-        assert_eq!(determine_bump("feat add login"), BumpType::None);
-        assert_eq!(determine_bump("fix something"), BumpType::None);
+        assert_eq!(
+            determine_bump("feat add login", &Default::default()),
+            BumpType::None
+        );
+        assert_eq!(
+            determine_bump("fix something", &Default::default()),
+            BumpType::None
+        );
     }
 
     #[test]
     fn test_extra_space_after_type() {
-        assert_eq!(determine_bump("feat : add login"), BumpType::None);
+        assert_eq!(
+            determine_bump("feat : add login", &Default::default()),
+            BumpType::None
+        );
     }
 
     #[test]
     fn test_empty_scope() {
-        assert_eq!(determine_bump("feat(): add login"), BumpType::None);
-        assert_eq!(determine_bump("fix(): bug"), BumpType::None);
+        assert_eq!(
+            determine_bump("feat(): add login", &Default::default()),
+            BumpType::None
+        );
+        assert_eq!(
+            determine_bump("fix(): bug", &Default::default()),
+            BumpType::None
+        );
     }
 
     #[test]
     fn test_breaking_change_not_at_line_start() {
         let msg = "feat: something\n\nnot a BREAKING CHANGE here";
-        assert_eq!(determine_bump(msg), BumpType::Minor);
+        assert_eq!(determine_bump(msg, &Default::default()), BumpType::Minor);
     }
 
     #[test]
@@ -406,19 +679,19 @@ mod tests {
     #[test]
     fn test_multiline_body_feat_in_body_does_not_match() {
         let msg = "chore: update deps\n\nfeat: this is in the body";
-        assert_eq!(determine_bump(msg), BumpType::None);
+        assert_eq!(determine_bump(msg, &Default::default()), BumpType::None);
     }
 
     #[test]
     fn test_multiline_body_fix_in_body_does_not_match() {
         let msg = "chore: update deps\n\nfix: this is in the body";
-        assert_eq!(determine_bump(msg), BumpType::None);
+        assert_eq!(determine_bump(msg, &Default::default()), BumpType::None);
     }
 
     #[test]
     fn test_multiline_body_breaking_marker_in_body_does_not_match() {
         let msg = "chore: update deps\n\nfeat!: this is in the body";
-        assert_eq!(determine_bump(msg), BumpType::None);
+        assert_eq!(determine_bump(msg, &Default::default()), BumpType::None);
     }
 
     #[test]
@@ -470,10 +743,13 @@ mod tests {
 
     #[test]
     fn test_is_breaking() {
-        assert!(is_breaking("feat!: x"));
-        assert!(is_breaking("feat: x\n\nBREAKING CHANGE: y"));
-        assert!(!is_breaking("feat: x"));
-        assert!(!is_breaking("fix: y"));
+        assert!(is_breaking("feat!: x", &Default::default()));
+        assert!(is_breaking(
+            "feat: x\n\nBREAKING CHANGE: y",
+            &Default::default()
+        ));
+        assert!(!is_breaking("feat: x", &Default::default()));
+        assert!(!is_breaking("fix: y", &Default::default()));
     }
 
     #[test]
@@ -486,7 +762,11 @@ mod tests {
             "Breaking Change: gone",
         ] {
             let msg = format!("feat: x\n\n{footer}");
-            assert_eq!(determine_bump(&msg), BumpType::Major, "footer: {footer:?}");
+            assert_eq!(
+                determine_bump(&msg, &Default::default()),
+                BumpType::Major,
+                "footer: {footer:?}"
+            );
         }
     }
 
@@ -495,15 +775,18 @@ mod tests {
         // Missing the colon-space, plural, prose, and mid-line placement must
         // not trip the detector — we accept case variants, not any shape.
         assert_eq!(
-            determine_bump("feat: x\n\nBreaking change:nospace"),
+            determine_bump("feat: x\n\nBreaking change:nospace", &Default::default()),
             BumpType::Minor
         );
         assert_eq!(
-            determine_bump("chore: x\n\nbreaking changes: none"),
+            determine_bump("chore: x\n\nbreaking changes: none", &Default::default()),
             BumpType::None
         );
         assert_eq!(
-            determine_bump("feat: x\n\nthis is a breaking change: really"),
+            determine_bump(
+                "feat: x\n\nthis is a breaking change: really",
+                &Default::default()
+            ),
             BumpType::Minor
         );
     }
@@ -511,12 +794,18 @@ mod tests {
     #[test]
     fn bang_inside_scope_is_breaking() {
         assert_eq!(
-            determine_bump("feat(api!): remove endpoint"),
+            determine_bump("feat(api!): remove endpoint", &Default::default()),
             BumpType::Major
         );
-        assert_eq!(determine_bump("fix(db!): drop table"), BumpType::Major);
+        assert_eq!(
+            determine_bump("fix(db!): drop table", &Default::default()),
+            BumpType::Major
+        );
         // Bang not immediately before the closing paren is not a marker.
-        assert_eq!(determine_bump("feat(a!b): middle"), BumpType::Minor);
+        assert_eq!(
+            determine_bump("feat(a!b): middle", &Default::default()),
+            BumpType::Minor
+        );
     }
 
     #[test]
@@ -551,7 +840,7 @@ mod tests {
                 }
                 let message = std::fs::read_to_string(&path).unwrap();
                 assert_eq!(
-                    is_breaking(&message),
+                    is_breaking(&message, &Default::default()),
                     expect_breaking,
                     "fixture {:?} should classify breaking={expect_breaking}",
                     path.file_name().unwrap()

--- a/src/conventional_commits.rs
+++ b/src/conventional_commits.rs
@@ -88,10 +88,6 @@ pub fn classify_commit(message: &str, formats: &CommitFormats) -> CommitCategory
     let subject = parse_subject(message);
     let cs = formats.case_sensitive;
 
-    // Structural breaking markers are recognised whatever the configured
-    // patterns say. A `BREAKING CHANGE:` footer lives in the body, which
-    // subject globs cannot see, and `feat(api!):` puts the bang where a
-    // `*!:*` glob does not reach.
     if breaking_header_re().is_match(subject)
         || breaking_scope_bang_re().is_match(subject)
         || breaking_footer_re().is_match(message)
@@ -103,9 +99,6 @@ pub fn classify_commit(message: &str, formats: &CommitFormats) -> CommitCategory
         return CommitCategory::Feature;
     }
     if formats.patch.matches(subject, cs) {
-        // Patch splits into two changelog sections. The configured patterns
-        // only carry a bump level, so the section is resolved from the
-        // conventional prefix when there is one, and falls back to Fix.
         return if refactor_header_re().is_match(subject) {
             CommitCategory::Refactor
         } else {
@@ -117,10 +110,6 @@ pub fn classify_commit(message: &str, formats: &CommitFormats) -> CommitCategory
 
 static REFACTOR_RE: OnceLock<Regex> = OnceLock::new();
 
-// Case-insensitive and accepting `/` as well as `:` so the Title-case and
-// branch-style spellings the default patterns bump (`Refactor:`, `Refactor/`,
-// `refactor/`) reach the Refactoring section too, rather than being filed
-// under Bug Fixes because only the lowercase colon form was recognised.
 fn refactor_header_re() -> &'static Regex {
     REFACTOR_RE.get_or_init(|| Regex::new(r"(?i)^refactor(\([^()]*\))?[:/]").unwrap())
 }
@@ -185,10 +174,6 @@ mod tests {
     use super::*;
     use crate::config::{CATCH_ALL, PatternSet};
 
-    /// The permissive defaults are a deliberate behaviour change (#247), so
-    /// the documented escape hatch has to actually work: with strict
-    /// patterns every branch-style and capitalised variant goes back to
-    /// being ignored, and plain conventional commits are unaffected.
     #[test]
     fn strict_patterns_restore_the_pre_247_behaviour() {
         let strict = CommitFormats {
@@ -230,10 +215,6 @@ mod tests {
         );
     }
 
-    /// The structural breaking markers must survive whatever patterns are
-    /// configured — a `BREAKING CHANGE:` footer lives in the body, which a
-    /// subject glob cannot see, and `feat(api!):` puts the bang where
-    /// `*!:*` does not reach.
     #[test]
     fn structural_breaking_markers_survive_a_config_that_omits_them() {
         let no_major = CommitFormats {
@@ -303,8 +284,6 @@ mod tests {
         assert_eq!(determine_bump("Fix(db): leak", &f), BumpType::Patch);
     }
 
-    /// Configured patterns carry a bump level, not a changelog section, so
-    /// a patch-level match still has to land in the right section.
     #[test]
     fn patch_level_splits_into_fix_and_refactor_sections() {
         let d = CommitFormats::default();
@@ -614,8 +593,6 @@ mod tests {
         );
     }
 
-    /// All-caps stays unmatched under the default patterns; only the
-    /// Title-case variants were added by #247.
     #[test]
     fn test_uppercase_types_not_matched() {
         assert_eq!(

--- a/src/hooks/context.rs
+++ b/src/hooks/context.rs
@@ -14,14 +14,14 @@ pub struct HookCommit {
 }
 
 impl HookCommit {
-    pub fn from_commit(hash: &str, message: &str) -> Self {
+    pub fn from_commit(hash: &str, message: &str, formats: &crate::config::CommitFormats) -> Self {
         let header = crate::conventional_commits::parse_header(message);
         HookCommit {
             hash: hash.to_string(),
             message: crate::conventional_commits::parse_subject(message).to_string(),
             commit_type: header.as_ref().map(|h| h.commit_type.to_string()),
             scope: header.as_ref().and_then(|h| h.scope.map(str::to_string)),
-            breaking: crate::conventional_commits::is_breaking(message),
+            breaking: crate::conventional_commits::is_breaking(message, formats),
         }
     }
 }
@@ -65,23 +65,25 @@ mod tests {
 
     #[test]
     fn hook_commit_extracts_type_scope_and_breaking() {
-        let c = HookCommit::from_commit("abc1234", "feat(api): add endpoint");
+        let c = HookCommit::from_commit("abc1234", "feat(api): add endpoint", &Default::default());
         assert_eq!(c.hash, "abc1234");
         assert_eq!(c.message, "feat(api): add endpoint");
         assert_eq!(c.commit_type.as_deref(), Some("feat"));
         assert_eq!(c.scope.as_deref(), Some("api"));
         assert!(!c.breaking);
 
-        let breaking = HookCommit::from_commit("d", "feat!: drop the old flag");
+        let breaking =
+            HookCommit::from_commit("d", "feat!: drop the old flag", &Default::default());
         assert!(breaking.breaking);
         assert_eq!(breaking.scope, None);
 
-        let footer = HookCommit::from_commit("e", "fix: x\n\nBREAKING CHANGE: gone");
+        let footer =
+            HookCommit::from_commit("e", "fix: x\n\nBREAKING CHANGE: gone", &Default::default());
         assert!(footer.breaking);
         // The serialized message is the subject only, not the footer.
         assert_eq!(footer.message, "fix: x");
 
-        let plain = HookCommit::from_commit("f", "just a plain message");
+        let plain = HookCommit::from_commit("f", "just a plain message", &Default::default());
         assert_eq!(plain.commit_type, None);
         assert_eq!(plain.scope, None);
         assert!(!plain.breaking);
@@ -89,7 +91,12 @@ mod tests {
 
     #[test]
     fn hook_commit_json_omits_absent_type_and_scope() {
-        let json = serde_json::to_string(&HookCommit::from_commit("h", "chore: bump")).unwrap();
+        let json = serde_json::to_string(&HookCommit::from_commit(
+            "h",
+            "chore: bump",
+            &Default::default(),
+        ))
+        .unwrap();
         // `type` present (chore), `scope` absent, `breaking` always present.
         assert!(json.contains(r#""type":"chore""#));
         assert!(!json.contains("scope"));

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -342,6 +342,7 @@ pub(super) fn run_release_logic(
 
         if dry_run && verbose && !quiet {
             let changelog_render = ChangelogRender {
+                formats: Some(&config.workspace.commit_formats),
                 config: config.workspace.changelog.as_ref(),
                 forge_base: forge_base.clone(),
                 last_tag: last_tag.clone(),
@@ -422,7 +423,7 @@ pub(super) fn run_release_logic(
 
         let hook_commits: Vec<HookCommit> = commits
             .iter()
-            .map(|c| HookCommit::from_commit(&c.hash, &c.message))
+            .map(|c| HookCommit::from_commit(&c.hash, &c.message, &config.workspace.commit_formats))
             .collect();
         let hook_bumped_files: Vec<HookFile> = pkg
             .versioned_files
@@ -523,6 +524,7 @@ pub(super) fn run_release_logic(
             }
 
             let changelog_render = ChangelogRender {
+                formats: Some(&config.workspace.commit_formats),
                 config: config.workspace.changelog.as_ref(),
                 forge_base: forge_base.clone(),
                 last_tag: last_tag.clone(),

--- a/src/monorepo/run/plan.rs
+++ b/src/monorepo/run/plan.rs
@@ -290,7 +290,7 @@ pub(super) fn compute_plan(
 
         let bump = commits
             .iter()
-            .map(|c| determine_bump(&c.message))
+            .map(|c| determine_bump(&c.message, &config.workspace.commit_formats))
             .max()
             .unwrap_or(BumpType::None);
 

--- a/src/monorepo/run/why/mod.rs
+++ b/src/monorepo/run/why/mod.rs
@@ -206,7 +206,7 @@ fn explain(
         commits_for_package(repo, pkg, &inputs)?
             .into_iter()
             .map(|c| CommitReport {
-                bump: determine_bump(&c.message).to_string(),
+                bump: determine_bump(&c.message, &config.workspace.commit_formats).to_string(),
                 subject: c.message.lines().next().unwrap_or_default().to_string(),
                 hash: c.hash,
             })

--- a/src/status.rs
+++ b/src/status.rs
@@ -73,7 +73,7 @@ pub fn run(
         )?;
         let has_changes = commits
             .iter()
-            .map(|c| determine_bump(&c.message))
+            .map(|c| determine_bump(&c.message, &config.workspace.commit_formats))
             .any(|b| b != BumpType::None);
 
         statuses.push(PackageStatus {

--- a/src/version_diff.rs
+++ b/src/version_diff.rs
@@ -89,7 +89,6 @@ pub fn run(spec: &[String], json: bool, config_path: Option<&Path>) -> Result<()
 /// only touched other packages. Keeping just the ones that touched this package
 /// makes the commit list, the breaking-change list and the rendered changelog
 /// match what `ferrflow release` would produce for it (#752).
-///
 /// A commit whose changed files can't be read is kept rather than dropped —
 /// over-reporting is recoverable, silently hiding a commit is not.
 fn commit_touches_package(

--- a/src/version_diff.rs
+++ b/src/version_diff.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use std::path::Path;
 
 use crate::changelog::{ChangelogRender, build_section_with};
+use crate::config::CommitFormats;
 use crate::config::{Config, PackageConfig, WorkspaceConfig};
 use crate::conventional_commits::{
     BumpType, determine_bump, is_breaking, parse_header, parse_subject,
@@ -43,7 +44,7 @@ pub fn run(spec: &[String], json: bool, config_path: Option<&Path>) -> Result<()
 
     let overall = commits
         .iter()
-        .map(|c| determine_bump(&c.message))
+        .map(|c| determine_bump(&c.message, &config.workspace.commit_formats))
         .max()
         .unwrap_or(BumpType::None);
 
@@ -59,16 +60,27 @@ pub fn run(spec: &[String], json: bool, config_path: Option<&Path>) -> Result<()
     let to_version = to_ref.trim_start_matches('v').to_string();
     let render = ChangelogRender {
         config: config.workspace.changelog.as_ref(),
+        formats: Some(&config.workspace.commit_formats),
         forge_base,
         last_tag: Some(from_tag.clone()),
         new_tag: Some(to_tag.clone()),
     };
     let changelog = build_section_with(&to_version, &commits, &render);
 
+    let report = DiffReport {
+        pkg,
+        from: from_ref,
+        to: to_ref,
+        overall,
+        commits: &commits,
+        files: &files,
+        changelog: &changelog,
+        formats: &config.workspace.commit_formats,
+    };
     if json {
-        print_json(pkg, from_ref, to_ref, overall, &commits, &files, &changelog)?;
+        print_json(&report)?;
     } else {
-        print_human(pkg, from_ref, to_ref, overall, &commits, &files, &changelog);
+        print_human(&report);
     }
     Ok(())
 }
@@ -182,6 +194,17 @@ fn resolve_endpoint(
     .error_code(error_code::DIFF_ENDPOINT_UNRESOLVED)
 }
 
+struct DiffReport<'a> {
+    pkg: &'a PackageConfig,
+    from: &'a str,
+    to: &'a str,
+    overall: BumpType,
+    commits: &'a [crate::git::GitLog],
+    files: &'a [String],
+    changelog: &'a str,
+    formats: &'a CommitFormats,
+}
+
 fn bump_label(bump: BumpType) -> ColoredString {
     match bump {
         BumpType::Major => "major".red().bold(),
@@ -191,15 +214,18 @@ fn bump_label(bump: BumpType) -> ColoredString {
     }
 }
 
-fn print_human(
-    pkg: &PackageConfig,
-    from: &str,
-    to: &str,
-    overall: BumpType,
-    commits: &[crate::git::GitLog],
-    files: &[String],
-    changelog: &str,
-) {
+fn print_human(r: &DiffReport<'_>) {
+    let DiffReport {
+        pkg,
+        from,
+        to,
+        overall,
+        commits,
+        files,
+        changelog,
+        formats,
+    } = *r;
+
     println!(
         "{}  {} → {}  ({})\n",
         pkg.name.bold(),
@@ -215,14 +241,16 @@ fn print_human(
     for c in commits {
         println!(
             "  {:<5}  {}  {}",
-            bump_label(determine_bump(&c.message)),
+            bump_label(determine_bump(&c.message, formats)),
             c.hash.dimmed(),
             parse_subject(&c.message)
         );
     }
 
-    let breaking: Vec<&crate::git::GitLog> =
-        commits.iter().filter(|c| is_breaking(&c.message)).collect();
+    let breaking: Vec<&crate::git::GitLog> = commits
+        .iter()
+        .filter(|c| is_breaking(&c.message, formats))
+        .collect();
     if !breaking.is_empty() {
         println!(
             "\n{}",
@@ -276,15 +304,18 @@ struct DiffJson<'a> {
     changelog: &'a str,
 }
 
-fn print_json(
-    pkg: &PackageConfig,
-    from: &str,
-    to: &str,
-    overall: BumpType,
-    commits: &[crate::git::GitLog],
-    files: &[String],
-    changelog: &str,
-) -> Result<()> {
+fn print_json(r: &DiffReport<'_>) -> Result<()> {
+    let DiffReport {
+        pkg,
+        from,
+        to,
+        overall,
+        commits,
+        files,
+        changelog,
+        formats,
+    } = *r;
+
     let commit_json: Vec<CommitJson> = commits
         .iter()
         .map(|c| {
@@ -294,14 +325,14 @@ fn print_json(
                 subject: parse_subject(&c.message).to_string(),
                 commit_type: header.as_ref().map(|h| h.commit_type.to_string()),
                 scope: header.as_ref().and_then(|h| h.scope.map(str::to_string)),
-                breaking: is_breaking(&c.message),
-                bump: determine_bump(&c.message).to_string(),
+                breaking: is_breaking(&c.message, formats),
+                bump: determine_bump(&c.message, formats).to_string(),
             }
         })
         .collect();
     let breaking: Vec<String> = commits
         .iter()
-        .filter(|c| is_breaking(&c.message))
+        .filter(|c| is_breaking(&c.message, formats))
         .map(|c| parse_subject(&c.message).to_string())
         .collect();
 


### PR DESCRIPTION
Closes #247.

Commit classification was hard-coded to strict lowercase conventional prefixes. `workspace.commitFormats` now lets a team declare which subjects map to which bump level:

```json
{
  "workspace": {
    "commitFormats": {
      "minor": ["feat:*", "feat(?*):*", "Feat/*"],
      "patch": "all",
      "major": "Breaking/*",
      "caseSensitive": false
    }
  }
}
```

Each level takes a string, a list, or `"all"`. Resolution is major → minor → patch, first match wins. `determine_bump` / `classify_commit` / `is_breaking` now take `&CommitFormats`, threaded through all 8 call sites (changelog, plan, status, why, version_diff, hooks, bench, wasm).

Defaults are permissive as the issue specifies — `Feat/`, `Fix:`, `Refactor/`, `feature:` and friends now trigger releases where they were previously ignored. Hence the `!`.

## Three deviations from the issue's spec, all deliberate

**1. Not `glob_match`.** The issue asked for the crate already used for branch matching. That crate has path semantics — `*` does not cross `/` — and commit subjects are prose full of slashes. Measured:

```
fix:*        vs  fix: update src/foo.rs        => false
feat(*):*    vs  feat(api/auth/jwt): add token => false
feat(**):**  vs  feat(api/auth/jwt): add token => false
```

`fix:*` failing on any subject that mentions a file path is not a viable default, and `**` does not rescue it inside parentheses. Replaced with a ~25-line `wildcard_match` supporting `*` and `?` with no separator semantics. Same syntax users expect, correct semantics for prose. There is an existing test — `test_deep_nested_scope` — that would have caught this.

**2. Default `major` is empty, not `["*!:*", "BREAKING CHANGE*"]`.** `*!:*` matches any subject containing `!:` anywhere, so it turns

```
fix: handle the !: token in the parser
```

into a major release. `build_section_does_not_misclassify_prose` exists specifically to guard that case. All real breaking markers (`feat!:`, `fix(api)!:`, the `feat(api!):` typo, a `BREAKING CHANGE:` footer) are detected **structurally in `classify_commit` regardless of configuration**, so the glob added false positives and no coverage. `BREAKING CHANGE*` would also have matched the plural `BREAKING CHANGES:`, which the footer regex deliberately excludes. The level stays configurable for teams whose convention is something else (`"major": "Breaking/*"`).

**3. `feat(?*):*` rather than `feat(*):*`.** `*` matches empty, so `feat(): x` would have started bumping. `?*` requires at least one character, preserving what the old `\(.+\)` regex enforced and what `test_empty_scope` asserts.

## Changelog integration

The issue flagged that `changelog.rs` shares this parsing. Configured patterns carry a bump *level*, but the changelog needs a *section* — and patch splits into Fix and Refactor. Resolved by deriving the section from the conventional prefix when there is one and falling back to Fix otherwise, so `refactor:` keeps its own section while `Fix/branch-style` lands under Bug Fixes. `#525`'s invariant — bump and changelog never disagree about whether a commit counts — is preserved.

## Real-world impact

Ran the new defaults over this repo's own 712-commit history: **6 commits** would newly trigger a release, all early branch-style PR merge titles:

```
Feat/tag prefix (#80)
Feat/json json5 config (#63)
Feat/status command (#41)
Feat/GitHub action (#24)
...
```

All long since released, so nothing changes for FerrFlow itself. It does confirm the feature does what the issue wanted on real data.

## The risk worth stating

For a repo with non-conventional history, this default causes releases that previously would not have happened. Since releases publish packages, that is not reversible. The documented escape hatch is a strict `commitFormats` block, and `strict_patterns_restore_the_pre_247_behaviour` asserts it reproduces the old behaviour exactly — including that `feat!:` and `BREAKING CHANGE:` footers still work under it.

## wasm

`determine_bump(message)` gained an optional second parameter and now returns `Result`. Existing JS calls keep working (wasm_bindgen makes a trailing `Option` optional), but the return type changed, so the playground's call site should be checked.

## Tests

1950 pass, clippy clean, `ferrflow-wasm` builds. New coverage: pattern shapes (string / list / `"all"`), case sensitivity both spellings, per-level default fallback, priority ordering, structural markers surviving a config that omits them, the strict-preset regression, and the Fix/Refactor section split.

Schema updated. The ferrflow.com copy and the docs ship in a FerrFlow-Cloud PR.