### PR TITLE
fix(formats): resolve the cargo crate name and retry lockfile updates online

### DIFF
--- a/src/formats/lockfiles.rs
+++ b/src/formats/lockfiles.rs
@@ -104,11 +104,7 @@ pub enum UpdateOutcome {
     Failed { program: String, detail: String },
 }
 
-pub fn update_for_manifest(
-    repo_root: &Path,
-    manifest_rel: &str,
-    package_name: &str,
-) -> anyhow::Result<UpdateOutcome> {
+pub fn update_for_manifest(repo_root: &Path, manifest_rel: &str) -> anyhow::Result<UpdateOutcome> {
     let manifest_path = join_within_repo(repo_root, manifest_rel)?;
     let filename = match manifest_path.file_name().and_then(|n| n.to_str()) {
         Some(name) => name,
@@ -125,15 +121,29 @@ pub fn update_for_manifest(
         else {
             continue;
         };
+        let per_package = match lockfile.update_kind {
+            UpdateKind::PerPackage => match manifest_package_name(&manifest_path) {
+                Some(name) => Some(name),
+                None => return Ok(UpdateOutcome::UnsupportedManifest),
+            },
+            UpdateKind::Whole => None,
+        };
         return Ok(run_update(
             repo_root,
             &lockfile_path,
             lockfile,
-            package_name,
+            per_package.as_deref(),
         ));
     }
 
     Ok(UpdateOutcome::NoLockfile)
+}
+
+fn manifest_package_name(manifest_path: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(manifest_path).ok()?;
+    let doc = content.parse::<toml_edit::DocumentMut>().ok()?;
+    let name = doc.get("package")?.get("name")?.as_str()?;
+    Some(name.to_string())
 }
 
 fn locate_lockfile(repo_root: &Path, manifest_dir: &Path, filename: &str) -> Option<PathBuf> {
@@ -150,22 +160,34 @@ fn locate_lockfile(repo_root: &Path, manifest_dir: &Path, filename: &str) -> Opt
     }
 }
 
+fn update_args(lockfile: &Lockfile, per_package: Option<&str>, offline: bool) -> Vec<String> {
+    let mut args: Vec<String> = lockfile.base_args.iter().map(|a| a.to_string()).collect();
+    if let Some(name) = per_package {
+        args.push("-p".to_string());
+        args.push(name.to_string());
+        if offline {
+            args.push("--offline".to_string());
+        }
+    }
+    args
+}
+
 fn run_update(
     repo_root: &Path,
     lockfile_path: &Path,
     lockfile: &Lockfile,
-    package_name: &str,
+    per_package: Option<&str>,
 ) -> UpdateOutcome {
     let lockfile_dir = lockfile_path.parent().unwrap_or(repo_root);
 
-    let mut cmd = std::process::Command::new(lockfile.program);
-    cmd.current_dir(lockfile_dir);
-    cmd.args(lockfile.base_args);
-    if let UpdateKind::PerPackage = lockfile.update_kind {
-        cmd.arg("-p").arg(package_name).arg("--offline");
-    }
+    let run = |offline: bool| {
+        std::process::Command::new(lockfile.program)
+            .current_dir(lockfile_dir)
+            .args(update_args(lockfile, per_package, offline))
+            .output()
+    };
 
-    let output = match cmd.output() {
+    let mut output = match run(per_package.is_some()) {
         Ok(output) => output,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
             return UpdateOutcome::NotOnPath {
@@ -179,6 +201,13 @@ fn run_update(
             };
         }
     };
+
+    if !output.status.success()
+        && per_package.is_some()
+        && let Ok(retry) = run(false)
+    {
+        output = retry;
+    }
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -222,11 +251,72 @@ mod tests {
         assert_eq!(Manifest::from_manifest_filename("Chart.yaml"), None);
     }
 
+    fn cargo() -> Lockfile {
+        Manifest::CargoToml.lockfiles()[0]
+    }
+
+    #[test]
+    fn the_retry_drops_offline_so_a_cold_registry_cache_can_be_filled() {
+        let first = update_args(&cargo(), Some("ferrgames-discord"), true);
+        assert_eq!(first, ["update", "-p", "ferrgames-discord", "--offline"]);
+
+        let retry = update_args(&cargo(), Some("ferrgames-discord"), false);
+        assert_eq!(
+            retry,
+            ["update", "-p", "ferrgames-discord"],
+            "the release job checks out and installs the toolchain but never builds, \
+             so the registry cache is empty and --offline cannot resolve dependencies"
+        );
+    }
+
+    #[test]
+    fn whole_lockfile_updates_never_get_offline_or_a_package() {
+        let args = update_args(&cargo(), None, true);
+        assert_eq!(args, ["update"]);
+    }
+
+    #[test]
+    fn cargo_updates_the_crate_name_not_the_ferrflow_package_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let member = root.join("crates").join("api");
+        std::fs::create_dir_all(member.join("src")).unwrap();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[workspace]\nresolver = \"3\"\nmembers = [\"crates/api\"]\n",
+        )
+        .unwrap();
+        std::fs::write(
+            member.join("Cargo.toml"),
+            "[package]\nname = \"ferrgames-api\"\nversion = \"2.0.0\"\nedition = \"2024\"\n",
+        )
+        .unwrap();
+        std::fs::write(member.join("src").join("lib.rs"), "").unwrap();
+        std::fs::write(
+            root.join("Cargo.lock"),
+            "version = 4\n\n[[package]]\nname = \"ferrgames-api\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+
+        let outcome = update_for_manifest(root, "crates/api/Cargo.toml").unwrap();
+
+        assert_eq!(
+            outcome,
+            UpdateOutcome::Updated {
+                lockfile_rel: "Cargo.lock".to_string()
+            },
+            "the ferrflow package is named `api` but the crate is `ferrgames-api`; \
+             passing the ferrflow name to `cargo update -p` fails and leaves the lock stale"
+        );
+        let lock = std::fs::read_to_string(root.join("Cargo.lock")).unwrap();
+        assert!(lock.contains("2.0.0"), "lockfile not bumped: {lock}");
+    }
+
     #[test]
     fn unsupported_manifest_is_a_noop() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("Chart.yaml"), "version: 1.0.0\n").unwrap();
-        let outcome = update_for_manifest(dir.path(), "Chart.yaml", "app").unwrap();
+        let outcome = update_for_manifest(dir.path(), "Chart.yaml").unwrap();
         assert_eq!(outcome, UpdateOutcome::UnsupportedManifest);
     }
 
