### PR TITLE
feat(release): say which source the current version came from

### DIFF
--- a/docs/api/release-output.md
+++ b/docs/api/release-output.md
@@ -55,7 +55,7 @@ repository.
 | `released[].tag` | string | The tag that was (or would be) created. |
 | `released[].commit_count` | number | Number of commits considered for this package's changelog. |
 | `released[].prerelease` | boolean | Whether the new version is a pre-release. |
-| `released[].version_source` | object | Where `previous_version` came from. See below. Omitted when the version was aligned to a `linked`/`fixed` group instead of resolved. |
+| `released[].version_source` | object | Where `previous_version` came from. See below. Omitted only when no source could be read at all. |
 | `released[].forge_release_url` | string \| null | URL of the created forge release. `null` on dry-run, when no forge is configured, or when the release was not created. |
 | `released[].forge_release_id` | number \| null | Numeric id of the created forge release (GitHub). `null` on dry-run, on GitLab, or when not created. |
 | `skipped[]` | array | Packages that were considered but not released. |
@@ -86,7 +86,11 @@ When both carry the same version the tag is credited, matching the
 resolution order. The same object appears in `check --json` under
 `packages[].version_source`, and in `why --json` at the top level.
 `why` reports `file` for a package it skipped, because that is the only
-source it reads in that case.
+source it reads in that case. A member pulled along by a `linked` or `fixed`
+group reports `file` for the same reason: its new version comes from the group,
+but the previous version it is compared against was read from its own versioned
+file. The field is absent only when no source could be read, which for a group
+member means the version was borrowed from the group target.
 
 ## Dry-run behaviour
 

--- a/docs/api/release-output.md
+++ b/docs/api/release-output.md
@@ -22,6 +22,11 @@ repository.
       "tag": "api@v1.3.0",
       "commit_count": 7,
       "prerelease": false,
+      "version_source": {
+        "kind": "file_over_tag",
+        "file": "api/Cargo.toml",
+        "tag": "api@v1.2.3"
+      },
       "forge_release_url": "https://github.com/owner/repo/releases/tag/api@v1.3.0",
       "forge_release_id": 123456789
     }
@@ -50,6 +55,7 @@ repository.
 | `released[].tag` | string | The tag that was (or would be) created. |
 | `released[].commit_count` | number | Number of commits considered for this package's changelog. |
 | `released[].prerelease` | boolean | Whether the new version is a pre-release. |
+| `released[].version_source` | object | Where `previous_version` came from. See below. Omitted when the version was aligned to a `linked`/`fixed` group instead of resolved. |
 | `released[].forge_release_url` | string \| null | URL of the created forge release. `null` on dry-run, when no forge is configured, or when the release was not created. |
 | `released[].forge_release_id` | number \| null | Numeric id of the created forge release (GitHub). `null` on dry-run, on GitLab, or when not created. |
 | `skipped[]` | array | Packages that were considered but not released. |
@@ -59,6 +65,26 @@ repository.
 | `git.tags_pushed` | array | Tags pushed to the remote. Empty on dry-run. |
 | `git.branch` | string | Branch the release targeted. |
 | `dry_run` | boolean | `true` when `--dry-run` was passed. |
+
+### `version_source`
+
+`previous_version` is resolved from up to two places: the highest tag
+reachable from HEAD, and the version written in the package's first
+versioned file. `version_source` reports which one it came from, so a
+package whose tag was never pushed is distinguishable from one that
+simply has no tags yet.
+
+| `kind` | Meaning | Extra fields |
+| --- | --- | --- |
+| `tag` | Only a tag was found. | `tag` |
+| `file` | Only the versioned file was found, no tag matched. | `file` |
+| `tag_over_file` | Both were found and the tag was the higher of the two. | `tag`, `file` |
+| `file_over_tag` | Both were found and the file was the higher of the two. | `file`, `tag` |
+| `bootstrap` | Neither was found, the version is the strategy's starting point. | none |
+
+When both carry the same version the tag is credited, matching the
+resolution order. The same object appears in `check --json` under
+`packages[].version_source`.
 
 ## Dry-run behaviour
 

--- a/docs/api/release-output.md
+++ b/docs/api/release-output.md
@@ -84,7 +84,9 @@ simply has no tags yet.
 
 When both carry the same version the tag is credited, matching the
 resolution order. The same object appears in `check --json` under
