### PR TITLE
fix(ci): grant the sonarqube scan job pull-requests write

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -39,6 +39,12 @@ jobs:
 
   scan:
     needs: version
+    # The reusable workflow declares `pull-requests: write` (it posts the diff
+    # against the base project). The job would otherwise inherit the read-only
+    # workflow-level block above, and GitHub rejects the run before it starts.
+    permissions:
+      contents: read
+      pull-requests: write
     uses: FerrLabs/.github/.github/workflows/reusable-sonarqube-scan.yml@5aec567fa6bfb149af54fc1819b1603bb7205c28 # main
     with:
       runner: ubuntu-latest


### PR DESCRIPTION
Closes #846.

The SonarQube workflow has never produced an analysis — the last 40 runs are all `startup_failure`, across six different pinned `FerrLabs/.github` digests, so it is not the digest.

`reusable-sonarqube-scan.yml` declares `pull-requests: write`. Our `scan` job declared no permissions of its own, so it inherited the workflow-level `contents: read`, which sets every other scope to `none`, and GitHub rejects a called workflow that asks for more than the caller grants. Nothing starts, so there is no log — which is why this reads as a flake.

FerrGames-Cloud and Infra call the same reusable workflow and pass; the only difference is the job-level grant this PR adds.

Worth knowing: `sonar.ferrlabs.com` has had no `ferrflow` analysis at all — no quality gate, no coverage, no new-code tracking. The first green run will seed the project from scratch, so expect a large initial issue count that reflects history rather than this change.