### PR TITLE
chore(release): publish a floating latest tag

### DIFF
--- a/.ferrflow
+++ b/.ferrflow
@@ -1,6 +1,7 @@
 {
   "$schema": "https://ferrflow.com/schema/ferrflow.json",
   "workspace": {
+    "latestTag": "latest",
     "releaseCommitBody": "full",
     "tagTemplate": "v{version}",
     "floatingTags": ["major"],


### PR DESCRIPTION
Sets `workspace.latestTag`, so each release also creates or moves a floating alias tag pointing at the newest non-prerelease version.

Multi-package repos get `"{name}@latest"` and single-package repos get `"latest"`. The `{name}` is not cosmetic in a monorepo: without it every package would overwrite the same ref and the last one released would win.

The tag is deliberately not derived from `tagTemplate`. A repo tagging `v{version}` gets `latest`, not `vlatest`, because the alias is a name rather than a version.

Requires the CLI support in [FerrFlow#866](https://github.com/FerrLabs/FerrFlow/pull/866). Until this repo runs a FerrFlow that has it the key is silently ignored, so this can merge in any order.

Part of an org-wide rollout across the 15 repos carrying a `.ferrflow`.