### PR TITLE
feat(config): let a repo choose which version source wins

### DIFF
--- a/docs/api/release-output.md
+++ b/docs/api/release-output.md
@@ -74,16 +74,24 @@ versioned file. `version_source` reports which one it came from, so a
 package whose tag was never pushed is distinguishable from one that
 simply has no tags yet.
 
+The `_over_` and `_by_policy` kinds both mean two sources were present,
+and they answer different questions. `_over_` means the winner was
+higher; `_by_policy` means `versionSource` named it and the comparison
+never ran. A consumer treating `tag_over_file` and `tag_by_policy` as the
+same thing will read a configured choice as evidence the tag was ahead.
+
 | `kind` | Meaning | Extra fields |
 | --- | --- | --- |
 | `tag` | Only a tag was found. | `tag` |
 | `file` | Only the versioned file was found, no tag matched. | `file` |
 | `tag_over_file` | Both were found and the tag was the higher of the two. | `tag`, `file` |
 | `file_over_tag` | Both were found and the file was the higher of the two. | `file`, `tag` |
+| `tag_by_policy` | Both were found and `versionSource: tag` took the tag, whichever was higher. | `tag`, `file` |
+| `file_by_policy` | Both were found and `versionSource: file` took the file, whichever was higher. | `file`, `tag` |
 | `bootstrap` | Neither was found, the version is the strategy's starting point. | none |
 
-When both carry the same version the tag is credited, matching the
-resolution order. The same object appears in `check --json` under
+Under the default `versionSource: highest`, when both carry the same
+version the tag is credited, matching the resolution order. The same object appears in `check --json` under
 `packages[].version_source`, and in `why --json` at the top level.
 `why` reports `file` for a package it skipped, because that is the only
 source it reads in that case. A member pulled along by a `linked` or `fixed`

--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -184,6 +184,16 @@
           "description": "How to handle tags pointing to orphaned commits (after rebase + force-push). 'warn' logs a warning and skips. 'treeHash' attempts recovery by matching the commit's tree hash. 'message' attempts recovery by matching the commit message.",
           "default": "warn"
         },
+        "versionSource": {
+          "type": "string",
+          "enum": [
+            "highest",
+            "tag",
+            "file"
+          ],
+          "description": "Which source wins when a package has both a git tag and a version in a versioned file. 'highest' (default) takes whichever is higher, so a mistake in either source ratchets the version upward and is never walked back. 'tag' treats the tags as the record of what shipped and ignores the file. 'file' treats the file as the source and ignores the tag, which is what a package migrated between repos usually needs. With only one source present the setting has no effect.",
+          "default": "highest"
+        },
         "hooks": {
           "$ref": "#/$defs/hooks"
         },
@@ -410,6 +420,16 @@
           "description": "Snake_case form of `orphanedTagStrategy` — both spellings are accepted. How to handle tags pointing to orphaned commits (after rebase + force-push). 'warn' logs a warning and skips. 'treeHash' attempts recovery by matching the commit's tree hash. 'message' attempts recovery by matching the commit message.",
           "default": "warn"
         },
+        "version_source": {
+          "type": "string",
+          "enum": [
+            "highest",
+            "tag",
+            "file"
+          ],
+          "description": "Snake_case form of `versionSource`, both spellings are accepted. Which source wins when a package has both a git tag and a version in a versioned file. 'highest' (default) takes whichever is higher, so a mistake in either source ratchets the version upward and is never walked back. 'tag' treats the tags as the record of what shipped and ignores the file. 'file' treats the file as the source and ignores the tag, which is what a package migrated between repos usually needs. With only one source present the setting has no effect.",
+          "default": "highest"
+        },
         "defer_publish": {
           "type": "boolean",
           "description": "Snake_case form of `deferPublish` — both spellings are accepted. When true, `ferrflow release` does not run the configured publishers inline — it defers them to a separate `ferrflow publish` invocation (e.g. a CI job that carries the docker/helm/npm build toolchain the release job lacks). `ferrflow publish` always runs the publishers regardless of this flag.",
@@ -602,6 +622,15 @@
             "type": "boolean",
             "description": "Per-package override for workspace.updateLockfiles. Set false to skip lockfile refresh for this package even when the workspace default is on; set true to refresh only this package when the workspace default is off. Omit to inherit the workspace setting."
           },
