### PR TITLE
ci: harden token permissions and pin dependencies flagged by Scorecard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,7 +430,7 @@ jobs:
             mkdir -p baseline
             echo '[]' > baseline/benchmark-data.json
           fi
-      - uses: benchmark-action/github-action-benchmark@v1
+      - uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           tool: cargo
           output-file-path: output.txt

--- a/.github/workflows/renovate-rebase.yml
+++ b/.github/workflows/renovate-rebase.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [edited]
 
+permissions: {}
+
 jobs:
   dispatch:
     uses: FerrLabs/.github/.github/workflows/reusable-renovate-dispatch.yml@60b3aea308d6e0d612f3ca4e3f7259dc38626429 # main

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -11,10 +11,12 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   scan:
     name: Secrets + CVE
+    permissions:
+      contents: read
+      security-events: write
     uses: FerrLabs/.github/.github/workflows/reusable-security-scan.yml@60b3aea308d6e0d612f3ca4e3f7259dc38626429 # main
     secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir -p benches && echo 'fn main() {}' > benches/ferrflow_benchmarks.rs \
     && cargo build --release --package ferrflow
 
 # Runtime stage
-FROM alpine:3.24
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /app/target/release/ferrflow /usr/local/bin/ferrflow
 ENTRYPOINT ["ferrflow"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM alpine:3.24
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 RUN apk upgrade --no-cache && apk add --no-cache ca-certificates
 ARG TARGETARCH
 COPY ferrflow-${TARGETARCH} /usr/local/bin/ferrflow


### PR DESCRIPTION
Closes #882

Clears 6 of the 13 open Scorecard alerts. Five files, eight added lines.

**Token-Permissions**

`renovate-rebase.yml` had no top-level `permissions`. The reusable workflow it calls declares `permissions: {}`, so the caller grants nothing.

`security-scan.yml` had `security-events: write` at file level, applying to every job. Moved onto the `scan` job, which is what the called workflow actually needs. Top level is now `contents: read`.

**Pinned-Dependencies**

`benchmark-action/github-action-benchmark` was the only action in the repo on a tag instead of a SHA. Pinned to v1.22.1.

`alpine:3.24` pinned by digest in both Dockerfiles. I resolved the digest against Docker Hub rather than trusting the one in the report; they matched. Renovate maintains digests that are already present, so this does not freeze the base image.

**Deliberately not changed**

The job-level `contents: write` in `ci.yml` and `publish.yml` is the point of those jobs, creating releases and uploading assets. Scorecard flags any write, so Token-Permissions will not reach 10 while those exist. Removing them would break releases to satisfy a score.

`rustlang/rust:nightly-alpine` stays on the floating tag. Pinning a nightly digest goes stale within a day and converts into daily Renovate PRs.

**Flagged, not fixed**

`publish.yml` still installs wasm-pack via `curl https://rustwasm.github.io/… | sh`. That is the one item on this list that is a genuine supply-chain hole rather than a scanner being strict, and it runs in a job that holds npm publish rights. It wants its own change: this is the same release path that was repaired this morning, and stacking a second edit on it the same day is how you end up debugging two things at once.