### PR TITLE
ci(pr-title): skip the title check on synchronize

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,6 +10,13 @@ permissions:
 jobs:
   conventional:
     name: Conventional commits
+    # Un push sur la branche de la PR ne peut pas changer son titre : revalider
+    # sur `synchronize` recalcule la meme reponse, et Renovate rebase en
+    # permanence. Le job est saute plutot que le declencheur retire : le
+    # workflow produit quand meme un check run sur le nouveau SHA de tete, ce
+    # dont un status check requis a besoin, et un job saute n'occupe aucun
+    # runner. Voir FerrLabs/.github#252.
+    if: github.event.action != 'synchronize'
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6


### PR DESCRIPTION
Refs FerrLabs/.github#252

`synchronize` fires on every push to a PR branch, so every Renovate rebase reruns the title check. A push cannot change a title, so each run recomputes the same answer and spins a runner to do it. Across the org, the vast majority of runs of this workflow are on `renovate/*` branches; on FerrGrowth-Cloud one long-lived branch accounted for 24 of the last 100.

```yaml
jobs:
  conventional:
    name: Conventional commits
    if: github.event.action != 'synchronize'
```

**Why skip the job rather than drop `synchronize` from the trigger**

`Conventional commits` is a required status check here. Required checks are evaluated per head SHA, so if the workflow does not run after a rebase the new SHA has no check and the PR is blocked until someone edits the title or reopens it.

A job skipped through `if:` still produces a check run, and it is never scheduled onto a runner. Verified on a probe PR in `FerrLabs/.github` before this sweep: after a `synchronize`, the new head SHA carries

```
Conventional commits | status=completed conclusion=skipped
```

so the check exists on the SHA the ruleset evaluates, and no pod started.

Same change landed in `FerrLabs/.github` and in `workflow-templates/pr-title.yml` (FerrLabs/.github#253).