+          "versionSource": {
+            "type": "string",
+            "enum": [
+              "highest",
+              "tag",
+              "file"
+            ],
+            "description": "Per-package override for workspace.versionSource. Lets one package in a monorepo pick its own tag-vs-file resolution without changing the policy for the others. Omit to inherit the workspace setting."
+          },
           "versioned_files": {
             "type": "array",
             "description": "Snake_case form of `versionedFiles` — both spellings are accepted. Files that contain the package version to update on release.",
@@ -697,6 +726,15 @@
           "update_lockfiles": {
             "type": "boolean",
             "description": "Snake_case form of `updateLockfiles` — both spellings are accepted. Per-package override for workspace.updateLockfiles. Set false to skip lockfile refresh for this package even when the workspace default is on; set true to refresh only this package when the workspace default is off. Omit to inherit the workspace setting."
+          },
+          "version_source": {
+            "type": "string",
+            "enum": [
+              "highest",
+              "tag",
+              "file"
+            ],
+            "description": "Snake_case form of `versionSource`, both spellings are accepted. Per-package override for workspace.versionSource. Lets one package in a monorepo pick its own tag-vs-file resolution without changing the policy for the others. Omit to inherit the workspace setting."
           }
         },
         "additionalProperties": false

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -175,6 +175,7 @@ fn collect_package(path_default: &str, monorepo: bool) -> PackageConfig {
         latest_tag: None,
         publishers: vec![],
         update_lockfiles: None,
+        version_source: None,
     }
 }
 

--- a/src/config/migrate.rs
+++ b/src/config/migrate.rs
@@ -318,6 +318,7 @@ pub fn build_config_from_releaserc(raw: &str) -> Result<(Config, MigrationReport
         latest_tag: None,
         publishers: vec![],
         update_lockfiles: None,
+        version_source: None,
     };
 
     report.warnings.push(

--- a/src/config/migrate/changesets.rs
+++ b/src/config/migrate/changesets.rs
@@ -156,6 +156,7 @@ fn scaffold_package(name: String, path: String) -> PackageConfig {
         latest_tag: None,
         publishers: vec![],
         update_lockfiles: None,
+        version_source: None,
     }
 }
 

--- a/src/config/migrate/release_please.rs
+++ b/src/config/migrate/release_please.rs
@@ -206,6 +206,7 @@ fn build_package(
         latest_tag: None,
         publishers: vec![],
         update_lockfiles: None,
+        version_source: None,
     }
 }
 

--- a/src/config/migrate/standard_version.rs
+++ b/src/config/migrate/standard_version.rs
@@ -152,6 +152,7 @@ pub(super) fn build(raw: &str) -> Result<(Config, MigrationReport)> {
         latest_tag: None,
         publishers: vec![],
         update_lockfiles: None,
+        version_source: None,
     };
 
     report.warnings.push(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -36,7 +36,7 @@ pub use package::{
 pub use types::{
     BranchChannelConfig, ChannelValue, DockerSign, ForgeKind, HooksConfig, OnFailure,
     OrphanedTagStrategy, PrereleaseIdentifier, PublisherConfig, RegistryConfig, ReleaseCommitBody,
-    ReleaseCommitMode, ReleaseCommitScope,
+    ReleaseCommitMode, ReleaseCommitScope, VersionSourcePolicy,
 };
 #[allow(unused_imports)]
 pub use workspace::{
@@ -243,6 +243,7 @@ impl Config {
                     latest_tag: None,
                     publishers: vec![],
                     update_lockfiles: None,
+                    version_source: None,
                 }]
             },
         }

--- a/src/config/package.rs
+++ b/src/config/package.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::conventional_commits::BumpType;
 
