### PR TITLE
docs(readme): pin the action example to v7

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ steps:
   - uses: actions/checkout@v6
     with:
       fetch-depth: 0
-  - uses: FerrLabs/FerrFlow@v6
+  - uses: FerrLabs/FerrFlow@v7
     with:
       bot: true
 ```


### PR DESCRIPTION
The README's quick-start still shows `FerrLabs/FerrFlow@v6`, but v7.0.0 shipped and `v7` is the current floating major tag. Anyone copying the snippet lands on a tag that no longer moves.

The pin was set to `@v6` during the MIT relicence (#813), which cut v6 — so it has been one major behind since `feat(commits)!` merged and cut v7.