### PR TITLE
refactor(release): replace the seven-field tag tuple with a named struct

### DIFF
--- a/src/bot_token.rs
+++ b/src/bot_token.rs
@@ -62,12 +62,12 @@ impl BotTokenExchange {
     pub fn issue(&self) -> Result<IssuedToken> {
         let req_url = std::env::var("ACTIONS_ID_TOKEN_REQUEST_URL").map_err(|_| {
             anyhow::anyhow!(
-                "bot mode requires `permissions: id-token: write` in your workflow — ACTIONS_ID_TOKEN_REQUEST_URL not set"
+                "bot mode requires `permissions: id-token: write` in your workflow: ACTIONS_ID_TOKEN_REQUEST_URL not set"
             )
         })?;
         let req_token = std::env::var("ACTIONS_ID_TOKEN_REQUEST_TOKEN").map_err(|_| {
             anyhow::anyhow!(
-                "bot mode requires `permissions: id-token: write` in your workflow — ACTIONS_ID_TOKEN_REQUEST_TOKEN not set"
+                "bot mode requires `permissions: id-token: write` in your workflow: ACTIONS_ID_TOKEN_REQUEST_TOKEN not set"
             )
         })?;
 

--- a/src/config/commit_formats.rs
+++ b/src/config/commit_formats.rs
@@ -27,19 +27,13 @@ impl PatternSet {
         if self.is_catch_all() {
             return true;
         }
-        let haystack = if case_sensitive {
-            subject.to_string()
-        } else {
-            subject.to_lowercase()
-        };
-        self.patterns().iter().any(|p| {
-            let pattern = if case_sensitive {
-                p.clone()
-            } else {
-                p.to_lowercase()
-            };
-            wildcard_match(&pattern, &haystack)
-        })
+        if case_sensitive {
+            return self.patterns().iter().any(|p| wildcard_match(p, subject));
+        }
+        let haystack = subject.to_lowercase();
+        self.patterns()
+            .iter()
+            .any(|p| wildcard_match(&p.to_lowercase(), &haystack))
     }
 }
 

--- a/src/monorepo/run/cascade.rs
+++ b/src/monorepo/run/cascade.rs
@@ -12,7 +12,7 @@ use crate::versioning::compute_next_version;
 use super::super::types::CheckPackage;
 use super::super::util::tags_for_package;
 use super::release_json::ReleasedPackage;
-use super::summary::TagToCreate;
+use super::summary::PlannedTag;
 use crate::changelog::update_changelog;
 
 /// Mutable accumulators the cascade writes into, shared with the main
@@ -24,7 +24,7 @@ pub(super) struct CascadeSink<'a> {
     pub released: &'a mut Vec<ReleasedPackage>,
     pub files_to_commit: &'a mut Vec<String>,
     pub files_per_package: &'a mut HashMap<String, Vec<String>>,
-    pub tags_to_create: &'a mut Vec<TagToCreate>,
+    pub tags_to_create: &'a mut Vec<PlannedTag>,
     pub pkg_outputs: &'a mut Vec<(String, Vec<String>)>,
     /// Name -> the bump each already-released package received this run. The
     /// cascade reads it to know what to propagate, and extends it as it goes.
@@ -180,18 +180,18 @@ pub(super) fn run_dependency_cascade(
                 sink.pkg_outputs.push((pkg.name.clone(), lines));
             }
             let body = format!("Dependency update: {}", dep_trigger.join(", "));
-            sink.tags_to_create.push((
+            sink.tags_to_create.push(PlannedTag {
                 tag,
-                format!(
+                message: format!(
                     "Release {}",
                     pkg.tag_for_version(&config.workspace, config.is_monorepo(), &new_version)
                 ),
                 body,
-                pkg.name.clone(),
-                new_version.clone(),
-                0,
-                false,
-            ));
+                package: pkg.name.clone(),
+                version: new_version.clone(),
+                commit_count: 0,
+                is_prerelease: false,
+            });
             sink.bumped.insert(pkg.name.clone(), bump);
             sink.bumped_versions.insert(pkg.name.clone(), new_version);
             *sink.any_bumped = true;

--- a/src/monorepo/run/commit_body.rs
+++ b/src/monorepo/run/commit_body.rs
@@ -1,10 +1,10 @@
 use crate::config::ReleaseCommitBody;
 
-use super::summary::TagToCreate;
+use super::summary::PlannedTag;
 
 pub(super) fn build_commit_message(
     subject: &str,
-    tags: &[TagToCreate],
+    tags: &[PlannedTag],
     mode: ReleaseCommitBody,
 ) -> String {
     match render_body(tags, mode) {
@@ -13,7 +13,7 @@ pub(super) fn build_commit_message(
     }
 }
 
-fn render_body(tags: &[TagToCreate], mode: ReleaseCommitBody) -> Option<String> {
+fn render_body(tags: &[PlannedTag], mode: ReleaseCommitBody) -> Option<String> {
     match mode {
         ReleaseCommitBody::None => None,
         ReleaseCommitBody::Summary => render_summary(tags),
@@ -21,28 +21,35 @@ fn render_body(tags: &[TagToCreate], mode: ReleaseCommitBody) -> Option<String> 
     }
 }
 
-fn render_summary(tags: &[TagToCreate]) -> Option<String> {
+fn render_summary(tags: &[PlannedTag]) -> Option<String> {
     let lines: Vec<String> = tags
         .iter()
-        .map(|(_, _, _, name, version, commits, _)| {
-            let plural = if *commits == 1 { "commit" } else { "commits" };
-            format!("- {name} {version} ({commits} {plural})")
+        .map(|t| {
+            let plural = if t.commit_count == 1 {
+                "commit"
+            } else {
+                "commits"
+            };
+            format!(
+                "- {} {} ({} {plural})",
+                t.package, t.version, t.commit_count
+            )
         })
         .collect();
     (!lines.is_empty()).then(|| lines.join("\n"))
 }
 
-fn render_full(tags: &[TagToCreate]) -> Option<String> {
+fn render_full(tags: &[PlannedTag]) -> Option<String> {
     let multi = tags.len() > 1;
     let sections: Vec<String> = tags
         .iter()
-        .filter_map(|(_, _, body, name, version, _, _)| {
-            let trimmed = body.trim();
+        .filter_map(|t| {
+            let trimmed = t.body.trim();
             if trimmed.is_empty() {
                 return None;
             }
             Some(if multi {
-                format!("## {name} {version}\n\n{trimmed}")
+                format!("## {} {}\n\n{trimmed}", t.package, t.version)
             } else {
                 trimmed.to_string()
             })
@@ -55,16 +62,16 @@ fn render_full(tags: &[TagToCreate]) -> Option<String> {
 mod tests {
     use super::*;
 
-    fn tag(name: &str, version: &str, body: &str, commits: i32) -> TagToCreate {
-        (
-            format!("{name}@v{version}"),
-            format!("Release {name}@v{version}"),
-            body.to_string(),
-            name.to_string(),
-            version.to_string(),
-            commits,
-            false,
-        )
+    fn tag(name: &str, version: &str, body: &str, commits: i32) -> PlannedTag {
+        PlannedTag {
+            tag: format!("{name}@v{version}"),
+            message: format!("Release {name}@v{version}"),
+            body: body.to_string(),
+            package: name.to_string(),
+            version: version.to_string(),
+            commit_count: commits,
+            is_prerelease: false,
+        }
     }
 
     const SUBJECT: &str = "chore(release): api v1.2.0";
@@ -126,7 +133,7 @@ mod tests {
 
     #[test]
     fn summary_is_one_bounded_line_per_package() {
-        let tags: Vec<TagToCreate> = (0..50)
+        let tags: Vec<PlannedTag> = (0..50)
             .map(|i| {
                 tag(
                     &format!("pkg{i}"),

--- a/src/monorepo/run/execute.rs
+++ b/src/monorepo/run/execute.rs
@@ -15,7 +15,7 @@ use crate::hooks::{HookContext, HookPoint, resolve_hook, resolve_on_failure, run
 use crate::versioning::truncate_version;
 
 use super::checkpoint::{Checkpoint, Phase};
-use super::summary::{TagToCreate, write_github_step_summary};
+use super::summary::{PlannedTag, write_github_step_summary};
 use crate::forge::{Forge, ReleaseResult};
 use crate::monorepo::preview::build_forge_instance;
 use crate::monorepo::util::{auto_stage_new_files, collect_dirty_files};
@@ -36,7 +36,7 @@ pub(super) struct ReleasePlan<'a> {
     pub verbose: bool,
     pub force: bool,
     pub draft: bool,
-    pub tags_to_create: &'a [TagToCreate],
+    pub tags_to_create: &'a [PlannedTag],
     pub hook_contexts: &'a [(HookContext, usize)],
     pub files_to_commit: &'a mut Vec<String>,
     pub files_per_package: &'a mut HashMap<String, Vec<String>>,
@@ -76,7 +76,7 @@ pub(super) fn execute_release(plan: &mut ReleasePlan<'_>) -> Result<()> {
     let release_parts: Vec<String> = plan
         .tags_to_create
         .iter()
-        .map(|(_, _, _, name, ver, _, _)| format!("{name} v{ver}"))
+        .map(|t| format!("{} v{}", t.package, t.version))
         .collect();
     let skip_ci = if plan.config.workspace.effective_skip_ci() {
         " [skip ci]"
@@ -216,11 +216,10 @@ fn run_commit_or_pr(
         ReleaseCommitMode::Commit => {
             if scope == ReleaseCommitScope::PerPackage && plan.tags_to_create.len() > 1 {
                 for tag in plan.tags_to_create.iter() {
-                    let (_, _, _, pkg_name, ver, _, _) = tag;
-                    if let Some(pkg_files) = plan.files_per_package.get(pkg_name) {
+                    if let Some(pkg_files) = plan.files_per_package.get(&tag.package) {
                         let refs: Vec<&str> = pkg_files.iter().map(String::as_str).collect();
                         let msg = super::commit_body::build_commit_message(
-                            &format!("chore(release): {pkg_name} v{ver}{skip_ci}"),
+                            &format!("chore(release): {} v{}{skip_ci}", tag.package, tag.version),
                             std::slice::from_ref(tag),
                             plan.config.workspace.release_commit_body,
                         );
@@ -268,11 +267,13 @@ fn run_commit_or_pr(
                     .tags_to_create
                     .iter()
                     .filter_map(|tag| {
-                        let (_, _, _, pkg_name, ver, _, _) = tag;
-                        plan.files_per_package.get(pkg_name).map(|pf| {
+                        plan.files_per_package.get(&tag.package).map(|pf| {
                             let refs: Vec<&str> = pf.iter().map(String::as_str).collect();
                             let msg = super::commit_body::build_commit_message(
-                                &format!("chore(release): {pkg_name} v{ver}{skip_ci}"),
+                                &format!(
+                                    "chore(release): {} v{}{skip_ci}",
+                                    tag.package, tag.version
+                                ),
                                 std::slice::from_ref(tag),
                                 plan.config.workspace.release_commit_body,
                             );
@@ -300,7 +301,7 @@ fn run_commit_or_pr(
                     "Automated release commit.\n\n{}",
                     plan.tags_to_create
                         .iter()
-                        .map(|(tag, _, _, _, _, _, _)| format!("- `{tag}`"))
+                        .map(|t| format!("- `{}`", t.tag))
                         .collect::<Vec<_>>()
                         .join("\n")
                 );
@@ -375,15 +376,15 @@ fn run_commit_or_pr(
 }
 
 fn create_release_tags(plan: &mut ReleasePlan<'_>) -> Result<()> {
-    for (tag_name, tag_msg, _, pkg_name, _, _, _) in plan.tags_to_create {
-        create_tag(plan.repo, tag_name, tag_msg)?;
+    for t in plan.tags_to_create {
+        create_tag(plan.repo, &t.tag, &t.message)?;
         if let Some((_, lines)) = plan
             .pkg_outputs
             .iter_mut()
             .rev()
-            .find(|(n, _)| n == pkg_name)
+            .find(|(n, _)| n == &t.package)
         {
-            lines.push(format!("  ✓ Created tag {}", tag_name.cyan()));
+            lines.push(format!("  ✓ Created tag {}", t.tag.cyan()));
         }
     }
     Ok(())
@@ -393,20 +394,20 @@ fn create_and_move_floating_tags(
     plan: &mut ReleasePlan<'_>,
     floating_tag_names: &mut Vec<String>,
 ) -> Result<()> {
-    for (_, _, _, pkg_name, new_version, _, is_pre) in plan.tags_to_create {
-        if *is_pre {
+    for t in plan.tags_to_create {
+        if t.is_prerelease {
             continue;
         }
         let pkg = plan
             .config
             .packages
             .iter()
-            .find(|p| &p.name == pkg_name)
-            .ok_or_else(|| anyhow::anyhow!("package '{pkg_name}' not found in config"))
+            .find(|p| p.name == t.package)
+            .ok_or_else(|| anyhow::anyhow!("package '{}' not found in config", t.package))
             .error_code(error_code::MONOREPO_PACKAGE_NOT_FOUND)?;
         let levels = pkg.effective_floating_tags(&plan.config.workspace);
         for level in levels {
-            if let Some(truncated) = truncate_version(new_version, *level) {
+            if let Some(truncated) = truncate_version(&t.version, *level) {
                 let float_tag = pkg.tag_for_version(
                     &plan.config.workspace,
                     plan.config.is_monorepo(),
@@ -417,7 +418,7 @@ fn create_and_move_floating_tags(
                     && let Some(old_ver) = old_msg.strip_prefix("Release ")
                     && semver::Version::parse(old_ver.trim_start_matches('v'))
                         .ok()
-                        .zip(semver::Version::parse(new_version.trim_start_matches('v')).ok())
+                        .zip(semver::Version::parse(t.version.trim_start_matches('v')).ok())
                         .is_some_and(|(old, new)| new < old)
                 {
                     if !plan.force {
@@ -425,7 +426,7 @@ fn create_and_move_floating_tags(
                             "Floating tag {} would move backward ({} → {}). Use --force to override.",
                             float_tag,
                             old_ver,
-                            new_version,
+                            t.version,
                         ))
                         .error_code(error_code::MONOREPO_PUSH_FAILED)?;
                     }
@@ -433,19 +434,19 @@ fn create_and_move_floating_tags(
                         "{}",
                         format!(
                             "  ⚠ Floating tag {} moves backward ({} → {})",
-                            float_tag, old_ver, new_version,
+                            float_tag, old_ver, t.version,
                         )
                         .yellow()
                     );
                 }
-                let msg = format!("Release {new_version}");
+                let msg = format!("Release {}", t.version);
                 let moved = create_or_move_tag(plan.repo, &float_tag, &msg)?;
                 let verb = if moved { "Moved" } else { "Created" };
                 if let Some((_, lines)) = plan
                     .pkg_outputs
                     .iter_mut()
                     .rev()
-                    .find(|(n, _)| n == pkg_name)
+                    .find(|(n, _)| n == &t.package)
                 {
                     lines.push(format!("  ✓ {} floating tag {}", verb, float_tag.cyan()));
                 }
@@ -481,11 +482,7 @@ fn run_release_summary_hook(plan: &ReleasePlan<'_>, point: HookPoint) -> Result<
     let ws_hooks = plan.config.workspace.hooks.as_ref();
     if let Some(cmd) = resolve_hook(None, ws_hooks, point) {
         let on_failure = resolve_on_failure(None, ws_hooks);
-        let tags: Vec<String> = plan
-            .tags_to_create
-            .iter()
-            .map(|(t, _, _, _, _, _, _)| t.clone())
-            .collect();
+        let tags: Vec<String> = plan.tags_to_create.iter().map(|t| t.tag.clone()).collect();
         let mut ctx =
             HookContext::release_summary(plan.root, &tags, plan.dry_run, plan.config.is_monorepo());
         if let Some((first, _)) = plan.hook_contexts.first() {
@@ -514,11 +511,7 @@ fn push_refs(
     mode: ReleaseCommitMode,
     floating_tag_names: &[String],
 ) -> Result<()> {
-    let tag_refs: Vec<&str> = plan
-        .tags_to_create
-        .iter()
-        .map(|(t, _, _, _, _, _, _)| t.as_str())
-        .collect();
+    let tag_refs: Vec<&str> = plan.tags_to_create.iter().map(|t| t.tag.as_str()).collect();
 
     if let ReleaseCommitMode::Commit = mode {
         push(plan.repo, &plan.config.workspace.remote, plan.target_branch)?;
@@ -570,9 +563,9 @@ fn publish_releases_with(plan: &mut ReleasePlan<'_>, forge: &dyn Forge) -> Resul
     let outcomes: Vec<(String, String, TagReleaseOutcome)> = pool.install(|| {
         plan.tags_to_create
             .par_iter()
-            .map(|(tag_name, _, body, pkg_name, _, _, is_pre)| {
-                let outcome = process_release_tag(forge, tag_name, body, *is_pre, draft);
-                (tag_name.clone(), pkg_name.clone(), outcome)
+            .map(|t| {
+                let outcome = process_release_tag(forge, &t.tag, &t.body, t.is_prerelease, draft);
+                (t.tag.clone(), t.package.clone(), outcome)
             })
             .collect()
     });

--- a/src/monorepo/run/execute_tests.rs
+++ b/src/monorepo/run/execute_tests.rs
@@ -12,7 +12,7 @@ use crate::hooks::HookContext;
 
 use super::checkpoint::{Checkpoint, Phase};
 use super::execute::{ReleasePlan, execute_release};
-use super::summary::TagToCreate;
+use super::summary::PlannedTag;
 
 fn git(dir: &Path, args: &[&str]) -> String {
     let out = Command::new("git")
@@ -194,16 +194,16 @@ impl Forge for RecordingForge {
     }
 }
 
-fn tag_to_create(tag: &str, pkg: &str, version: &str) -> TagToCreate {
-    (
-        tag.to_string(),
-        format!("{pkg} {version}"),
-        "release notes".to_string(),
-        pkg.to_string(),
-        version.to_string(),
-        1,
-        false,
-    )
+fn tag_to_create(tag: &str, pkg: &str, version: &str) -> PlannedTag {
+    PlannedTag {
+        tag: tag.to_string(),
+        message: format!("{pkg} {version}"),
+        body: "release notes".to_string(),
+        package: pkg.to_string(),
+        version: version.to_string(),
+        commit_count: 1,
+        is_prerelease: false,
+    }
 }
 
 /// Drives the publish half of `execute_release`. The checkpoint starts at
@@ -211,12 +211,12 @@ fn tag_to_create(tag: &str, pkg: &str, version: &str) -> TagToCreate {
 /// creates the tags itself — and execution lands directly on push → publish.
 fn run_publish_phase(
     harness: &Harness,
-    tags: &[TagToCreate],
+    tags: &[PlannedTag],
     forge: &dyn Forge,
 ) -> (Result<()>, Vec<(String, ReleaseResult)>) {
     let mut checkpoint = Checkpoint::new(
         harness.git(&["rev-parse", "HEAD"]).trim().to_string(),
-        tags.iter().map(|(t, ..)| t.clone()).collect(),
+        tags.iter().map(|t| t.tag.clone()).collect(),
     );
     checkpoint.advance(Phase::TagsCreated);
 

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -44,7 +44,7 @@ use forced::{Forced, parse_forced_version};
 use plan::{PackagePlan, PlanInputs, SkipReason, compute_plan};
 use rayon::prelude::*;
 use release_json::{GitInfo, ReleaseJson, ReleasedPackage, SkippedPackage};
-use summary::{TagToCreate, collect_outputs};
+use summary::{PlannedTag, collect_outputs};
 pub use why::why;
 
 #[allow(clippy::too_many_arguments)]
@@ -196,7 +196,7 @@ pub(super) fn run_release_logic(
     let mut skipped: Vec<SkippedPackage> = Vec::new();
     let mut files_to_commit: Vec<String> = Vec::new();
     let mut files_per_package: HashMap<String, Vec<String>> = HashMap::new();
-    let mut tags_to_create: Vec<TagToCreate> = Vec::new();
+    let mut tags_to_create: Vec<PlannedTag> = Vec::new();
     let mut hook_contexts: Vec<(HookContext, usize)> = Vec::new(); // (ctx, pkg_index)
     // Name -> bump, so the dependency cascade can propagate the real bump
     // type instead of assuming a patch.
@@ -574,15 +574,15 @@ pub(super) fn run_release_logic(
                 }
             }
 
-            tags_to_create.push((
-                tag.clone(),
-                format!("Release {tag}"),
+            tags_to_create.push(PlannedTag {
+                tag: tag.clone(),
+                message: format!("Release {tag}"),
                 body,
-                pkg.name.clone(),
-                new_version.clone(),
-                commits.len() as i32,
+                package: pkg.name.clone(),
+                version: new_version.clone(),
+                commit_count: commits.len() as i32,
                 is_prerelease,
-            ));
+            });
         }
 
         hook_contexts.push((hook_ctx, pkg_idx));
@@ -650,7 +650,7 @@ pub(super) fn run_release_logic(
         if !dry_run && let Some(manifest_rel) = config.workspace.manifest_file.as_deref() {
             let overrides: std::collections::BTreeMap<String, String> = tags_to_create
                 .iter()
-                .map(|(_, _, _, name, ver, _, _)| (name.clone(), ver.clone()))
+                .map(|t| (t.package.clone(), t.version.clone()))
                 .collect();
             let packages = crate::manifest::snapshot_with_overrides(config, root, &overrides);
             let commit = repo
@@ -680,10 +680,7 @@ pub(super) fn run_release_logic(
             .ok()
             .map(|id| id.to_string())
             .unwrap_or_default();
-        let tag_names: Vec<String> = tags_to_create
-            .iter()
-            .map(|(t, _, _, _, _, _, _)| t.clone())
-            .collect();
+        let tag_names: Vec<String> = tags_to_create.iter().map(|t| t.tag.clone()).collect();
         let mut checkpoint = if dry_run {
             None
         } else {
@@ -735,10 +732,7 @@ pub(super) fn run_release_logic(
         let release_result = execute_release(&mut plan);
         timing.record("release commit phase", release_start.elapsed());
 
-        let released_tags: Vec<String> = tags_to_create
-            .iter()
-            .map(|(t, _, _, _, _, _, _)| t.clone())
-            .collect();
+        let released_tags: Vec<String> = tags_to_create.iter().map(|t| t.tag.clone()).collect();
         let ws_hooks = config.workspace.hooks.as_ref();
         match release_result {
             Ok(()) => {
@@ -834,10 +828,7 @@ pub(super) fn run_release_logic(
         let tags_pushed = if dry_run {
             Vec::new()
         } else {
-            tags_to_create
-                .iter()
-                .map(|(t, _, _, _, _, _, _)| t.clone())
-                .collect()
+            tags_to_create.iter().map(|t| t.tag.clone()).collect()
         };
         let payload = ReleaseJson {
             released,

--- a/src/monorepo/run/summary.rs
+++ b/src/monorepo/run/summary.rs
@@ -1,13 +1,14 @@
-/// Tag tuple used by the release loop: (tag_name, message, body,
-/// pkg_name, version, commit_count, is_prerelease).
-pub(super) type TagToCreate = (String, String, String, String, String, i32, bool);
+#[derive(Debug, Clone)]
+pub(super) struct PlannedTag {
+    pub tag: String,
+    pub message: String,
+    pub body: String,
+    pub package: String,
+    pub version: String,
+    pub commit_count: i32,
+    pub is_prerelease: bool,
+}
 
-/// Print the per-package output lines collected during the run,
-/// followed by the shared cross-package output lines, in the exact
-/// formatting the orchestrator used to do inline.
-///
-/// `pkg_outputs` entries are `(pkg_name, lines)`. The name is unused at
-/// print time today but kept for future grouping needs.
 pub(super) fn collect_outputs(
     pkg_outputs: &[(String, Vec<String>)],
     shared_outputs: &[String],
@@ -26,12 +27,7 @@ pub(super) fn collect_outputs(
     out
 }
 
-/// Write the per-tag release blurb to `$GITHUB_STEP_SUMMARY` when the
-/// environment variable is set (GitHub Actions). Silent no-op otherwise.
-///
-/// Kept out of the main orchestrator so the entry function reads as a
-/// pipeline of stages instead of stage + side-effect appendix.
-pub(super) fn write_github_step_summary(tags: &[TagToCreate]) {
+pub(super) fn write_github_step_summary(tags: &[PlannedTag]) {
     let Ok(summary_path) = std::env::var("GITHUB_STEP_SUMMARY") else {
         return;
     };
@@ -44,8 +40,8 @@ pub(super) fn write_github_step_summary(tags: &[TagToCreate]) {
         return;
     };
     let _ = writeln!(file, "## Released\n");
-    for (tag_name, _, body, _, _, _, _) in tags {
-        let _ = writeln!(file, "### {tag_name}\n");
-        let _ = writeln!(file, "{body}");
+    for t in tags {
+        let _ = writeln!(file, "### {}\n", t.tag);
+        let _ = writeln!(file, "{}", t.body);
     }
 }


### PR DESCRIPTION
Pure refactor, no behaviour change. 1966 tests pass unchanged, clippy clean, `ferrflow-wasm` builds.

## The tuple

The release loop carried its planned tags as `(String, String, String, String, String, i32, bool)`, aliased `TagToCreate`. Five of the seven fields are `String`, so the compiler could not catch a reorder, and every consumer read it positionally:

```rust
.map(|(t, _, _, _, _, _, _)| t.clone())
.map(|(_, _, _, name, ver, _, _)| format!("{name} v{ver}"))
.filter_map(|(_, _, body, name, version, _, _)| ...)
for (tag_name, tag_msg, _, pkg_name, _, _, _) in plan.tags_to_create
```

Eleven of those across six files. The workspace `CLAUDE.md` names this directly: *use named structs instead of positional tuples for rows*.

Now `PlannedTag { tag, message, body, package, version, commit_count, is_prerelease }`, and the same call sites read as `t.tag`, `t.package`, `t.is_prerelease`. Net **-19 lines**.

The safety gain is the real point: swapping `message` and `body`, or `package` and `version`, was previously a silent behaviour change that compiled. Both pairs are adjacent same-typed fields, and `body` is what lands in the changelog while `message` is the annotated tag text.

## Two smaller items in the same pass

**`PatternSet::matches` no longer allocates on the default path.** It built a `String` for the subject and cloned every pattern even under `case_sensitive: true`, which is the default and the hot path: once per commit, per bump level, per pattern. On a 10k-commit history that is a lot of pointless allocation for a comparison that can borrow. The case-insensitive branch still lowercases, since it has to.

**Two user-facing error strings lost an em dash**, replaced with a colon. `bot mode requires ... in your workflow: ACTIONS_ID_TOKEN_REQUEST_URL not set`. Product copy rule, and these are strings a user reads when their release fails.

## Scope

Comments removed only from the modules added in this batch (`commit_formats`, `commit_body`, `http`, `summary`). Pre-existing comments elsewhere are untouched — stripping the repo wholesale is not what was asked and would bury this diff.

`Debug` and `Clone` derived on the struct: `Clone` because `cascade.rs` and the checkpoint path already needed owned copies, `Debug` because a 7-field release plan is worth being able to print when a release goes sideways.