### PR TITLE
docs(readme): show metrics sonar has instead of a coverage it does not

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ writes the changelog, and cuts the tagged release. Any language, any repo layout
 
 [![Latest release](https://img.shields.io/github/v/release/FerrLabs/FerrFlow)](https://github.com/FerrLabs/FerrFlow/releases/latest)
 [![Quality Gate](https://sonar.ferrlabs.com/api/project_badges/measure?project=ferrflow&metric=alert_status&token=sqb_53f0d93466bd01a6c6a94a15125d5aa8390c67fa)](https://sonar.ferrlabs.com/dashboard?id=ferrflow)
-[![Coverage](https://sonar.ferrlabs.com/api/project_badges/measure?project=ferrflow&metric=coverage&token=sqb_53f0d93466bd01a6c6a94a15125d5aa8390c67fa)](https://sonar.ferrlabs.com/dashboard?id=ferrflow)
+[![Maintainability](https://sonar.ferrlabs.com/api/project_badges/measure?project=ferrflow&metric=sqale_rating&token=sqb_53f0d93466bd01a6c6a94a15125d5aa8390c67fa)](https://sonar.ferrlabs.com/dashboard?id=ferrflow)
+[![Security](https://sonar.ferrlabs.com/api/project_badges/measure?project=ferrflow&metric=security_rating&token=sqb_53f0d93466bd01a6c6a94a15125d5aa8390c67fa)](https://sonar.ferrlabs.com/dashboard?id=ferrflow)
 [![License](https://img.shields.io/github/license/FerrLabs/FerrFlow)](LICENSE)
 [![Socket Badge](https://badge.socket.dev/npm/package/ferrflow/latest)](https://badge.socket.dev/npm/package/ferrflow/latest)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/FerrLabs/FerrFlow/badge)](https://scorecard.dev/viewer/?uri=github.com/FerrLabs/FerrFlow)


### PR DESCRIPTION
Closes #856.

The coverage badge renders **0%** because `sonarqube.yml` sends Sonar no coverage report, not because the tests do not exist. On the front page of an OSS CLI that reads as "no tests", so it comes out and two metrics Sonar genuinely holds go in.

Checked against the instance rather than assumed:

```
alert_status              quality gate passed
coverage                  coverage 0%
sqale_rating              maintainability A
security_rating           security A
```

Wiring real coverage is the better answer and is deliberately not this PR: LFSX already runs `cargo-llvm-cov` and passes `-Dsonar.rust.lcov.reportPaths` to the scan, so it is about twenty lines copied from something that works. A wrong number on the front page is worth removing today rather than whenever that lands. #856 keeps both options written down.