### PR TITLE
fix(bot): stop retrying token-exchange errors a retry cannot fix

### DIFF
--- a/src/bot_token.rs
+++ b/src/bot_token.rs
@@ -161,6 +161,11 @@ fn backoff_for(attempt: u32) -> std::time::Duration {
 fn is_retryable(err: &ureq::Error) -> bool {
     match err {
         ureq::Error::StatusCode(code) => matches!(code, 429 | 500..=599),
+        ureq::Error::BadUri(_)
+        | ureq::Error::InvalidProxyUrl
+        | ureq::Error::TooManyRedirects
+        | ureq::Error::BodyExceedsLimit(_)
+        | ureq::Error::Pem(_) => false,
         _ => true,
     }
 }
@@ -397,6 +402,17 @@ mod tests {
         assert!(!is_retryable(&ureq::Error::StatusCode(401)));
         assert!(!is_retryable(&ureq::Error::StatusCode(404)));
         assert!(!is_retryable(&ureq::Error::StatusCode(400)));
+        assert!(!is_retryable(&ureq::Error::InvalidProxyUrl));
+        assert!(!is_retryable(&ureq::Error::TooManyRedirects));
+    }
+
+    #[test]
+    fn a_mistyped_endpoint_fails_immediately() {
+        let bad = ureq::Error::BadUri("h ttp://typo".to_string());
+        assert!(
+            !is_retryable(&bad),
+            "FERRFLOW_BOT_ENDPOINT is user-set, so a typo must not burn the retry budget"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Review nit on #848.

> `is_retryable`'s catch-all `_ => true` retries every non-`StatusCode` `ureq::Error` variant, including ones that can't be fixed by retrying (e.g. a malformed URL).

Correct, and it matters a bit more than the nit suggests: `FERRFLOW_BOT_ENDPOINT` is a user-settable env var, also exposed as the Action's `bot_endpoint` input. A typo there produced `BadUri`, which then burned the full 8s retry budget before failing with the same error it had on the first attempt.

Permanent variants now classified as terminal:

```rust
ureq::Error::BadUri(_)
| ureq::Error::InvalidProxyUrl
| ureq::Error::TooManyRedirects
| ureq::Error::BodyExceedsLimit(_)
| ureq::Error::Pem(_) => false,
```

The catch-all stays `true` for the rest, which is the right default: `Io`, `Timeout`, `ConnectionFailed`, `HostNotFound` and the TLS handshake variants are all genuinely transient, and that is the case the retry exists for.

`Der` was in the first draft and removed: the variant is behind a ureq feature this build does not enable, so it does not compile here.

## Tests

- `does_not_retry_what_a_retry_cannot_fix` extended with `InvalidProxyUrl` and `TooManyRedirects`
- `a_mistyped_endpoint_fails_immediately` covers `BadUri` specifically, and says why in the assertion message so the reason survives the next refactor

1967 tests pass, clippy clean.