-`packages[].version_source`.
+`packages[].version_source`, and in `why --json` at the top level.
+`why` reports `file` for a package it skipped, because that is the only
+source it reads in that case.
 
 ## Dry-run behaviour
 

--- a/src/monorepo/mod.rs
+++ b/src/monorepo/mod.rs
@@ -4,6 +4,7 @@ mod release;
 mod run;
 mod types;
 mod util;
+mod version_source;
 
 pub use check::check;
 pub use release::release;

--- a/src/monorepo/run/cascade.rs
+++ b/src/monorepo/run/cascade.rs
@@ -11,6 +11,7 @@ use crate::versioning::compute_next_version;
 
 use super::super::types::CheckPackage;
 use super::super::util::tags_for_package;
+use super::super::version_source::VersionSource;
 use super::release_json::ReleasedPackage;
 use super::summary::PlannedTag;
 use crate::changelog::update_changelog;
@@ -100,6 +101,9 @@ pub(super) fn run_dependency_cascade(
                     tag: tag.clone(),
                     commit_count: 0,
                     prerelease: false,
+                    version_source: Some(VersionSource::File {
+                        file: vf.path.clone(),
+                    }),
                     forge_release_url: None,
                     forge_release_id: None,
                 });
@@ -114,6 +118,9 @@ pub(super) fn run_dependency_cascade(
                     tag: tag.clone(),
                     channel: channel.map(str::to_string),
                     prerelease: false,
+                    version_source: Some(VersionSource::File {
+                        file: vf.path.clone(),
+                    }),
                     commits: vec![],
                 });
             } else {

--- a/src/monorepo/run/groups.rs
+++ b/src/monorepo/run/groups.rs
@@ -6,6 +6,7 @@ use crate::conventional_commits::BumpType;
 use crate::formats::read_version;
 
 use super::super::util::pick_higher_semver;
+use super::super::version_source::VersionSource;
 use super::plan::{PackageBump, PackagePlan};
 
 pub(super) fn apply_groups(config: &Config, root: &Path, plans: &mut [Option<PackagePlan>]) {
@@ -47,10 +48,14 @@ pub(super) fn apply_groups(config: &Config, root: &Path, plans: &mut [Option<Pac
                     plans[idx] = Some(PackagePlan::Bump(bump));
                 }
                 _ => {
-                    let current = pkg
-                        .versioned_files
-                        .first()
-                        .and_then(|vf| read_version(vf, root).ok())
+                    let file_source = pkg.versioned_files.first().and_then(|vf| {
+                        read_version(vf, root)
+                            .ok()
+                            .map(|version| (vf.path.clone(), version))
+                    });
+                    let current = file_source
+                        .as_ref()
+                        .map(|(_, version)| version.clone())
                         .unwrap_or_else(|| target_version.clone());
                     plans[idx] = Some(PackagePlan::Bump(Box::new(PackageBump {
                         recovered: false,
@@ -61,6 +66,7 @@ pub(super) fn apply_groups(config: &Config, root: &Path, plans: &mut [Option<Pac
                         commits: Vec::new(),
                         bump: BumpType::None,
                         strategy_label: group.kind.label().to_string(),
+                        version_source: file_source.map(|(file, _)| VersionSource::File { file }),
                         tag: target_tag,
                     })));
                 }
@@ -136,6 +142,7 @@ mod tests {
             bump,
             strategy_label: bump.to_string(),
             tag: tag.to_string(),
+            version_source: None,
         })))
     }
 

--- a/src/monorepo/run/groups.rs
+++ b/src/monorepo/run/groups.rs
@@ -177,6 +177,13 @@ mod tests {
             b.current_version, "1.0.0",
             "current read from the version file"
         );
+        assert_eq!(
+            b.version_source,
+            Some(VersionSource::File {
+                file: "b/Cargo.toml".to_string()
+            }),
+            "an aligned member names the file it read its current version from"
+        );
         assert!(b.commits.is_empty(), "no commits of its own");
     }
 

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -305,6 +305,7 @@ pub(super) fn run_release_logic(
         let commits = bump_plan.commits;
         let bump = bump_plan.bump;
         let strategy_label = bump_plan.strategy_label;
+        let version_source = bump_plan.version_source;
         let tag = bump_plan.tag;
 
         if release_json {
@@ -316,6 +317,7 @@ pub(super) fn run_release_logic(
                 tag: tag.clone(),
                 commit_count: commits.len(),
                 prerelease: is_prerelease,
+                version_source: version_source.clone(),
                 forge_release_url: None,
                 forge_release_id: None,
             });
@@ -350,6 +352,7 @@ pub(super) fn run_release_logic(
                 tag: tag.clone(),
                 channel: prerelease_ctx.channel.clone(),
                 prerelease: is_prerelease,
+                version_source: version_source.clone(),
                 commits: check_commits,
             });
         } else {
@@ -358,13 +361,18 @@ pub(super) fn run_release_logic(
             } else {
                 String::new()
             };
+            let source_label = version_source
+                .as_ref()
+                .map(|source| format!(", {source}"))
+                .unwrap_or_default();
             let mut lines = vec![format!(
-                "{} {}  {} → {}  ({}{})",
+                "{} {}  {} → {}  ({}{}{})",
                 "●".green().bold(),
                 pkg.name.bold(),
                 current_version.dimmed(),
                 new_version.green().bold(),
                 strategy_label.cyan(),
+                source_label.dimmed(),
                 channel_label.yellow()
             )];
 
@@ -973,6 +981,7 @@ mod tests {
             bump,
             strategy_label: bump.to_string(),
             tag: format!("v{new_version}"),
+            version_source: None,
         }))
     }
 

