### PR TITLE
fix(schema): declare latestTag on packages and validate the template

### DIFF
--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -579,6 +579,14 @@
               ]
             }
           },
+          "latestTag": {
+            "type": "string",
+            "description": "Floating alias tag template for this package. Overrides workspace default. Absent means the workspace setting applies.",
+            "examples": [
+              "latest",
+              "{name}@latest"
+            ]
+          },
           "hooks": {
             "$ref": "#/$defs/hooks"
           },

--- a/src/validate/checks.rs
+++ b/src/validate/checks.rs
@@ -74,6 +74,36 @@ pub(super) fn check_tag_templates(config: &Config) -> Vec<ValidationEntry> {
             check_template(tmpl, &format!("{}.tagTemplate", pkg.name));
         }
     }
+
+    let mut check_latest = |template: &str, context: &str| {
+        if template.contains("{version}") {
+            entries.push(ValidationEntry {
+                level: ValidationLevel::Error,
+                path: context.to_string(),
+                message: format!(
+                    "latest tag template \"{template}\" contains {{version}}, which is not substituted: the alias is a name, not a version"
+                ),
+            });
+        }
+        if is_monorepo && !template.contains("{name}") {
+            entries.push(ValidationEntry {
+                level: ValidationLevel::Warning,
+                path: context.to_string(),
+                message: format!(
+                    "latest tag template \"{template}\" does not contain {{name}}: every package would overwrite the same ref"
+                ),
+            });
+        }
+    };
+
+    if let Some(ref tmpl) = config.workspace.latest_tag {
+        check_latest(tmpl, "workspace.latestTag");
+    }
+    for pkg in &config.packages {
+        if let Some(ref tmpl) = pkg.latest_tag {
+            check_latest(tmpl, &format!("{}.latestTag", pkg.name));
+        }
+    }
     entries
 }
 

--- a/src/validate/tests.rs
+++ b/src/validate/tests.rs
@@ -232,6 +232,36 @@ fn pass_tag_template_missing_name_monorepo() {
 }
 
 #[test]
+fn latest_tag_with_version_placeholder_is_an_error() {
+    let mut config = make_config(vec![make_package("app", ".")]);
+    config.workspace.latest_tag = Some("{name}@v{version}-latest".to_string());
+    let entries = check_tag_templates(&config);
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].level, ValidationLevel::Error);
+    assert!(entries[0].message.contains("{version}"));
+}
+
+#[test]
+fn latest_tag_without_name_in_a_monorepo_warns() {
+    let mut config = make_config(vec![
+        make_package("api", "packages/api"),
+        make_package("web", "packages/web"),
+    ]);
+    config.workspace.latest_tag = Some("latest".to_string());
+    let entries = check_tag_templates(&config);
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].level, ValidationLevel::Warning);
+    assert!(entries[0].message.contains("overwrite the same ref"));
+}
+
+#[test]
+fn latest_tag_is_fine_bare_in_a_single_package_repo() {
+    let mut config = make_config(vec![make_package("app", ".")]);
+    config.workspace.latest_tag = Some("latest".to_string());
+    assert!(check_tag_templates(&config).is_empty());
+}
+
+#[test]
 fn pass_package_paths_exist() {
     let tmp = TempDir::new().unwrap();
     fs::create_dir_all(tmp.path().join("packages/api")).unwrap();


### PR DESCRIPTION
Blocking review finding on [FerrFlow-Cloud#830](https://github.com/FerrLabs/FerrFlow-Cloud/pull/830), plus the two nits from #866. The fix belongs here, since the served schema is a copy of this one.

## The blocking bug

`#866` added `latestTag` to `workspace.properties` but not to `package.items.properties`, and `package.items` carries `additionalProperties: false`. So:

```json
{ "package": [{ "name": "api", "latestTag": "api@latest" }] }
```

fails schema validation and loses editor autocomplete, even though `PackageConfig.latest_tag` exists and `latest_tag_name` reads it first. The code supported the per-package override, the schema denied it, and the docs promised it. Declared it now, mirroring the `floatingTags` entry directly above.

## The two nits, both taken

**Validation for `latestTag`.** The reviewer pointed out that `check_tag_templates` already warns when a monorepo `tagTemplate` omits `{name}`, so the same precedent should apply here. It should, and the consequence is worse: a colliding `latest` ref is silent, where a colliding version tag usually fails on push. Now a warning.

**`{version}` in a `latestTag` is an error, not a warning.** The other nit was that `{version}` is left literal, producing a broken ref name silently. `{name}@v{version}-latest` would create a ref containing `{version}` verbatim. That is never intentional, so it is an `Error` rather than a `Warning`, and the message says why: the alias is a name, not a version.

## Tests

Three new, alongside the existing `check_tag_templates` cases:

- `latest_tag_with_version_placeholder_is_an_error`
- `latest_tag_without_name_in_a_monorepo_warns`
- `latest_tag_is_fine_bare_in_a_single_package_repo`, so the warning does not fire on the 8 single-package repos that just adopted `"latest"`

1983 pass, clippy clean.

## On the snake_case twin

The review also noted `latestTag` has no `latest_tag` counterpart in the schema, unlike `floatingTags`/`floating_tags`. Checked: that is a pre-existing inconsistency rather than something this introduced. `releaseCommitBody` and `commitFormats` have no twins either, and `workspace` is `additionalProperties: false`, so snake_case spellings that serde accepts are already rejected by the schema across several keys. Worth one sweep that adds every missing twin at once rather than a one-off here, so I left it out. Happy to file that separately.