### PR TITLE
fix(publish): publish to npm with trusted publishing over OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -399,6 +399,9 @@ jobs:
     name: Publish npm
     needs: upload
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -412,7 +415,6 @@ jobs:
           TAG: ${{ github.ref_name }}
       - name: Publish platform packages and wrapper
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash npm/scripts/publish.sh "${{ steps.version.outputs.value }}"
 
@@ -420,6 +422,9 @@ jobs:
     name: Publish @ferrflow/wasm
     needs: upload
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
@@ -437,8 +442,6 @@ jobs:
         env:
           TAG: ${{ github.ref_name }}
       - name: Build and publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: bash npm/scripts/publish-wasm.sh "${{ steps.version.outputs.value }}"
 
   publish-docker:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,3 +33,5 @@ That string is display text inside a `console.error` on the unsupported-platform
 There are no `preinstall`, `postinstall` or `prepare` scripts in the wrapper or in any platform package. The platform packages carry no JavaScript at all: the binary is placed into them by the release workflow, and they declare no `bin` and no `scripts`.
 
 Releases ship a `SHA256SUMS`, cosign signatures and build-provenance attestations. See [Verifying releases](https://ferrflow.com/docs/verifying-releases) for how to check them yourself; the GitHub Action verifies the digest before extracting.
+
+The npm packages are published with npm trusted publishing over OIDC. There is no long-lived npm token in the release workflow: publishing rights are bound to this repository and the `publish.yml` workflow, and npm generates a provenance attestation for every published package automatically.


### PR DESCRIPTION
Closes #874

npm publishing has failed on every tag since v7.1.0 with `E403 ... Two-factor authentication is required to publish this package but an automation token was specified`. crates.io, Docker, the GitHub Release and the binaries all shipped, so npm is three versions behind and nothing said so.

Rather than reopen the packages to automation tokens, this moves publishing to OIDC. Trusted publishing is explicitly unaffected by the "require 2FA, disallow tokens" setting that is rejecting us today, so the fix and the hardening are the same change.

- `id-token: write` on `publish-npm` and `publish-wasm` (both list `contents: read` too, since a job-level block replaces the top-level one rather than extending it).
- `NODE_AUTH_TOKEN` removed from both. No npm token remains anywhere in the repo.
- `setup-node` keeps `registry-url`, which is still what points npm at the registry.

The publish scripts need no change: they call plain `npm publish --access public`, and npm attaches a provenance attestation automatically under trusted publishing, so nothing has to pass `--provenance`.

Requirements checked against npm's own documentation rather than assumed: npm CLI 11.5.1+ and Node 22.14+, which Node 24 already satisfies, and npm's reference workflow for this is the same shape as ours with no explicit npm upgrade step.

## This does not work until the npm side is configured

A trusted publisher has to be registered on npmjs.com for each package, pointing at `FerrLabs/FerrFlow` and workflow `publish.yml`. All fields are case-sensitive and the filename must match exactly. Nine packages need it:

`ferrflow`, `@ferrflow/wasm`, and `@ferrflow/{linux-x64,linux-arm64,linux-arm,darwin-x64,darwin-arm64,win32-x64,win32-arm64}`

Merging this before that is done swaps one publish failure for another, so it is worth doing in the other order. Once it publishes, the `NPM_TOKEN` secret can be deleted.

## Left for a follow-up

#874 also notes that the release reported success while npm silently fell three versions behind. That guard is a separate change and this PR does not add it.