--- a/src/monorepo/run/plan.rs
+++ b/src/monorepo/run/plan.rs
@@ -16,6 +16,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use super::super::util::{is_package_touched, pick_higher_semver, tags_for_package};
+use super::super::version_source::VersionSource;
 use super::forced::{Forced, forced_version_for};
 
 pub(super) enum SkipReason {
@@ -46,6 +47,7 @@ pub(super) struct PackageBump {
     pub bump: BumpType,
     pub strategy_label: String,
     pub tag: String,
+    pub version_source: Option<VersionSource>,
 }
 
 pub(super) enum PackagePlan {
@@ -242,10 +244,11 @@ pub(super) fn compute_plan(
         tags_for_package(inputs.all_tags, &tag_search_prefix)
     });
 
-    let file_version = pkg
-        .versioned_files
-        .first()
-        .and_then(|vf| read_version(vf, inputs.root).ok());
+    let file_source = pkg.versioned_files.first().and_then(|vf| {
+        read_version(vf, inputs.root)
+            .ok()
+            .map(|version| (vf.path.clone(), version))
+    });
     let strategy = config.workspace.orphaned_tag_strategy;
     let highest_tag = if let (Some(idx), OrphanedTagStrategy::Warn) = (inputs.tag_index, strategy) {
         idx.find_highest_semver_tag(&tag_search_prefix, strategy)
@@ -258,13 +261,17 @@ pub(super) fn compute_plan(
         )?
     };
     let last_tag = highest_tag.as_ref().map(|(tag, _version)| tag.clone());
-    let tag_version = highest_tag.map(|(_tag, version)| version);
-    let current_version = match (tag_version, file_version) {
-        (Some(tag), Some(file)) => pick_higher_semver(&file, &tag),
-        (Some(tag), None) => tag,
-        (None, Some(file)) => file,
+    let current_version = match (&highest_tag, &file_source) {
+        (Some((_, tag)), Some((_, file))) => pick_higher_semver(file, tag),
+        (Some((_, tag)), None) => tag.clone(),
+        (None, Some((_, file))) => file.clone(),
         (None, None) => crate::versioning::bootstrap_version(pkg_strategy),
     };
+    let version_source = Some(VersionSource::resolve(
+        highest_tag,
+        file_source,
+        &current_version,
+    ));
 
     let prerelease = inputs.prerelease_ctx.is_prerelease();
 
@@ -345,6 +352,7 @@ pub(super) fn compute_plan(
         bump,
         strategy_label,
         tag,
+        version_source,
     })))
 }
 

--- a/src/monorepo/run/release_json.rs
+++ b/src/monorepo/run/release_json.rs
@@ -1,5 +1,7 @@
 use serde::Serialize;
 
