### PR TITLE
fix(bot): retry the token exchange on transient failures

### DIFF
--- a/src/bot_token.rs
+++ b/src/bot_token.rs
@@ -98,24 +98,39 @@ impl BotTokenExchange {
         }
 
         let payload = serde_json::json!({ "token": oidc_body.value });
-        let mut response = match agent
-            .post(&self.endpoint)
-            .header("Content-Type", "application/json")
-            .header("Accept", "application/json")
-            .header(
-                "User-Agent",
-                concat!("ferrflow/", env!("CARGO_PKG_VERSION")),
-            )
-            .send_json(payload)
-        {
-            Ok(r) => r,
-            Err(ureq::Error::StatusCode(code)) => {
-                return Err(map_status_error(code));
-            }
-            Err(err) => {
-                bail!(
-                    "FerrFlow hosted bot unavailable: {err}. Check https://status.ferrlabs.com or fall back to a PAT via `token:`."
-                );
+        let mut attempt = 0u32;
+        let mut response = loop {
+            attempt += 1;
+            let outcome = agent
+                .post(&self.endpoint)
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json")
+                .header(
+                    "User-Agent",
+                    concat!("ferrflow/", env!("CARGO_PKG_VERSION")),
+                )
+                .send_json(payload.clone());
+
+            match outcome {
+                Ok(r) => break r,
+                Err(err) => {
+                    let retryable = is_retryable(&err);
+                    if retryable && attempt < MAX_EXCHANGE_ATTEMPTS {
+                        let backoff = backoff_for(attempt);
+                        tracing::warn!(
+                            "FerrFlow bot token exchange failed ({err}); retrying in {}s (attempt {attempt}/{MAX_EXCHANGE_ATTEMPTS})",
+                            backoff.as_secs()
+                        );
+                        std::thread::sleep(backoff);
+                        continue;
+                    }
+                    return Err(match err {
+                        ureq::Error::StatusCode(code) => map_status_error(code),
+                        other => anyhow::anyhow!(
+                            "FerrFlow hosted bot unavailable: {other}. Check https://status.ferrlabs.com or fall back to a PAT via `token:`."
+                        ),
+                    });
+                }
             }
         };
 
@@ -133,6 +148,24 @@ impl BotTokenExchange {
             expires_at: body.expires_at,
             repository: body.repository,
         })
+    }
+}
+
+const MAX_EXCHANGE_ATTEMPTS: u32 = 3;
+const EXCHANGE_BACKOFF_SECS: [u64; 2] = [2, 6];
+
+fn backoff_for(attempt: u32) -> std::time::Duration {
+    let secs = EXCHANGE_BACKOFF_SECS
+        .get((attempt - 1) as usize)
+        .copied()
+        .unwrap_or(6);
+    std::time::Duration::from_secs(secs)
+}
+
+fn is_retryable(err: &ureq::Error) -> bool {
+    match err {
+        ureq::Error::StatusCode(code) => matches!(code, 429 | 500..=599),
+        _ => true,
     }
 }
 
@@ -360,6 +393,37 @@ mod tests {
                 );
             },
         );
+    }
+
+    #[test]
+    fn retries_transport_errors_and_server_faults() {
+        assert!(is_retryable(&ureq::Error::StatusCode(502)));
+        assert!(is_retryable(&ureq::Error::StatusCode(503)));
+        assert!(is_retryable(&ureq::Error::StatusCode(500)));
+        assert!(is_retryable(&ureq::Error::StatusCode(429)));
+    }
+
+    #[test]
+    fn does_not_retry_what_a_retry_cannot_fix() {
+        assert!(!is_retryable(&ureq::Error::StatusCode(401)));
+        assert!(!is_retryable(&ureq::Error::StatusCode(404)));
+        assert!(!is_retryable(&ureq::Error::StatusCode(400)));
+    }
+
+    #[test]
+    fn backoff_grows_then_plateaus() {
+        assert_eq!(backoff_for(1).as_secs(), 2);
+        assert_eq!(backoff_for(2).as_secs(), 6);
+        assert_eq!(backoff_for(9).as_secs(), 6);
+    }
+
+    #[test]
+    fn a_502_run_is_bounded_by_the_attempt_cap() {
+        let total: u64 = (1..MAX_EXCHANGE_ATTEMPTS)
+            .map(|a| backoff_for(a).as_secs())
+            .sum();
+        assert_eq!(MAX_EXCHANGE_ATTEMPTS, 3);
+        assert_eq!(total, 8, "a fully-failing exchange must not stall the job");
     }
 
     #[test]


### PR DESCRIPTION
Addresses the second half of #815.

> a plain 502 from the token exchange is worth one retry with backoff before failing the release — the current behaviour turns any blip in that single call into a failed release

The exchange POST now retries up to 3 times with 2s then 6s backoff. Bounded at 8s of waiting, so a genuinely dead service still fails the job promptly rather than stalling it.

Retried: transport errors, `429`, and `5xx` — the shapes where the same request can succeed on the next attempt. Not retried: `401` (the runner's OIDC token was rejected), `404` (the App is not installed), `4xx` generally. Retrying those burns time to reach the same error, and the existing diagnostics for them already point at the fix.

The OIDC call to the runner is left alone. It talks to a local service on the runner itself, it was not what failed in #815, and widening the scope means more surface to reason about for no reported benefit.

## The first half of #815 looks already resolved

Worth stating with evidence rather than assuming:

- `.github@d3ce80b` — the SHA FerrGames-Discord pinned back to as a stopgap — resolves to **FerrFlow v5.47.1**, i.e. the version from *before* the endpoint change. That is why it works, not because the host recovered.
- `Fixtures` is on `.github@79e493a`, which pins **FerrFlow v7.0.0** with `bot: true`, and released successfully three times this morning (08:02, 08:06, 08:16) from the same runner pool.

So `api.ferrflow.com` is reachable in-cluster now, and the endpoint has additionally moved from `/v1/ferrflow/token` to `/ferrflow/token` (FerrFlow-Cloud#784). FerrGames-Discord's stopgap pin is therefore stale — lifting it is a separate PR on that repo.

## Tests

Four new tests covering the classification and the bound:

- `retries_transport_errors_and_server_faults` — 500/502/503/429
- `does_not_retry_what_a_retry_cannot_fix` — 400/401/404
- `backoff_grows_then_plateaus`
- `a_502_run_is_bounded_by_the_attempt_cap` — asserts total sleep is 8s, so a raised attempt cap cannot silently turn a dead service into a hung job

1966 tests pass, clippy clean.