### PR TITLE
docs(security): record what the npm package actually contains

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,3 +15,21 @@ If you discover a security vulnerability, please report it privately via [GitHub
 Do **not** open a public issue for security vulnerabilities.
 
 You can expect an initial response within 48 hours. We will work with you to understand the issue and coordinate a fix before any public disclosure.
+
+## What the npm package contains
+
+Supply-chain scanners flag the `ferrflow` npm package for containing a remote URL. This section records the review so it does not have to be repeated per release.
+
+The package publishes `bin/` only (`files: ["bin"]`), which is a single file: `bin/ferrflow.js`. It contains exactly one URL:
+
+```js
+"Install ferrflow from https://github.com/FerrLabs/FerrFlow/releases"
+```
+
+That string is display text inside a `console.error` on the unsupported-platform path. It is never fetched.
+
+**The package cannot make a network request.** Its entire import graph is `child_process`, `fs`, `path`, `url`, `module` and `os`. There is no HTTP client, no `fetch`, and no `net`. Its only job is to resolve the platform binary from the matching `@ferrflow/*` optional dependency and `spawnSync` it.
+
+There are no `preinstall`, `postinstall` or `prepare` scripts in the wrapper or in any platform package. The platform packages carry no JavaScript at all: the binary is placed into them by the release workflow, and they declare no `bin` and no `scripts`.
+
+Releases ship a `SHA256SUMS`, cosign signatures and build-provenance attestations. Verification instructions are in the release notes; the GitHub Action verifies the digest before extracting.


### PR DESCRIPTION
Answers the Socket "URL strings" alert on [socket.dev/npm/package/ferrflow](https://socket.dev/npm/package/ferrflow), whose suggestion is to *review all remote URLs to ensure they are intentional, point to trusted sources, and are not used for data exfiltration or untrusted code loading at runtime*.

Reviewed. No code change is warranted, so the deliverable is the review itself, written down in `SECURITY.md` so it does not get redone every release.

## Findings

The `ferrflow` package publishes `bin/` only (`files: ["bin"]`), which is one file. It contains exactly one URL:

```js
"Install ferrflow from https://github.com/FerrLabs/FerrFlow/releases"
```

Display text inside a `console.error` on the unsupported-platform path. Never fetched.

Against Socket's three questions:

| Question | Answer |
|---|---|
| Intentional? | Yes, it tells a user on an unsupported platform where to get a binary. |
| Trusted source? | Yes, the project's own releases page. |
| Exfiltration or runtime code loading? | Impossible. |

That last one is not a judgement call. The whole import graph is `child_process`, `fs`, `path`, `url`, `module`, `os`. No `fetch`, no `http`/`https`, no `net`. The package has no way to issue a request.

Also checked while in there: no `preinstall` / `postinstall` / `prepare` in the wrapper or in any of the seven platform packages, and the platform packages ship no JavaScript at all. They declare no `bin` and no `scripts`; the binary is placed into them by the release workflow.

## On removing the URL

Considered and rejected. Deleting it would leave a user on an unsupported platform with an error that does not say where to go, to silence a heuristic that is correctly reporting a string and incorrectly implying a capability.

Socket's package page is public and not configurable from this repo, so the alert will recur on every version. That is why this belongs in `SECURITY.md`, where someone evaluating the package can find the answer, rather than in a suppression file that only affects our own PRs.