### PR TITLE
docs(security): link the verification guide instead of the release notes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,4 +32,4 @@ That string is display text inside a `console.error` on the unsupported-platform
 
 There are no `preinstall`, `postinstall` or `prepare` scripts in the wrapper or in any platform package. The platform packages carry no JavaScript at all: the binary is placed into them by the release workflow, and they declare no `bin` and no `scripts`.
 
-Releases ship a `SHA256SUMS`, cosign signatures and build-provenance attestations. Verification instructions are in the release notes; the GitHub Action verifies the digest before extracting.
+Releases ship a `SHA256SUMS`, cosign signatures and build-provenance attestations. See [Verifying releases](https://ferrflow.com/docs/verifying-releases) for how to check them yourself; the GitHub Action verifies the digest before extracting.


### PR DESCRIPTION
Review nit on #852.

`SECURITY.md` said verification instructions were in the release notes. They are not: they live in `docs/verifying-releases.md`, published at [ferrflow.com/docs/verifying-releases](https://ferrflow.com/docs/verifying-releases). Someone landing on `SECURITY.md` and going to the release notes would find nothing.

Linked the published page rather than the repo file, since `SECURITY.md` is read by people evaluating the package who are not necessarily in the source tree.