### PR TITLE
ci(pr-title): call the shared reusable workflow

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,40 +1,23 @@
 name: PR title
 
+# `pull_request_target` est délibéré et sûr ici : le job appelé ne fait aucun
+# `checkout`, n'exécute donc rien qui vienne de la PR, et ne lit que le titre
+# dans la charge utile de l'événement. C'est aussi ce qui empêche une PR de fork
+# d'affaiblir sa propre validation en modifiant ce fichier, ce que
+# `pull_request` autoriserait.
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [opened, edited, reopened, synchronize]
 
+# Obligatoire : un workflow appelé ne peut que restreindre ce que l'appelant lui
+# donne. Sans ce bloc, le run finit en `startup_failure` et ne produit aucun
+# check run.
 permissions:
   pull-requests: read
 
 jobs:
-  conventional:
-    name: Conventional commits
-    # Un push sur la branche de la PR ne peut pas changer son titre : revalider
-    # sur `synchronize` recalcule la meme reponse, et Renovate rebase en
-    # permanence. Le job est saute plutot que le declencheur retire : le
-    # workflow produit quand meme un check run sur le nouveau SHA de tete, ce
-    # dont un status check requis a besoin, et un job saute n'occupe aucun
-    # runner. Voir FerrLabs/.github#252.
-    if: github.event.action != 'synchronize'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          types: |
-            feat
-            fix
-            refactor
-            docs
-            chore
-            style
-            test
-            perf
-            ci
-            build
-          requireScope: false
-          subjectPattern: ^[A-Za-z].+$
-          subjectPatternError: |
-            Subject "{subject}" must start with an uppercase or lowercase letter and not be empty.
+  title:
+    name: PR title
+    uses: FerrLabs/.github/.github/workflows/reusable-pr-title.yml@64d3151ca65e6ec163a32db9497e66b1381fd20f # main
+    with:
+      runner: ubuntu-latest


### PR DESCRIPTION
Refs FerrLabs/.github#252

Replaces the per-repo copy of the title check with a call to the shared reusable added in FerrLabs/.github#255.

```yaml
permissions:
  pull-requests: read

jobs:
  title:
    name: PR title
    uses: FerrLabs/.github/.github/workflows/reusable-pr-title.yml@64d3151 # main
```

**The check context changes**

A `uses:` job reports as `<caller job name> / <reusable job name>`, so `Conventional commits` becomes `PR title / Conventional commits`. Measured on the Fixtures pilot, not assumed. The ruleset for this repo is updated to require the new context in the same window as this merge.

**The `permissions` block is not optional**

A called workflow can only narrow what the caller granted. Without it the run ends in `startup_failure`:

```
The workflow is requesting 'pull-requests: read', but is only allowed 'pull-requests: none'.
```

and a startup failure produces no check run at all, which on a repo with a required check is a silent block on every PR. That is what the pilot caught.

**Why bother**

The `if: github.event.action != 'synchronize'` we shipped last week took 20 PRs. The next change to this logic takes one.