+use super::super::version_source::VersionSource;
+
 #[derive(Serialize, Default)]
 pub(super) struct ReleaseJson {
     pub released: Vec<ReleasedPackage>,
@@ -17,6 +19,8 @@ pub(super) struct ReleasedPackage {
     pub tag: String,
     pub commit_count: usize,
     pub prerelease: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version_source: Option<VersionSource>,
     pub forge_release_url: Option<String>,
     pub forge_release_id: Option<u64>,
 }

--- a/src/monorepo/run/why/mod.rs
+++ b/src/monorepo/run/why/mod.rs
@@ -10,6 +10,7 @@ use crate::prerelease::PrereleaseContext;
 use crate::versioning::compute_next_version;
 
 use super::super::util::tags_for_package;
+use super::super::version_source::VersionSource;
 use super::plan::{
     ChangedFilesCache, PackagePlan, PlanInputs, commits_for_package, compute_plan, evaluate_touch,
 };
@@ -25,6 +26,8 @@ pub(super) struct Explanation {
     shared_paths: Vec<String>,
     strategy: String,
     current_version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version_source: Option<VersionSource>,
     monorepo: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     channel: Option<String>,
@@ -217,7 +220,7 @@ fn explain(
     let cascade = cascade_bumps(repo, root, config, &inputs)?;
     let dependencies = dependency_reports(pkg, &cascade);
 
-    let current_version = current_version(pkg, root, &plan);
+    let (current_version, version_source) = current_version(pkg, root, &plan);
     let decision = decide(
         config,
         pkg,
@@ -234,6 +237,7 @@ fn explain(
         shared_paths: pkg.shared_paths.clone(),
         strategy: format!("{strategy:?}").to_lowercase(),
         current_version,
+        version_source,
         monorepo: is_monorepo,
         channel: prerelease_ctx.channel.clone(),
         touch: TouchReport {
@@ -352,14 +356,23 @@ fn dependency_reports(
         .collect()
 }
 
-fn current_version(pkg: &PackageConfig, root: &Path, plan: &PackagePlan) -> String {
+fn current_version(
+    pkg: &PackageConfig,
+    root: &Path,
+    plan: &PackagePlan,
+) -> (String, Option<VersionSource>) {
     match plan {
-        PackagePlan::Bump(bump) => bump.current_version.clone(),
+        PackagePlan::Bump(bump) => (bump.current_version.clone(), bump.version_source.clone()),
         PackagePlan::Skipped { .. } => pkg
             .versioned_files
             .first()
-            .and_then(|vf| read_version(vf, root).ok())
-            .unwrap_or_else(|| "unknown".to_string()),
+            .and_then(|vf| {
+                read_version(vf, root).ok().map(|version| {
+                    let file = vf.path.clone();
+                    (version, Some(VersionSource::File { file }))
+                })
+            })
+            .unwrap_or_else(|| ("unknown".to_string(), None)),
     }
 }
 

--- a/src/monorepo/run/why/render.rs
+++ b/src/monorepo/run/why/render.rs
@@ -15,7 +15,11 @@ pub(super) fn lines(x: &Explanation) -> Vec<String> {
         ));
     }
     out.push(format!("  {:<14} {}", "Strategy:", x.strategy));
-    out.push(format!("  {:<14} {}", "Version:", x.current_version));
+    let version = match &x.version_source {
+        Some(source) => format!("{} ({source})", x.current_version),
+        None => x.current_version.clone(),
+    };
+    out.push(format!("  {:<14} {}", "Version:", version));
     if let Some(channel) = &x.channel {
         out.push(format!("  {:<14} {}", "Channel:", channel));
     }

--- a/src/monorepo/types.rs
+++ b/src/monorepo/types.rs
@@ -1,3 +1,5 @@
+use super::version_source::VersionSource;
+
 #[derive(serde::Serialize, serde::Deserialize)]
 pub(super) struct CheckCommit {
     pub hash: String,
@@ -14,6 +16,8 @@ pub(super) struct CheckPackage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub channel: Option<String>,
     pub prerelease: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version_source: Option<VersionSource>,
     pub commits: Vec<CheckCommit>,
 }
 

--- a/src/monorepo/version_source/mod.rs
+++ b/src/monorepo/version_source/mod.rs
@@ -1,0 +1,54 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(in crate::monorepo) enum VersionSource {
+    Tag { tag: String },
+    File { file: String },
+    TagOverFile { tag: String, file: String },
+    FileOverTag { file: String, tag: String },
+    Bootstrap,
+}
+
+impl VersionSource {
+    pub(in crate::monorepo) fn resolve(
+        tag: Option<(String, String)>,
+        file: Option<(String, String)>,
+        winner: &str,
+    ) -> Self {
+        match (tag, file) {
+            (Some((tag_name, tag_version)), Some((file_path, _))) => {
+                if winner == tag_version {
+                    Self::TagOverFile {
+                        tag: tag_name,
+                        file: file_path,
+                    }
+                } else {
+                    Self::FileOverTag {
+                        file: file_path,
+                        tag: tag_name,
+                    }
+                }
+            }
+            (Some((tag_name, _)), None) => Self::Tag { tag: tag_name },
+            (None, Some((file_path, _))) => Self::File { file: file_path },
+            (None, None) => Self::Bootstrap,
+        }
+    }
+}
+
+impl fmt::Display for VersionSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Tag { tag } => write!(f, "from tag {tag}"),
+            Self::File { file } => write!(f, "from {file}"),
+            Self::TagOverFile { tag, file } => write!(f, "from tag {tag}, over {file}"),
+            Self::FileOverTag { file, tag } => write!(f, "from {file}, over tag {tag}"),
+            Self::Bootstrap => write!(f, "bootstrapped"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/monorepo/version_source/tests.rs
+++ b/src/monorepo/version_source/tests.rs
@@ -1,0 +1,91 @@
+use super::VersionSource;
+
+fn tag() -> Option<(String, String)> {
+    Some(("discord-v2026.8.1".to_string(), "2026.8.1".to_string()))
+}
+
+fn file() -> Option<(String, String)> {
+    Some(("discord/Cargo.toml".to_string(), "2026.8.18".to_string()))
+}
+
+#[test]
+fn resolve_names_the_file_when_the_file_won_the_comparison() {
+    assert_eq!(
+        VersionSource::resolve(tag(), file(), "2026.8.18"),
+        VersionSource::FileOverTag {
+            file: "discord/Cargo.toml".to_string(),
+            tag: "discord-v2026.8.1".to_string(),
+        }
+    );
+}
+
+#[test]
+fn resolve_names_the_tag_when_the_tag_won_the_comparison() {
+    assert_eq!(
+        VersionSource::resolve(tag(), file(), "2026.8.1"),
+        VersionSource::TagOverFile {
+            tag: "discord-v2026.8.1".to_string(),
+            file: "discord/Cargo.toml".to_string(),
+        }
+    );
+}
+
+#[test]
+fn resolve_credits_the_tag_when_both_carry_the_same_version() {
+    let same = Some(("discord/Cargo.toml".to_string(), "2026.8.1".to_string()));
+    assert_eq!(
+        VersionSource::resolve(tag(), same, "2026.8.1"),
+        VersionSource::TagOverFile {
+            tag: "discord-v2026.8.1".to_string(),
+            file: "discord/Cargo.toml".to_string(),
+        }
+    );
+}
+
+#[test]
+fn resolve_reports_the_single_available_source() {
+    assert_eq!(
+        VersionSource::resolve(tag(), None, "2026.8.1"),
+        VersionSource::Tag {
+            tag: "discord-v2026.8.1".to_string()
+        }
+    );
+    assert_eq!(
+        VersionSource::resolve(None, file(), "2026.8.18"),
+        VersionSource::File {
+            file: "discord/Cargo.toml".to_string()
+        }
+    );
+}
+
+#[test]
+fn resolve_reports_bootstrap_when_neither_source_exists() {
+    assert_eq!(
+        VersionSource::resolve(None, None, "0.0.0"),
+        VersionSource::Bootstrap
+    );
+}
+
+#[test]
+fn a_missed_tag_is_distinguishable_from_a_real_first_release() {
+    let missed_tag = VersionSource::resolve(None, file(), "2026.8.18");
+    let first_release = VersionSource::resolve(None, None, "0.0.0");
+    assert_ne!(missed_tag, first_release);
+    assert_eq!(missed_tag.to_string(), "from discord/Cargo.toml");
+    assert_eq!(first_release.to_string(), "bootstrapped");
+}
+
+#[test]
+fn serializes_with_a_kind_discriminator_for_ci() {
+    let json = serde_json::to_value(VersionSource::resolve(None, file(), "2026.8.18")).unwrap();
+    assert_eq!(json["kind"], "file");
+    assert_eq!(json["file"], "discord/Cargo.toml");
+
+    let json = serde_json::to_value(VersionSource::Bootstrap).unwrap();
+    assert_eq!(json["kind"], "bootstrap");
+
+    let json = serde_json::to_value(VersionSource::resolve(tag(), file(), "2026.8.18")).unwrap();
+    assert_eq!(json["kind"], "file_over_tag");
+    assert_eq!(json["file"], "discord/Cargo.toml");
+    assert_eq!(json["tag"], "discord-v2026.8.1");
+}

--- a/tests/fixtures/definitions/version-source-file-without-tag.json
+++ b/tests/fixtures/definitions/version-source-file-without-tag.json
@@ -1,0 +1,26 @@
+{
+  "meta": {
+    "name": "version-source-file-without-tag",
+    "description": "A package with no tag reports that its current version came from the versioned file"
+  },
+  "config": {
+    "content": "{\n  \"package\": [\n    {\n      \"name\": \"discord\",\n      \"path\": \".\",\n      \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]\n    }\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "discord",
+      "path": ".",
+      "initial_version": "1.4.0"
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat: fold the bot into the repo",
+      "files": ["src/main.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["discord", "1.5.0", "from version.toml"],
+    "check_not_contains": ["bootstrapped"]
+  }
+}


### PR DESCRIPTION
Closes #862

`current_version` is resolved from four different places and the output printed
the resulting number without ever saying which one it came from. A package whose
tag was never pushed looked identical to one that simply has no tags yet.

```
● discord  2026.8.18 → 2026.8.19  (calverseq, from discord/Cargo.toml)
```

## What it reports

`VersionSource` is resolved at the point of the existing four-arm match, where the
information already exists and was being dropped immediately after.

| `kind` | Printed as | When |
| --- | --- | --- |
| `tag` | `from tag v1.2.3` | only a tag was found |
| `file` | `from discord/Cargo.toml` | only the versioned file was found |
| `tag_over_file` | `from tag v1.2.3, over discord/Cargo.toml` | both found, tag higher |
| `file_over_tag` | `from discord/Cargo.toml, over tag v1.2.3` | both found, file higher |
| `bootstrap` | `bootstrapped` | neither found |

On equality the tag is credited, matching `pick_higher_semver`'s own resolution
order. Cascade bumps always read the file, so they report `file`. Members aligned
to a `linked`/`fixed` group also report `file`: their new version comes from the
group, but the previous version they are compared against was read from their own
versioned file. The clause is omitted only when no source could be read at all.

`ferrflow why` reports the same source on its `Version:` line and in `why --json`,
which closes the gap between the version it prints and the `Last tag:` line below:

```
  Version:       2026.8.18 (from discord/Cargo.toml, over tag v2026.8.1)

Last tag: v2026.8.1 (6676654, 15 minutes ago, reachable from HEAD)
```

## JSON

Added to both `release --json` (`released[].version_source`) and `check --json`
(`packages[].version_source`), as a `kind`-tagged object so CI can branch on it
without parsing prose. Additive and optional, which the documented stability
contract already allows for.

```json
"version_source": { "kind": "file_over_tag", "file": "discord/Cargo.toml", "tag": "v2026.8.1" }
```

## Verified

All four arms exercised end-to-end against a real repo, not just unit tests:

```
● discord  2026.8.18 → 2026.8.19  (calverseq, from discord/Cargo.toml)
● discord  2026.8.18 → 2026.8.19  (calverseq, from discord/Cargo.toml, over tag v2026.8.1)
● discord  2026.9.5  → 2026.8.1   (calverseq, from tag v2026.9.5, over discord/Cargo.toml)
● api      0.0.0     → 0.1.0      (minor, bootstrapped)
```

Unit tests cover the resolution branching and pin the JSON discriminator; a
fixture covers the issue's own scenario end-to-end. `docs/api/release-output.md`
documents the field.

The file fallback itself is untouched, as the issue asks: only its visibility was
missing.