@@ -238,7 +328,7 @@ mod tests {
             "[package]\nname = \"app\"\nversion = \"1.0.0\"\n",
         )
         .unwrap();
-        let outcome = update_for_manifest(dir.path(), "Cargo.toml", "app").unwrap();
+        let outcome = update_for_manifest(dir.path(), "Cargo.toml").unwrap();
         assert_eq!(outcome, UpdateOutcome::NoLockfile);
     }
 

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -970,7 +970,7 @@ pub(super) fn refresh_lockfiles(
 
     let mut handled: HashSet<String> = HashSet::new();
     for vf in &pkg.versioned_files {
-        let outcome = match lockfiles::update_for_manifest(root, &vf.path, &pkg.name) {
+        let outcome = match lockfiles::update_for_manifest(root, &vf.path) {
             Ok(outcome) => outcome,
             Err(err) => {
                 tracing::warn!(package = %pkg.name, manifest = %vf.path, error = %err, "lockfile update skipped");

--- a/src/monorepo/tests.rs
+++ b/src/monorepo/tests.rs
@@ -878,7 +878,7 @@ mod lockfile_flow {
         .unwrap();
         std::fs::write(dir.path().join("mix.lock"), "%{}\n").unwrap();
 
-        let outcome = lockfiles::update_for_manifest(dir.path(), "mix.exs", "app").unwrap();
+        let outcome = lockfiles::update_for_manifest(dir.path(), "mix.exs").unwrap();
         if program_on_path("mix") {
             assert!(matches!(
                 outcome,


### PR DESCRIPTION
Closes #843.

`updateLockfiles: true` was leaving `Cargo.lock` at the previous version. The failure is a `tracing::warn!`, so the release still reported green and the drift only showed up later as a dirty tree.

Two independent causes, both reproduced before writing any code.

**The name passed to `cargo update -p` was the FerrFlow package name**

`refresh_lockfiles` forwarded `pkg.name`. That is the name in `ferrflow.json`, not the cargo crate name — in FerrGames-Cloud the package is `api` and the crate is `ferrgames-api`, so cargo answered `package ID specification 'api' did not match any packages`.

The caller cannot know the crate name, so it no longer supplies one: `update_for_manifest` reads `[package] name` from the manifest it is about to version. The `package_name` parameter is gone rather than left to be passed wrongly again.

**`--offline` cannot resolve on a cold registry cache**

That explains FerrGames-Discord, where the two names *do* match and the lock drifted anyway. The release job checks out and installs the toolchain but never builds, so `~/.cargo/registry` is empty and `--offline` fails on the first dependency it cannot find. It is intermittent by nature — `v2026.8.1` landed on a warm self-hosted runner and updated its lock, `v2026.8.2` and `v2026.8.3` did not.

`--offline` is still the first attempt: it is faster and it works with no network and no private-registry credentials, which is the local `ferrflow release` case. On failure it retries once without it.

**Tests**

- `cargo_updates_the_crate_name_not_the_ferrflow_package_name` builds a workspace whose member crate is named differently from its directory and asserts the lock is bumped. Verified it fails on the old code with the exact production error.
- The `--offline` retry needed a seam, so argument construction moved into `update_args`, which two tests pin directly.

Symptom-only lock syncs already merged: FerrGames-Cloud#1001, FerrGames-Discord#90. Both repos will stay in sync on their own once this ships.
