### PR TITLE
docs(readme): point the Socket badge at the crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ updates your version files, writes the changelog, and cuts the tagged release. A
 [![Maintainability](https://sonar.ferrlabs.com/api/project_badges/measure?project=ferrflow&metric=sqale_rating&token=sqb_53f0d93466bd01a6c6a94a15125d5aa8390c67fa)](https://sonar.ferrlabs.com/dashboard?id=ferrflow)
 [![Security](https://sonar.ferrlabs.com/api/project_badges/measure?project=ferrflow&metric=security_rating&token=sqb_53f0d93466bd01a6c6a94a15125d5aa8390c67fa)](https://sonar.ferrlabs.com/dashboard?id=ferrflow)
 [![License](https://img.shields.io/github/license/FerrLabs/FerrFlow)](LICENSE)
-[![Socket Badge](https://badge.socket.dev/npm/package/ferrflow/latest)](https://badge.socket.dev/npm/package/ferrflow/latest)
+[![Socket Badge](https://badge.socket.dev/cargo/package/ferrflow/latest)](https://socket.dev/cargo/package/ferrflow)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/FerrLabs/FerrFlow/badge)](https://scorecard.dev/viewer/?uri=github.com/FerrLabs/FerrFlow)
 
 [Documentation](https://ferrflow.com/docs) | [Changelog](https://ferrlabs.com/changelog/) | [GitHub App](https://github.com/apps/ferrflow)


### PR DESCRIPTION
Closes #880

The badge pointed at the npm package, which is the launcher: 0 dependencies, 7 optional deps that are the platform binary stubs, no scripts. Socket reads package behaviour and dependency trees, so there was next to nothing for it to report. The alerts on 7.3.1 show it: `URL strings` came from the wrapper's own error message, `unpopular package` from a binary stub.

`cargo/package/ferrflow` covers the 317 packages in `Cargo.lock`, which is the tree worth a supply-chain read.

The link target is fixed at the same time: it pointed at the badge SVG rather than the package page.

Same choice as LFSX#191, which points at Cargo for the same reason. As with that one, I could not load the URL to confirm it renders, since socket.dev serves a bot check to anything I fetch, including the npm badge that works today. Worth a glance at the rendered README after merge.