### PR TITLE
chore(ci): add socket.yml for Socket for GitHub

### DIFF
--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,13 @@
+version: 2
+
+triggerPaths:
+  - "Cargo.toml"
+  - "Cargo.lock"
+  - "npm/package.json"
+
+projectIgnorePaths:
+  - "npm/platforms"
+
+githubApp:
+  enabled: true
+  dependencyOverviewEnabled: true


### PR DESCRIPTION
Closes #876

Configuration for Socket for GitHub, so the App has something to read once it is installed. Inert until then.

`triggerPaths` is limited to the three real manifests. `npm/platforms` is ignored because those seven `package.json` files are generated stubs carrying a binary, with no dependencies and no scripts, so scanning them only pads the dependency overview.

No `issueRules` overrides on purpose. It is tempting to pre-silence the two alerts visible on the public package page, but they are a different thing: those are computed from our published tarball, while `issueRules` governs alerts raised against incoming dependencies. Disabling `unpopularPackage` here would suppress a real signal on a dependency and would not change the public page. Better to run the default policy and tune it when something actually proves noisy.

Installing the App is a manual step on GitHub and is not part of this PR.