### PR TITLE
fix(ci): drop socket.yml triggerPaths

### DIFF
--- a/socket.yml
+++ b/socket.yml
@@ -1,10 +1,5 @@
 version: 2
 
-triggerPaths:
-  - "Cargo.toml"
-  - "Cargo.lock"
-  - "npm/package.json"
-
 projectIgnorePaths:
   - "npm/platforms"
 


### PR DESCRIPTION
Closes #878

`triggerPaths` defaults to `["*"]` and a specified list replaces that default rather than extending it. #877 therefore did the opposite of what it read like: instead of documenting which manifests matter, it switched Socket off for every path not in the list.

The list was incomplete too. `ferrflow-wasm/Cargo.toml` matches none of the three patterns, so a dependency edit there would have gone unscanned. Root `Cargo.lock` covers most real changes, but a member manifest can move without the lockfile moving.

Dropping the key restores the default. The trade is a Socket check run on every PR against a silent coverage gap, and that trade is not close: Socket reports nothing on a PR that touches no dependency, so the cost is a passing check, while the gap is invisible by construction.

`projectIgnorePaths` stays as it was.