-use super::types::{HooksConfig, PublisherConfig};
+use super::types::{HooksConfig, PublisherConfig, VersionSourcePolicy};
 use super::workspace::WorkspaceConfig;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -29,6 +29,8 @@ pub struct PackageConfig {
     pub publishers: Vec<PublisherConfig>,
     #[serde(default, alias = "updateLockfiles")]
     pub update_lockfiles: Option<bool>,
+    #[serde(default, alias = "versionSource")]
+    pub version_source: Option<VersionSourcePolicy>,
 }
 
 /// An upstream package this one depends on.
@@ -216,6 +218,10 @@ impl PackageConfig {
     pub fn effective_update_lockfiles(&self, workspace: &WorkspaceConfig) -> bool {
         self.update_lockfiles.unwrap_or(workspace.update_lockfiles)
     }
+
+    pub fn effective_version_source(&self, workspace: &WorkspaceConfig) -> VersionSourcePolicy {
+        self.version_source.unwrap_or(workspace.version_source)
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -314,6 +320,7 @@ mod tests {
 
     fn pkg(path: &str, shared: &[&str]) -> PackageConfig {
         PackageConfig {
+            version_source: None,
             name: "api".to_string(),
             path: path.to_string(),
             versioned_files: Vec::new(),

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -194,6 +194,7 @@ fn effective_versioning_inherits_workspace() {
         ..WorkspaceConfig::default()
     };
     let pkg = PackageConfig {
+        version_source: None,
         name: "a".into(),
         path: ".".into(),
         versioned_files: vec![],
@@ -221,6 +222,7 @@ fn effective_versioning_package_overrides() {
         ..WorkspaceConfig::default()
     };
     let pkg = PackageConfig {
+        version_source: None,
         name: "a".into(),
         path: ".".into(),
         versioned_files: vec![],
@@ -248,6 +250,7 @@ fn effective_versioning_does_not_read_tags_when_strategy_is_configured() {
         ..WorkspaceConfig::default()
     };
     let pkg = PackageConfig {
+        version_source: None,
         name: "a".into(),
         path: ".".into(),
         versioned_files: vec![],
@@ -271,6 +274,7 @@ fn effective_versioning_does_not_read_tags_when_strategy_is_configured() {
 fn effective_versioning_autodetects_from_tags_when_unset() {
     let ws = WorkspaceConfig::default();
     let pkg = PackageConfig {
+        version_source: None,
         name: "a".into(),
         path: ".".into(),
         versioned_files: vec![],
@@ -296,6 +300,7 @@ fn effective_versioning_autodetects_from_tags_when_unset() {
 fn effective_versioning_falls_back_to_semver_without_tags() {
     let ws = WorkspaceConfig::default();
     let pkg = PackageConfig {
+        version_source: None,
         name: "a".into(),
         path: ".".into(),
         versioned_files: vec![],
@@ -318,6 +323,7 @@ fn effective_versioning_falls_back_to_semver_without_tags() {
 
 fn make_pkg(name: &str, tag_template: Option<&str>) -> PackageConfig {
     PackageConfig {
+        version_source: None,
         name: name.into(),
         path: ".".into(),
         versioned_files: vec![],
@@ -555,6 +561,7 @@ fn json_serializes_camel_case() {
             ..WorkspaceConfig::default()
         },
         packages: vec![PackageConfig {
+            version_source: None,
             name: "app".into(),
             path: ".".into(),
             versioned_files: vec![VersionedFile {
@@ -604,6 +611,7 @@ fn toml_keeps_snake_case() {
             ..WorkspaceConfig::default()
         },
         packages: vec![PackageConfig {
+            version_source: None,
             name: "app".into(),
             path: ".".into(),
             versioned_files: vec![VersionedFile {
@@ -1166,6 +1174,7 @@ fn depends_on_deserializes_snake_case() {
 fn tag_prefix_no_version_placeholder() {
     let ws = WorkspaceConfig::default();
     let pkg = PackageConfig {
+        version_source: None,
         name: "app".to_string(),
         path: ".".to_string(),
         latest_tag: None,
@@ -1187,6 +1196,7 @@ fn tag_prefix_no_version_placeholder() {
 fn tag_for_version_replaces_placeholders() {
     let ws = WorkspaceConfig::default();
     let pkg = PackageConfig {
+        version_source: None,
         name: "api".to_string(),
         latest_tag: None,
         path: ".".to_string(),

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -51,6 +51,15 @@ pub enum OnFailure {
     Continue,
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum VersionSourcePolicy {
+    #[default]
+    Highest,
+    Tag,
+    File,
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub enum OrphanedTagStrategy {

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -4,7 +4,7 @@ use super::commit_formats::CommitFormats;
 use super::package::{FloatingTagLevel, VersioningStrategy};
 use super::types::{
     BranchChannelConfig, ForgeKind, HooksConfig, OrphanedTagStrategy, RegistryConfig,
-    ReleaseCommitBody, ReleaseCommitMode, ReleaseCommitScope,
+    ReleaseCommitBody, ReleaseCommitMode, ReleaseCommitScope, VersionSourcePolicy,
 };
 use std::collections::BTreeMap;
 
@@ -42,6 +42,8 @@ pub struct WorkspaceConfig {
     pub latest_tag: Option<String>,
     #[serde(default, alias = "orphanedTagStrategy")]
     pub orphaned_tag_strategy: OrphanedTagStrategy,
+    #[serde(default, alias = "versionSource")]
+    pub version_source: VersionSourcePolicy,
     #[serde(default)]
     pub forge: ForgeKind,
     #[serde(default)]

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -259,6 +259,7 @@ mod tests {
 
     fn pkg(name: &str, path: &str) -> PackageConfig {
         PackageConfig {
+            version_source: None,
             name: name.to_string(),
             path: ".".to_string(),
             versioned_files: vec![VersionedFile {

--- a/src/monorepo/run/graph.rs
+++ b/src/monorepo/run/graph.rs
@@ -142,6 +142,7 @@ mod tests {
 
     fn pkg(name: &str, deps: &[&str]) -> PackageConfig {
         PackageConfig {
+            version_source: None,
             name: name.to_string(),
             path: name.to_string(),
             versioned_files: vec![],

--- a/src/monorepo/run/plan.rs
+++ b/src/monorepo/run/plan.rs
@@ -15,7 +15,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
-use super::super::util::{is_package_touched, pick_higher_semver, tags_for_package};
+use super::super::util::{is_package_touched, tags_for_package};
 use super::super::version_source::VersionSource;
 use super::forced::{Forced, forced_version_for};
 
@@ -261,17 +261,14 @@ pub(super) fn compute_plan(
         )?
     };
     let last_tag = highest_tag.as_ref().map(|(tag, _version)| tag.clone());
-    let current_version = match (&highest_tag, &file_source) {
-        (Some((_, tag)), Some((_, file))) => pick_higher_semver(file, tag),
-        (Some((_, tag)), None) => tag.clone(),
-        (None, Some((_, file))) => file.clone(),
-        (None, None) => crate::versioning::bootstrap_version(pkg_strategy),
-    };
-    let version_source = Some(VersionSource::resolve(
+    let (resolved, source) = VersionSource::resolve(
         highest_tag,
         file_source,
-        &current_version,
-    ));
+        pkg.effective_version_source(&config.workspace),
+    );
+    let current_version =
+        resolved.unwrap_or_else(|| crate::versioning::bootstrap_version(pkg_strategy));
+    let version_source = Some(source);
 
     let prerelease = inputs.prerelease_ctx.is_prerelease();
 

--- a/src/monorepo/tests.rs
+++ b/src/monorepo/tests.rs
@@ -516,6 +516,7 @@ fn pick_higher_semver_strips_leading_v() {
 
 fn make_pkg(name: &str, path: &str, shared: &[&str]) -> PackageConfig {
     PackageConfig {
+        version_source: None,
         name: name.into(),
         path: path.into(),
         versioned_files: vec![],

--- a/src/monorepo/version_source/mod.rs
+++ b/src/monorepo/version_source/mod.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+use super::util::pick_higher_semver;
+use crate::config::VersionSourcePolicy;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub(in crate::monorepo) enum VersionSource {
@@ -8,6 +11,8 @@ pub(in crate::monorepo) enum VersionSource {
     File { file: String },
     TagOverFile { tag: String, file: String },
     FileOverTag { file: String, tag: String },
+    TagByPolicy { tag: String, file: String },
+    FileByPolicy { file: String, tag: String },
     Bootstrap,
 }
 
@@ -15,25 +20,47 @@ impl VersionSource {
     pub(in crate::monorepo) fn resolve(
         tag: Option<(String, String)>,
         file: Option<(String, String)>,
-        winner: &str,
-    ) -> Self {
+        policy: VersionSourcePolicy,
+    ) -> (Option<String>, Self) {
         match (tag, file) {
-            (Some((tag_name, tag_version)), Some((file_path, _))) => {
-                if winner == tag_version {
-                    Self::TagOverFile {
+            (Some((tag_name, tag_version)), Some((file_path, file_version))) => match policy {
+                VersionSourcePolicy::Tag => (
+                    Some(tag_version),
+                    Self::TagByPolicy {
                         tag: tag_name,
                         file: file_path,
-                    }
-                } else {
-                    Self::FileOverTag {
+                    },
+                ),
+                VersionSourcePolicy::File => (
+                    Some(file_version),
+                    Self::FileByPolicy {
                         file: file_path,
                         tag: tag_name,
-                    }
+                    },
+                ),
+                VersionSourcePolicy::Highest => {
+                    let winner = pick_higher_semver(&file_version, &tag_version);
+                    let source = if winner == tag_version {
+                        Self::TagOverFile {
+                            tag: tag_name,
+                            file: file_path,
+                        }
+                    } else {
+                        Self::FileOverTag {
+                            file: file_path,
+                            tag: tag_name,
+                        }
+                    };
+                    (Some(winner), source)
                 }
+            },
+            (Some((tag_name, tag_version)), None) => {
+                (Some(tag_version), Self::Tag { tag: tag_name })
             }
-            (Some((tag_name, _)), None) => Self::Tag { tag: tag_name },
-            (None, Some((file_path, _))) => Self::File { file: file_path },
-            (None, None) => Self::Bootstrap,
+            (None, Some((file_path, file_version))) => {
+                (Some(file_version), Self::File { file: file_path })
+            }
+            (None, None) => (None, Self::Bootstrap),
         }
     }
 }
@@ -45,6 +72,12 @@ impl fmt::Display for VersionSource {
             Self::File { file } => write!(f, "from {file}"),
             Self::TagOverFile { tag, file } => write!(f, "from tag {tag}, over {file}"),
             Self::FileOverTag { file, tag } => write!(f, "from {file}, over tag {tag}"),
+            Self::TagByPolicy { tag, file } => {
+                write!(f, "from tag {tag}, {file} ignored by versionSource: tag")
+            }
+            Self::FileByPolicy { file, tag } => {
+                write!(f, "from {file}, tag {tag} ignored by versionSource: file")
+            }
             Self::Bootstrap => write!(f, "bootstrapped"),
         }
     }

--- a/src/monorepo/version_source/tests.rs
+++ b/src/monorepo/version_source/tests.rs
@@ -1,4 +1,11 @@
 use super::VersionSource;
+use crate::config::VersionSourcePolicy;
+
+const ALL: [VersionSourcePolicy; 3] = [
+    VersionSourcePolicy::Highest,
+    VersionSourcePolicy::Tag,
+    VersionSourcePolicy::File,
+];
 
 fn tag() -> Option<(String, String)> {
     Some(("discord-v2026.8.1".to_string(), "2026.8.1".to_string()))
@@ -9,9 +16,11 @@ fn file() -> Option<(String, String)> {
 }
 
 #[test]
-fn resolve_names_the_file_when_the_file_won_the_comparison() {
+fn highest_names_the_file_when_the_file_won_the_comparison() {
+    let (version, source) = VersionSource::resolve(tag(), file(), VersionSourcePolicy::Highest);
+    assert_eq!(version.as_deref(), Some("2026.8.18"));
     assert_eq!(
-        VersionSource::resolve(tag(), file(), "2026.8.18"),
+        source,
         VersionSource::FileOverTag {
             file: "discord/Cargo.toml".to_string(),
             tag: "discord-v2026.8.1".to_string(),
@@ -20,22 +29,39 @@ fn resolve_names_the_file_when_the_file_won_the_comparison() {
 }
 
 #[test]
-fn resolve_names_the_tag_when_the_tag_won_the_comparison() {
+fn highest_names_the_tag_when_the_tag_won_the_comparison() {
+    let higher_tag = Some(("discord-v2027.1.0".to_string(), "2027.1.0".to_string()));
+    let (version, source) =
+        VersionSource::resolve(higher_tag, file(), VersionSourcePolicy::Highest);
+    assert_eq!(version.as_deref(), Some("2027.1.0"));
     assert_eq!(
-        VersionSource::resolve(tag(), file(), "2026.8.1"),
+        source,
         VersionSource::TagOverFile {
-            tag: "discord-v2026.8.1".to_string(),
+            tag: "discord-v2027.1.0".to_string(),
             file: "discord/Cargo.toml".to_string(),
         }
     );
 }
 
 #[test]
-fn resolve_credits_the_tag_when_both_carry_the_same_version() {
+fn highest_credits_the_tag_when_both_carry_the_same_version() {
     let same = Some(("discord/Cargo.toml".to_string(), "2026.8.1".to_string()));
+    let (version, source) = VersionSource::resolve(tag(), same, VersionSourcePolicy::Highest);
+    assert_eq!(version.as_deref(), Some("2026.8.1"));
+    assert!(matches!(source, VersionSource::TagOverFile { .. }));
+}
+
+#[test]
+fn tag_policy_ignores_a_file_that_ratcheted_above_the_tags() {
+    let (version, source) = VersionSource::resolve(tag(), file(), VersionSourcePolicy::Tag);
     assert_eq!(
-        VersionSource::resolve(tag(), same, "2026.8.1"),
-        VersionSource::TagOverFile {
+        version.as_deref(),
+        Some("2026.8.1"),
+        "the inflated file version must not win"
+    );
+    assert_eq!(
+        source,
+        VersionSource::TagByPolicy {
             tag: "discord-v2026.8.1".to_string(),
             file: "discord/Cargo.toml".to_string(),
         }
@@ -43,33 +69,70 @@ fn resolve_credits_the_tag_when_both_carry_the_same_version() {
 }
 
 #[test]
-fn resolve_reports_the_single_available_source() {
+fn file_policy_ignores_a_tag_that_sits_above_the_file() {
+    let higher_tag = Some(("discord-v2027.1.0".to_string(), "2027.1.0".to_string()));
+    let (version, source) = VersionSource::resolve(higher_tag, file(), VersionSourcePolicy::File);
+    assert_eq!(version.as_deref(), Some("2026.8.18"));
     assert_eq!(
-        VersionSource::resolve(tag(), None, "2026.8.1"),
-        VersionSource::Tag {
-            tag: "discord-v2026.8.1".to_string()
-        }
-    );
-    assert_eq!(
-        VersionSource::resolve(None, file(), "2026.8.18"),
-        VersionSource::File {
-            file: "discord/Cargo.toml".to_string()
+        source,
+        VersionSource::FileByPolicy {
+            file: "discord/Cargo.toml".to_string(),
+            tag: "discord-v2027.1.0".to_string(),
         }
     );
 }
 
 #[test]
-fn resolve_reports_bootstrap_when_neither_source_exists() {
-    assert_eq!(
-        VersionSource::resolve(None, None, "0.0.0"),
-        VersionSource::Bootstrap
+fn a_policy_choice_is_distinguishable_from_a_comparison() {
+    let (_, by_policy) = VersionSource::resolve(tag(), file(), VersionSourcePolicy::Tag);
+    let higher_tag = Some(("discord-v2027.1.0".to_string(), "2027.1.0".to_string()));
+    let (_, by_height) = VersionSource::resolve(higher_tag, file(), VersionSourcePolicy::Highest);
+    assert_ne!(
+        by_policy, by_height,
+        "chosen because configured must not read as chosen because higher"
     );
+    assert!(by_policy.to_string().contains("ignored by versionSource"));
+    assert!(by_height.to_string().contains("over"));
+}
+
+#[test]
+fn a_single_source_is_unaffected_by_the_policy() {
+    for policy in ALL {
+        let (version, source) = VersionSource::resolve(tag(), None, policy);
+        assert_eq!(version.as_deref(), Some("2026.8.1"), "{policy:?}");
+        assert_eq!(
+            source,
+            VersionSource::Tag {
+                tag: "discord-v2026.8.1".to_string()
+            },
+            "{policy:?}"
+        );
+
+        let (version, source) = VersionSource::resolve(None, file(), policy);
+        assert_eq!(version.as_deref(), Some("2026.8.18"), "{policy:?}");
+        assert_eq!(
+            source,
+            VersionSource::File {
+                file: "discord/Cargo.toml".to_string()
+            },
+            "{policy:?}"
+        );
+    }
+}
+
+#[test]
+fn bootstrap_is_unaffected_by_the_policy() {
+    for policy in ALL {
+        let (version, source) = VersionSource::resolve(None, None, policy);
+        assert_eq!(version, None, "{policy:?}");
+        assert_eq!(source, VersionSource::Bootstrap, "{policy:?}");
+    }
 }
 
 #[test]
 fn a_missed_tag_is_distinguishable_from_a_real_first_release() {
-    let missed_tag = VersionSource::resolve(None, file(), "2026.8.18");
-    let first_release = VersionSource::resolve(None, None, "0.0.0");
+    let (_, missed_tag) = VersionSource::resolve(None, file(), VersionSourcePolicy::Highest);
+    let (_, first_release) = VersionSource::resolve(None, None, VersionSourcePolicy::Highest);
     assert_ne!(missed_tag, first_release);
     assert_eq!(missed_tag.to_string(), "from discord/Cargo.toml");
     assert_eq!(first_release.to_string(), "bootstrapped");
@@ -77,15 +140,26 @@ fn a_missed_tag_is_distinguishable_from_a_real_first_release() {
 
 #[test]
 fn serializes_with_a_kind_discriminator_for_ci() {
-    let json = serde_json::to_value(VersionSource::resolve(None, file(), "2026.8.18")).unwrap();
+    let kind = |policy, tag, file| {
+        let (_, source) = VersionSource::resolve(tag, file, policy);
+        serde_json::to_value(source).unwrap()
+    };
+
+    let json = kind(VersionSourcePolicy::Highest, None, file());
     assert_eq!(json["kind"], "file");
     assert_eq!(json["file"], "discord/Cargo.toml");
 
-    let json = serde_json::to_value(VersionSource::Bootstrap).unwrap();
+    let json = kind(VersionSourcePolicy::Highest, None, None);
     assert_eq!(json["kind"], "bootstrap");
 
-    let json = serde_json::to_value(VersionSource::resolve(tag(), file(), "2026.8.18")).unwrap();
+    let json = kind(VersionSourcePolicy::Highest, tag(), file());
     assert_eq!(json["kind"], "file_over_tag");
-    assert_eq!(json["file"], "discord/Cargo.toml");
+
+    let json = kind(VersionSourcePolicy::Tag, tag(), file());
+    assert_eq!(json["kind"], "tag_by_policy");
     assert_eq!(json["tag"], "discord-v2026.8.1");
+    assert_eq!(json["file"], "discord/Cargo.toml");
+
+    let json = kind(VersionSourcePolicy::File, tag(), file());
+    assert_eq!(json["kind"], "file_by_policy");
 }

--- a/src/validate/tests.rs
+++ b/src/validate/tests.rs
@@ -14,6 +14,7 @@ fn make_config(packages: Vec<PackageConfig>) -> Config {
 
 fn make_package(name: &str, path: &str) -> PackageConfig {
     PackageConfig {
+        version_source: None,
         name: name.to_string(),
         path: path.to_string(),
         versioned_files: vec![],

--- a/tests/fixtures/definitions/version-source-tag-policy.json
+++ b/tests/fixtures/definitions/version-source-tag-policy.json
@@ -1,0 +1,27 @@
+{
+  "meta": {
+    "name": "version-source-tag-policy",
+    "description": "versionSource tag ignores a versioned file that drifted above the tags"
+  },
+  "config": {
+    "content": "{\n  \"workspace\": {\"versionSource\": \"tag\"},\n  \"package\": [\n    {\"name\": \"discord\", \"path\": \".\", \"versioned_files\": [{\"path\": \"version.toml\", \"format\": \"toml\"}]}\n  ]\n}\n"
+  },
+  "packages": [
+    {
+      "name": "discord",
+      "path": ".",
+      "initial_version": "1.0.0",
+      "tag": "v0.5.0"
+    }
+  ],
+  "commits": [
+    {
+      "message": "feat: add a thing",
+      "files": ["src/main.rs"]
+    }
+  ],
+  "expect": {
+    "check_contains": ["discord", "0.6.0", "ignored by versionSource: tag"],
+    "check_not_contains": ["1.1.0"]
+  }
+}


### PR DESCRIPTION
Closes #863

`versionSource` picks which source wins when a package has both a tag and a versioned file. Default `highest` is today's behaviour, so nothing changes on upgrade and no repo needs config to keep what it has.

```jsonc
{ "workspace": { "versionSource": "highest" } }  // "tag" | "file"
```

Overridable per package, alongside `versioning`, `tagTemplate`, `floatingTags` and `updateLockfiles`.

## What it does, against a real repo

File at `2026.8.18`, tag at `v2026.8.1`:

```
default   ● discord  2026.8.18 → 2026.8.19  (calverseq, from discord/Cargo.toml, over tag v2026.8.1)
tag       ● discord  2026.8.1  → 2026.8.2   (calverseq, from tag v2026.8.1, discord/Cargo.toml ignored by versionSource: tag)
file      ● discord  2026.8.18 → 2026.8.19  (calverseq, from discord/Cargo.toml, tag v2026.8.1 ignored by versionSource: file)
```

The single-source and bootstrap arms are untouched, as the issue asks, and a test asserts that across all three policies.

## Why the reporting from #862 had to grow

With a policy, `from tag X, over <file>` becomes a lie: nothing was compared, the tag was named. Two kinds were added, `tag_by_policy` and `file_by_policy`, so `_over_` keeps meaning "was higher" and is never used for a configured choice. A consumer that conflated them would read a policy decision as evidence the tag was ahead.

`resolve` now returns the version alongside the source instead of taking the already-computed winner and inferring the source by string comparison. That removes the equality trick the review on #870 called out, and makes "which won, and why" answerable without re-deriving it.

## Schema

Added at both levels, camelCase and snake_case, because `additionalProperties: false` applies to both and serde accepts either spelling. Omitting the package level is the bug #868 fixed for `latestTag`.

Inserted as text rather than by re-serialising: a round-trip through a JSON formatter reflowed unrelated compact objects (`{ "type": "string" }` onto three lines), which would fail the schema-parity check even though the parsed document was identical. The diff is 38 insertions, 0 deletions.

The site copy is a separate repo, so parity stays red until this merges.

## Verified

10 unit tests over every policy and arm combination. The behaviour and the new fixture's expected strings were both checked by running the built binary against real repos, since the fixture generator does not build on this machine (rustc crashes on `vcpkg`).