### PR TITLE
feat(versioning): versionTemplate, a version format built from named variables

### DIFF
--- a/ferrflow-wasm/src/lib.rs
+++ b/ferrflow-wasm/src/lib.rs
@@ -17,7 +17,12 @@ pub fn determine_bump(message: &str, formats_json: Option<String>) -> Result<Str
 }
 
 #[wasm_bindgen]
-pub fn compute_next_version(current: &str, bump: &str, strategy: &str) -> Result<String, JsError> {
+pub fn compute_next_version(
+    current: &str,
+    bump: &str,
+    strategy: &str,
+    version_template: Option<String>,
+) -> Result<String, JsError> {
     let bump_type = match bump {
         "major" => ferrflow::conventional_commits::BumpType::Major,
         "minor" => ferrflow::conventional_commits::BumpType::Minor,
@@ -34,8 +39,13 @@ pub fn compute_next_version(current: &str, bump: &str, strategy: &str) -> Result
         _ => ferrflow::config::VersioningStrategy::Semver,
     };
 
-    versioning::compute_next_version(current, bump_type, strategy_type)
-        .map_err(|e| JsError::new(&e.to_string()))
+    versioning::compute_next_version(
+        current,
+        bump_type,
+        strategy_type,
+        version_template.as_deref(),
+    )
+    .map_err(|e| JsError::new(&e.to_string()))
 }
 
 #[wasm_bindgen]

--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -48,6 +48,16 @@
           ],
           "default": "semver"
         },
+        "versionTemplate": {
+          "type": "string",
+          "description": "Version format built from named variables. Variables: year, short_year, month, padded_month, day, padded_day, week, padded_week, quarter, seq, major, minor, patch. Each must be separated by a literal so the previous version can be read back. Takes precedence over 'versioning'.",
+          "examples": [
+            "{year}.{month}.{day}",
+            "{short_year}.{padded_month}.{seq}",
+            "{year}.Q{quarter}.{seq}",
+            "{year}.{minor}.{patch}"
+          ]
+        },
         "tagTemplate": {
           "type": "string",
           "description": "Tag template. Use {name} for package name and {version} for version. Default: 'v{version}' for single repos, '{name}@v{version}' for monorepos.",
@@ -576,6 +586,16 @@
               "calver-seq",
               "sequential",
               "zerover"
+            ]
+          },
+          "versionTemplate": {
+            "type": "string",
+            "description": "Version format built from named variables. Variables: year, short_year, month, padded_month, day, padded_day, week, padded_week, quarter, seq, major, minor, patch. Each must be separated by a literal so the previous version can be read back. Overrides workspace default. Takes precedence over 'versioning'.",
+            "examples": [
+              "{year}.{month}.{day}",
+              "{short_year}.{padded_month}.{seq}",
+              "{year}.Q{quarter}.{seq}",
+              "{year}.{minor}.{patch}"
             ]
           },
           "tagTemplate": {

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -170,6 +170,7 @@ fn collect_package(path_default: &str, monorepo: bool) -> PackageConfig {
         depends_on: vec![],
         versioning: None,
         tag_template: None,
+        version_template: None,
         hooks: None,
         floating_tags: None,
         latest_tag: None,

--- a/src/config/migrate.rs
+++ b/src/config/migrate.rs
@@ -313,6 +313,7 @@ pub fn build_config_from_releaserc(raw: &str) -> Result<(Config, MigrationReport
         depends_on: vec![],
         versioning: None,
         tag_template: None,
+        version_template: None,
         hooks: None,
         floating_tags: None,
         latest_tag: None,

--- a/src/config/migrate/changesets.rs
+++ b/src/config/migrate/changesets.rs
@@ -151,6 +151,7 @@ fn scaffold_package(name: String, path: String) -> PackageConfig {
         depends_on: vec![],
         versioning: None,
         tag_template: None,
+        version_template: None,
         hooks: None,
         floating_tags: None,
         latest_tag: None,

--- a/src/config/migrate/release_please.rs
+++ b/src/config/migrate/release_please.rs
@@ -201,6 +201,7 @@ fn build_package(
         depends_on: vec![],
         versioning: None,
         tag_template: None,
+        version_template: None,
         hooks: None,
         floating_tags: None,
         latest_tag: None,

--- a/src/config/migrate/standard_version.rs
+++ b/src/config/migrate/standard_version.rs
@@ -147,6 +147,7 @@ pub(super) fn build(raw: &str) -> Result<(Config, MigrationReport)> {
         depends_on: vec![],
         versioning: None,
         tag_template: None,
+        version_template: None,
         hooks: None,
         floating_tags: None,
         latest_tag: None,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -238,6 +238,7 @@ impl Config {
                     depends_on: vec![],
                     versioning: None,
                     tag_template: None,
+                    version_template: None,
                     hooks: None,
                     floating_tags: None,
                     latest_tag: None,

--- a/src/config/package.rs
+++ b/src/config/package.rs
@@ -19,6 +19,8 @@ pub struct PackageConfig {
     pub versioning: Option<VersioningStrategy>,
     #[serde(alias = "tagTemplate")]
     pub tag_template: Option<String>,
+    #[serde(alias = "versionTemplate")]
+    pub version_template: Option<String>,
     #[serde(default, alias = "floatingTags")]
     pub floating_tags: Option<Vec<FloatingTagLevel>>,
     #[serde(default, alias = "latestTag")]
@@ -164,6 +166,15 @@ impl PackageConfig {
             .unwrap_or_default()
     }
 
+    pub fn effective_version_template<'a>(
+        &'a self,
+        workspace: &'a WorkspaceConfig,
+    ) -> Option<&'a str> {
+        self.version_template
+            .as_deref()
+            .or(workspace.version_template.as_deref())
+    }
+
     fn effective_template<'a>(
         &'a self,
         workspace: &'a WorkspaceConfig,
@@ -263,6 +274,7 @@ mod tests {
     fn ws(tag_template: Option<&str>, latest: Option<&str>) -> WorkspaceConfig {
         WorkspaceConfig {
             tag_template: tag_template.map(str::to_string),
+            version_template: None,
             latest_tag: latest.map(str::to_string),
             ..Default::default()
         }
@@ -329,6 +341,7 @@ mod tests {
             depends_on: Vec::new(),
             versioning: None,
             tag_template: None,
+            version_template: None,
             floating_tags: None,
             latest_tag: None,
             hooks: None,

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -203,6 +203,7 @@ fn effective_versioning_inherits_workspace() {
         depends_on: vec![],
         versioning: None,
         tag_template: None,
+        version_template: None,
         hooks: None,
         floating_tags: None,
         latest_tag: None,
@@ -231,6 +232,7 @@ fn effective_versioning_package_overrides() {
         depends_on: vec![],
         versioning: Some(VersioningStrategy::Zerover),
         tag_template: None,
+        version_template: None,
         hooks: None,
         latest_tag: None,
         floating_tags: None,
@@ -259,6 +261,7 @@ fn effective_versioning_does_not_read_tags_when_strategy_is_configured() {
         depends_on: vec![],
         versioning: None,
         tag_template: None,
+        version_template: None,
         latest_tag: None,
         hooks: None,
         floating_tags: None,
@@ -284,6 +287,7 @@ fn effective_versioning_autodetects_from_tags_when_unset() {
         versioning: None,
         latest_tag: None,
         tag_template: None,
+        version_template: None,
         hooks: None,
         floating_tags: None,
         publishers: vec![],
@@ -310,6 +314,7 @@ fn effective_versioning_falls_back_to_semver_without_tags() {
         latest_tag: None,
         versioning: None,
         tag_template: None,
+        version_template: None,
         hooks: None,
         floating_tags: None,
         publishers: vec![],
@@ -333,6 +338,7 @@ fn make_pkg(name: &str, tag_template: Option<&str>) -> PackageConfig {
         depends_on: vec![],
         versioning: None,
         tag_template: tag_template.map(String::from),
+        version_template: None,
         hooks: None,
         floating_tags: None,
         publishers: vec![],
@@ -360,6 +366,7 @@ fn tag_default_monorepo() {
 fn tag_custom_workspace_template() {
     let ws = WorkspaceConfig {
         tag_template: Some("release-{version}".into()),
+        version_template: None,
         ..WorkspaceConfig::default()
     };
     let pkg = make_pkg("myapp", None);
@@ -371,6 +378,7 @@ fn tag_custom_workspace_template() {
 fn tag_package_overrides_workspace() {
     let ws = WorkspaceConfig {
         tag_template: Some("v{version}".into()),
+        version_template: None,
         ..WorkspaceConfig::default()
     };
     let pkg = make_pkg("api", Some("{name}/v{version}"));
@@ -557,6 +565,7 @@ fn json_serializes_camel_case() {
     let config = Config {
         workspace: WorkspaceConfig {
             tag_template: Some("v{version}".into()),
+            version_template: None,
             recover_missed_releases: true,
             ..WorkspaceConfig::default()
         },
@@ -575,6 +584,7 @@ fn json_serializes_camel_case() {
             depends_on: vec![],
             versioning: None,
             tag_template: Some("{name}@v{version}".into()),
+            version_template: None,
             hooks: None,
             floating_tags: None,
             publishers: vec![],
@@ -607,6 +617,7 @@ fn toml_keeps_snake_case() {
     let config = Config {
         workspace: WorkspaceConfig {
             tag_template: Some("v{version}".into()),
+            version_template: None,
             recover_missed_releases: true,
             ..WorkspaceConfig::default()
         },
@@ -625,6 +636,7 @@ fn toml_keeps_snake_case() {
             depends_on: vec![],
             versioning: None,
             tag_template: Some("{name}@v{version}".into()),
+            version_template: None,
             hooks: None,
             floating_tags: None,
             publishers: vec![],
@@ -1184,6 +1196,7 @@ fn tag_prefix_no_version_placeholder() {
         depends_on: vec![],
         versioning: None,
         tag_template: Some("release-latest".to_string()),
+        version_template: None,
         hooks: None,
         floating_tags: None,
         publishers: vec![],
@@ -1206,6 +1219,7 @@ fn tag_for_version_replaces_placeholders() {
         depends_on: vec![],
         versioning: None,
         tag_template: Some("{name}/v{version}".to_string()),
+        version_template: None,
         hooks: None,
         floating_tags: None,
         publishers: vec![],

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -20,6 +20,8 @@ pub struct WorkspaceConfig {
     pub versioning: Option<VersioningStrategy>,
     #[serde(alias = "tagTemplate")]
     pub tag_template: Option<String>,
+    #[serde(alias = "versionTemplate")]
+    pub version_template: Option<String>,
     #[serde(default, alias = "recoverMissedReleases")]
     pub recover_missed_releases: bool,
     #[serde(default, alias = "releaseCommitMode")]

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -272,6 +272,7 @@ mod tests {
             depends_on: vec![],
             versioning: None,
             tag_template: None,
+            version_template: None,
             hooks: None,
             floating_tags: None,
             latest_tag: None,

--- a/src/monorepo/run/cascade.rs
+++ b/src/monorepo/run/cascade.rs
@@ -78,7 +78,9 @@ pub(super) fn run_dependency_cascade(
             let strategy = pkg.effective_versioning(&config.workspace, || {
                 tags_for_package(all_tags, &pkg_tag_prefix)
             });
-            let Ok(new_version) = compute_next_version(&current_version, bump, strategy, None)
+            let version_template = pkg.effective_version_template(&config.workspace);
+            let Ok(new_version) =
+                compute_next_version(&current_version, bump, strategy, version_template)
             else {
                 continue;
             };
@@ -301,6 +303,96 @@ mod tests {
         )
         .unwrap();
         (lines, files_to_commit)
+    }
+
+    fn templated_workspace() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        for name in ["core", "cli"] {
+            std::fs::create_dir(root.join(name)).unwrap();
+        }
+        std::fs::write(
+            root.join("core/package.json"),
+            "{
+  \"name\": \"core\",
+  \"version\": \"1.0.0\"
+}
+",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("cli/package.json"),
+            "{
+  \"name\": \"cli\",
+  \"version\": \"1.0.0\",
+  \"dependencies\": {
+    \"core\": \"^1.0.0\"
+  }
+}
+",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("ferrflow.json"),
+            r#"{
+  "package": [
+    { "name": "core", "path": "core",
+      "versionedFiles": [{ "path": "core/package.json", "format": "json" }] },
+    { "name": "cli", "path": "cli", "dependsOn": [{ "name": "core" }],
+      "versionTemplate": "{year}.{month}.{seq}",
+      "versionedFiles": [{ "path": "cli/package.json", "format": "json" }] }
+  ]
+}
+"#,
+        )
+        .unwrap();
+        dir
+    }
+
+    #[test]
+    fn a_cascaded_package_uses_its_version_template() {
+        let dir = templated_workspace();
+        let config = Config::load(dir.path(), None).unwrap();
+
+        let mut any_bumped = false;
+        let mut json_packages = Vec::new();
+        let mut released = Vec::new();
+        let mut files_to_commit = Vec::new();
+        let mut files_per_package = HashMap::new();
+        let mut tags_to_create = Vec::new();
+        let mut pkg_outputs = Vec::new();
+        let mut bumped = HashMap::from([("core".to_string(), BumpType::Minor)]);
+        let mut bumped_versions = HashMap::from([("core".to_string(), "1.1.0".to_string())]);
+        let mut sink = CascadeSink {
+            any_bumped: &mut any_bumped,
+            json_packages: &mut json_packages,
+            released: &mut released,
+            files_to_commit: &mut files_to_commit,
+            files_per_package: &mut files_per_package,
+            tags_to_create: &mut tags_to_create,
+            pkg_outputs: &mut pkg_outputs,
+            bumped: &mut bumped,
+            bumped_versions: &mut bumped_versions,
+        };
+
+        run_dependency_cascade(
+            &config,
+            dir.path(),
+            &[],
+            None,
+            false,
+            false,
+            true,
+            &mut sink,
+        )
+        .unwrap();
+
+        let cli = bumped_versions.get("cli").expect("cli should be cascaded");
+        let year = chrono::Utc::now().format("%Y").to_string();
+        assert!(
+            cli.starts_with(&format!("{year}.")),
+            "cascaded package ignored its versionTemplate: got {cli}"
+        );
     }
 
     #[test]

--- a/src/monorepo/run/cascade.rs
+++ b/src/monorepo/run/cascade.rs
@@ -78,7 +78,8 @@ pub(super) fn run_dependency_cascade(
             let strategy = pkg.effective_versioning(&config.workspace, || {
                 tags_for_package(all_tags, &pkg_tag_prefix)
             });
-            let Ok(new_version) = compute_next_version(&current_version, bump, strategy) else {
+            let Ok(new_version) = compute_next_version(&current_version, bump, strategy, None)
+            else {
                 continue;
             };
             if current_version == new_version {

--- a/src/monorepo/run/graph.rs
+++ b/src/monorepo/run/graph.rs
@@ -155,6 +155,7 @@ mod tests {
             update_lockfiles: None,
             versioning: None,
             tag_template: None,
+            version_template: None,
             floating_tags: None,
             latest_tag: None,
             hooks: None,

--- a/src/monorepo/run/plan.rs
+++ b/src/monorepo/run/plan.rs
@@ -292,14 +292,17 @@ pub(super) fn compute_plan(
             .max()
             .unwrap_or(BumpType::None);
 
-        if bump == BumpType::None && !is_date_or_seq(pkg_strategy) {
+        let version_template = pkg.effective_version_template(&config.workspace);
+
+        if bump == BumpType::None && version_template.is_none() && !is_date_or_seq(pkg_strategy) {
             return Ok(PackagePlan::Skipped {
                 reason: SkipReason::NoReleasableCommits,
                 recovered,
             });
         }
 
-        let base_version = compute_next_version(&current_version, bump, pkg_strategy)?;
+        let base_version =
+            compute_next_version(&current_version, bump, pkg_strategy, version_template)?;
 
         let (new_version, is_prerelease) = if prerelease {
             let tag_prefix = pkg.tag_prefix(&config.workspace, is_monorepo);

--- a/src/monorepo/run/why/mod.rs
+++ b/src/monorepo/run/why/mod.rs
@@ -316,7 +316,8 @@ fn cascade_bumps(
                             &other.tag_prefix(&config.workspace, true),
                         )
                     });
-                    compute_next_version(&current, bump, strategy, None)
+                    let version_template = other.effective_version_template(&config.workspace);
+                    compute_next_version(&current, bump, strategy, version_template)
                         .is_ok_and(|next| next == current)
                 });
             if unchanged {
@@ -407,8 +408,15 @@ fn decide(
 
     if let Some(bump) = cascade.get(&pkg.name).copied()
         && bump != BumpType::None
-        && let Some(next) = read_version_for_cascade(pkg, root)
-            .and_then(|current| compute_next_version(&current, bump, strategy, None).ok())
+        && let Some(next) = read_version_for_cascade(pkg, root).and_then(|current| {
+            compute_next_version(
+                &current,
+                bump,
+                strategy,
+                pkg.effective_version_template(&config.workspace),
+            )
+            .ok()
+        })
         && next != current_version
     {
         return Ok(Decision::Bump {

--- a/src/monorepo/run/why/mod.rs
+++ b/src/monorepo/run/why/mod.rs
@@ -316,7 +316,8 @@ fn cascade_bumps(
                             &other.tag_prefix(&config.workspace, true),
                         )
                     });
-                    compute_next_version(&current, bump, strategy).is_ok_and(|next| next == current)
+                    compute_next_version(&current, bump, strategy, None)
+                        .is_ok_and(|next| next == current)
                 });
             if unchanged {
                 continue;
@@ -407,7 +408,7 @@ fn decide(
     if let Some(bump) = cascade.get(&pkg.name).copied()
         && bump != BumpType::None
         && let Some(next) = read_version_for_cascade(pkg, root)
-            .and_then(|current| compute_next_version(&current, bump, strategy).ok())
+            .and_then(|current| compute_next_version(&current, bump, strategy, None).ok())
         && next != current_version
     {
         return Ok(Decision::Bump {

--- a/src/monorepo/tests.rs
+++ b/src/monorepo/tests.rs
@@ -525,6 +525,7 @@ fn make_pkg(name: &str, path: &str, shared: &[&str]) -> PackageConfig {
         depends_on: vec![],
         versioning: None,
         tag_template: None,
+        version_template: None,
         hooks: None,
         floating_tags: None,
         latest_tag: None,

--- a/src/validate/checks.rs
+++ b/src/validate/checks.rs
@@ -43,6 +43,31 @@ pub(super) fn check_duplicate_paths(config: &Config) -> Vec<ValidationEntry> {
     entries
 }
 
+pub(super) fn check_version_templates(config: &Config) -> Vec<ValidationEntry> {
+    let mut entries = Vec::new();
+
+    let mut check = |template: &str, context: &str| {
+        if let Err(err) = crate::versioning::validate_version_template(template) {
+            entries.push(ValidationEntry {
+                level: ValidationLevel::Error,
+                path: context.to_string(),
+                message: err.to_string(),
+            });
+        }
+    };
+
+    if let Some(ref tmpl) = config.workspace.version_template {
+        check(tmpl, "workspace.versionTemplate");
+    }
+    for pkg in &config.packages {
+        if let Some(ref tmpl) = pkg.version_template {
+            check(tmpl, &format!("{}.versionTemplate", pkg.name));
+        }
+    }
+
+    entries
+}
+
 pub(super) fn check_tag_templates(config: &Config) -> Vec<ValidationEntry> {
     let mut entries = Vec::new();
     let is_monorepo = config.packages.len() > 1;

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -25,7 +25,8 @@ pub use source::{GitHubSource, GitLabSource, RemoteProvider, parse_repo_spec};
 use checks::{
     check_changelog_paths, check_duplicate_names, check_duplicate_paths, check_groups,
     check_package_paths, check_shared_paths, check_suggestions, check_tag_templates,
-    check_version_consistency, check_versioned_files, check_versioned_files_exist,
+    check_version_consistency, check_version_templates, check_versioned_files,
+    check_versioned_files_exist,
 };
 #[cfg(feature = "cli")]
 use output::output_result;
@@ -100,6 +101,7 @@ fn collect_entries(
     entries.extend(check_duplicate_names(config));
     entries.extend(check_duplicate_paths(config));
     entries.extend(check_tag_templates(config));
+    entries.extend(check_version_templates(config));
     entries.extend(check_package_paths(config, source));
     entries.extend(check_versioned_files_exist(config, source));
     let (file_entries, versions) = check_versioned_files(config, source);

--- a/src/validate/tests.rs
+++ b/src/validate/tests.rs
@@ -23,6 +23,7 @@ fn make_package(name: &str, path: &str) -> PackageConfig {
         depends_on: vec![],
         versioning: None,
         tag_template: None,
+        version_template: None,
         floating_tags: None,
         latest_tag: None,
         publishers: vec![],

--- a/src/versioning/mod.rs
+++ b/src/versioning/mod.rs
@@ -5,8 +5,10 @@ use crate::conventional_commits::BumpType;
 
 mod detect;
 mod strategies;
+mod template;
 
 pub use detect::detect_strategy_from_tags;
+pub use template::validate as validate_version_template;
 
 use strategies::{bump_semver, bump_sequential, bump_zerover, calver_seq_version, calver_version};
 
@@ -23,7 +25,11 @@ pub fn compute_next_version(
     current: &str,
     bump: BumpType,
     strategy: VersioningStrategy,
+    version_template: Option<&str>,
 ) -> Result<String> {
+    if let Some(tpl) = version_template {
+        return template::render(current, bump, tpl);
+    }
     match strategy {
         VersioningStrategy::Semver => bump_semver(current, bump),
         VersioningStrategy::Calver => calver_version("%Y.%m.%d"),

--- a/src/versioning/template.rs
+++ b/src/versioning/template.rs
@@ -1,0 +1,328 @@
+use anyhow::{Result, bail};
+use chrono::{DateTime, Datelike, Utc};
+use regex::Regex;
+
+use crate::conventional_commits::BumpType;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Var {
+    Year,
+    ShortYear,
+    Month,
+    PaddedMonth,
+    Day,
+    PaddedDay,
+    Week,
+    PaddedWeek,
+    Quarter,
+    Seq,
+    Major,
+    Minor,
+    Patch,
+}
+
+impl Var {
+    fn from_name(name: &str) -> Option<Self> {
+        Some(match name {
+            "year" => Self::Year,
+            "short_year" => Self::ShortYear,
+            "month" => Self::Month,
+            "padded_month" => Self::PaddedMonth,
+            "day" => Self::Day,
+            "padded_day" => Self::PaddedDay,
+            "week" => Self::Week,
+            "padded_week" => Self::PaddedWeek,
+            "quarter" => Self::Quarter,
+            "seq" => Self::Seq,
+            "major" => Self::Major,
+            "minor" => Self::Minor,
+            "patch" => Self::Patch,
+            _ => return None,
+        })
+    }
+
+    fn is_calendar(self) -> bool {
+        !matches!(self, Self::Seq | Self::Major | Self::Minor | Self::Patch)
+    }
+
+    fn render_calendar(self, now: DateTime<Utc>) -> String {
+        match self {
+            Self::Year => now.year().to_string(),
+            Self::ShortYear => format!("{:02}", now.year() % 100),
+            Self::Month => now.month().to_string(),
+            Self::PaddedMonth => format!("{:02}", now.month()),
+            Self::Day => now.day().to_string(),
+            Self::PaddedDay => format!("{:02}", now.day()),
+            Self::Week => now.iso_week().week().to_string(),
+            Self::PaddedWeek => format!("{:02}", now.iso_week().week()),
+            Self::Quarter => ((now.month() - 1) / 3 + 1).to_string(),
+            _ => unreachable!(),
+        }
+    }
+}
+
+const VALID_VARS: &str = "year, short_year, month, padded_month, day, padded_day, \
+week, padded_week, quarter, seq, major, minor, patch";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Segment {
+    Literal(String),
+    Var(Var),
+}
+
+#[derive(Debug, Clone)]
+pub struct VersionTemplate {
+    segments: Vec<Segment>,
+}
+
+impl VersionTemplate {
+    pub fn parse(template: &str) -> Result<Self> {
+        if template.trim().is_empty() {
+            bail!("versionTemplate is empty");
+        }
+
+        let mut segments = Vec::new();
+        let mut literal = String::new();
+        let mut rest = template;
+
+        while let Some(open) = rest.find('{') {
+            literal.push_str(&rest[..open]);
+            let after = &rest[open + 1..];
+            let Some(close) = after.find('}') else {
+                bail!("versionTemplate has an unclosed '{{' in {template:?}");
+            };
+            let name = &after[..close];
+            let Some(var) = Var::from_name(name) else {
+                bail!("versionTemplate uses unknown variable {{{name}}}. Valid: {VALID_VARS}");
+            };
+            if !literal.is_empty() {
+                segments.push(Segment::Literal(std::mem::take(&mut literal)));
+            } else if matches!(segments.last(), Some(Segment::Var(_))) {
+                bail!(
+                    "versionTemplate puts {{{name}}} directly after another variable, which cannot be read back. Separate them with a literal, e.g. '.'"
+                );
+            }
+            segments.push(Segment::Var(var));
+            rest = &after[close + 1..];
+        }
+        literal.push_str(rest);
+        if !literal.is_empty() {
+            segments.push(Segment::Literal(literal));
+        }
+
+        if !segments.iter().any(|s| matches!(s, Segment::Var(_))) {
+            bail!("versionTemplate {template:?} contains no variables");
+        }
+        if segments
+            .iter()
+            .filter(|s| matches!(s, Segment::Var(Var::Seq)))
+            .count()
+            > 1
+        {
+            bail!("versionTemplate uses {{seq}} more than once");
+        }
+
+        Ok(Self { segments })
+    }
+
+    fn vars(&self) -> impl Iterator<Item = Var> + '_ {
+        self.segments.iter().filter_map(|s| match s {
+            Segment::Var(v) => Some(*v),
+            Segment::Literal(_) => None,
+        })
+    }
+
+    fn read_back(&self, current: &str) -> Option<Vec<(Var, u64)>> {
+        let mut pattern = String::from("^");
+        for segment in &self.segments {
+            match segment {
+                Segment::Literal(text) => pattern.push_str(&regex::escape(text)),
+                Segment::Var(_) => pattern.push_str(r"(\d+)"),
+            }
+        }
+        pattern.push('$');
+
+        let re = Regex::new(&pattern).ok()?;
+        let caps = re.captures(current.trim_start_matches('v'))?;
+        self.vars()
+            .enumerate()
+            .map(|(i, var)| caps.get(i + 1)?.as_str().parse().ok().map(|n| (var, n)))
+            .collect()
+    }
+
+    pub fn render(&self, current: &str, bump: BumpType, now: DateTime<Utc>) -> String {
+        let previous = self.read_back(current);
+
+        let calendar_rolled = previous.as_ref().is_none_or(|vals| {
+            vals.iter()
+                .filter(|(v, _)| v.is_calendar())
+                .any(|(v, n)| v.render_calendar(now) != n.to_string())
+        });
+
+        let previous_of = |want: Var| {
+            previous
+                .as_ref()
+                .and_then(|vals| vals.iter().find(|(v, _)| *v == want).map(|(_, n)| *n))
+        };
+
+        let seq = if calendar_rolled {
+            1
+        } else {
+            previous_of(Var::Seq).unwrap_or(0) + 1
+        };
+
+        let major = previous_of(Var::Major).unwrap_or(0);
+        let minor = previous_of(Var::Minor).unwrap_or(0);
+        let patch = previous_of(Var::Patch).unwrap_or(0);
+        let (major, minor, patch) = match bump {
+            BumpType::Major => (major + 1, 0, 0),
+            BumpType::Minor => (major, minor + 1, 0),
+            BumpType::Patch => (major, minor, patch + 1),
+            BumpType::None => (major, minor, patch),
+        };
+
+        self.segments
+            .iter()
+            .map(|segment| match segment {
+                Segment::Literal(text) => text.clone(),
+                Segment::Var(Var::Seq) => seq.to_string(),
+                Segment::Var(Var::Major) => major.to_string(),
+                Segment::Var(Var::Minor) => minor.to_string(),
+                Segment::Var(Var::Patch) => patch.to_string(),
+                Segment::Var(var) => var.render_calendar(now),
+            })
+            .collect()
+    }
+}
+
+pub fn validate(template: &str) -> Result<()> {
+    VersionTemplate::parse(template).map(|_| ())
+}
+
+pub fn render(current: &str, bump: BumpType, template: &str) -> Result<String> {
+    Ok(VersionTemplate::parse(template)?.render(current, bump, Utc::now()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn at(y: i32, m: u32, d: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(y, m, d, 12, 0, 0).unwrap()
+    }
+
+    fn render_at(template: &str, current: &str, bump: BumpType, now: DateTime<Utc>) -> String {
+        VersionTemplate::parse(template)
+            .unwrap()
+            .render(current, bump, now)
+    }
+
+    #[test]
+    fn renders_calendar_variables() {
+        let now = at(2026, 8, 5);
+        assert_eq!(
+            render_at("{year}.{month}.{day}", "0.0.0", BumpType::None, now),
+            "2026.8.5"
+        );
+        assert_eq!(
+            render_at(
+                "{short_year}.{padded_month}.{padded_day}",
+                "0.0.0",
+                BumpType::None,
+                now
+            ),
+            "26.08.05"
+        );
+        assert_eq!(
+            render_at("{year}.Q{quarter}", "0.0", BumpType::None, now),
+            "2026.Q3"
+        );
+    }
+
+    #[test]
+    fn seq_increments_while_the_calendar_part_holds() {
+        let now = at(2026, 8, 20);
+        assert_eq!(
+            render_at("{year}.{month}.{seq}", "2026.8.3", BumpType::None, now),
+            "2026.8.4"
+        );
+    }
+
+    #[test]
+    fn seq_resets_when_the_calendar_part_rolls() {
+        let now = at(2026, 9, 1);
+        assert_eq!(
+            render_at("{year}.{month}.{seq}", "2026.8.7", BumpType::None, now),
+            "2026.9.1"
+        );
+    }
+
+    #[test]
+    fn seq_resets_when_the_current_version_does_not_match_the_template() {
+        let now = at(2026, 8, 20);
+        assert_eq!(
+            render_at("{year}.{month}.{seq}", "1.4.2-rc.1", BumpType::None, now),
+            "2026.8.1"
+        );
+    }
+
+    #[test]
+    fn mixes_calendar_and_semver_parts() {
+        let now = at(2026, 8, 20);
+        assert_eq!(
+            render_at("{year}.{minor}.{patch}", "2026.4.7", BumpType::Minor, now),
+            "2026.5.0"
+        );
+        assert_eq!(
+            render_at("{year}.{minor}.{patch}", "2026.4.7", BumpType::Patch, now),
+            "2026.4.8"
+        );
+    }
+
+    #[test]
+    fn a_leading_v_on_the_current_version_still_reads_back() {
+        let now = at(2026, 8, 20);
+        assert_eq!(
+            render_at("{year}.{month}.{seq}", "v2026.8.3", BumpType::None, now),
+            "2026.8.4"
+        );
+    }
+
+    #[test]
+    fn rejects_an_unknown_variable() {
+        let err = VersionTemplate::parse("{yaer}.{month}")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unknown variable {yaer}"), "{err}");
+        assert!(err.contains("short_year"), "{err}");
+    }
+
+    #[test]
+    fn rejects_adjacent_variables_because_they_cannot_be_read_back() {
+        let err = VersionTemplate::parse("{year}{month}")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("directly after another variable"), "{err}");
+    }
+
+    #[test]
+    fn rejects_an_unclosed_brace() {
+        assert!(VersionTemplate::parse("{year.{month}").is_err());
+    }
+
+    #[test]
+    fn rejects_a_template_with_no_variables() {
+        assert!(VersionTemplate::parse("1.0.0").is_err());
+    }
+
+    #[test]
+    fn rejects_more_than_one_seq() {
+        assert!(VersionTemplate::parse("{seq}.{seq}").is_err());
+    }
+
+    #[test]
+    fn rejects_an_empty_template() {
+        assert!(VersionTemplate::parse("   ").is_err());
+    }
+}

--- a/src/versioning/tests.rs
+++ b/src/versioning/tests.rs
@@ -35,7 +35,7 @@ fn bootstrap_values_survive_first_bump_for_every_strategy() {
     ] {
         let baseline = bootstrap_version(strategy);
         for bump in [BumpType::Patch, BumpType::Minor, BumpType::Major] {
-            let result = compute_next_version(&baseline, bump, strategy);
+            let result = compute_next_version(&baseline, bump, strategy, None);
             assert!(
                 result.is_ok(),
                 "bootstrap {baseline:?} with {bump:?} on {strategy:?} failed: {result:?}"
@@ -127,7 +127,7 @@ fn test_calver_seq_same_month() {
 #[test]
 fn test_compute_next_version_semver() {
     assert_eq!(
-        compute_next_version("1.2.3", BumpType::Minor, VersioningStrategy::Semver).unwrap(),
+        compute_next_version("1.2.3", BumpType::Minor, VersioningStrategy::Semver, None).unwrap(),
         "1.3.0"
     );
 }
@@ -135,7 +135,7 @@ fn test_compute_next_version_semver() {
 #[test]
 fn test_compute_next_version_zerover() {
     assert_eq!(
-        compute_next_version("0.5.2", BumpType::Major, VersioningStrategy::Zerover).unwrap(),
+        compute_next_version("0.5.2", BumpType::Major, VersioningStrategy::Zerover, None).unwrap(),
         "0.6.0"
     );
 }
@@ -143,7 +143,7 @@ fn test_compute_next_version_zerover() {
 #[test]
 fn test_compute_next_version_sequential() {
     assert_eq!(
-        compute_next_version("10", BumpType::Patch, VersioningStrategy::Sequential).unwrap(),
+        compute_next_version("10", BumpType::Patch, VersioningStrategy::Sequential, None).unwrap(),
         "11"
     );
 }
@@ -224,7 +224,8 @@ fn test_sequential_with_v_prefix() {
 
 #[test]
 fn test_compute_next_version_calver() {
-    let v = compute_next_version("0.0.0", BumpType::Minor, VersioningStrategy::Calver).unwrap();
+    let v =
+        compute_next_version("0.0.0", BumpType::Minor, VersioningStrategy::Calver, None).unwrap();
     assert_eq!(v.split('.').count(), 3);
     let year: u32 = v.split('.').next().unwrap().parse().unwrap();
     assert!(year >= 2026);
@@ -232,16 +233,26 @@ fn test_compute_next_version_calver() {
 
 #[test]
 fn test_compute_next_version_calver_short() {
-    let v =
-        compute_next_version("0.0.0", BumpType::Minor, VersioningStrategy::CalverShort).unwrap();
+    let v = compute_next_version(
+        "0.0.0",
+        BumpType::Minor,
+        VersioningStrategy::CalverShort,
+        None,
+    )
+    .unwrap();
     let year: u32 = v.split('.').next().unwrap().parse().unwrap();
     assert!(year < 100);
 }
 
 #[test]
 fn test_compute_next_version_calver_seq() {
-    let v =
-        compute_next_version("2020.1.5", BumpType::Minor, VersioningStrategy::CalverSeq).unwrap();
+    let v = compute_next_version(
+        "2020.1.5",
+        BumpType::Minor,
+        VersioningStrategy::CalverSeq,
+        None,
+    )
+    .unwrap();
     let parts: Vec<&str> = v.split('.').collect();
     assert_eq!(parts.len(), 3);
     assert_eq!(parts[2], "1");
@@ -526,14 +537,40 @@ fn detect_calver_seq_mixed_with_calver_shape_prefers_seq() {
 
 #[test]
 fn compute_next_version_all_strategies() {
-    assert!(compute_next_version("1.0.0", BumpType::Patch, VersioningStrategy::Semver).is_ok());
-    assert!(compute_next_version("0.1.0", BumpType::Patch, VersioningStrategy::Zerover).is_ok());
-    assert!(compute_next_version("5", BumpType::Patch, VersioningStrategy::Sequential).is_ok());
-    assert!(compute_next_version("2020.1.1", BumpType::Patch, VersioningStrategy::Calver).is_ok());
     assert!(
-        compute_next_version("2020.1.1", BumpType::Patch, VersioningStrategy::CalverShort).is_ok()
+        compute_next_version("1.0.0", BumpType::Patch, VersioningStrategy::Semver, None).is_ok()
     );
     assert!(
-        compute_next_version("2020.1.1", BumpType::Patch, VersioningStrategy::CalverSeq).is_ok()
+        compute_next_version("0.1.0", BumpType::Patch, VersioningStrategy::Zerover, None).is_ok()
+    );
+    assert!(
+        compute_next_version("5", BumpType::Patch, VersioningStrategy::Sequential, None).is_ok()
+    );
+    assert!(
+        compute_next_version(
+            "2020.1.1",
+            BumpType::Patch,
+            VersioningStrategy::Calver,
+            None
+        )
+        .is_ok()
+    );
+    assert!(
+        compute_next_version(
+            "2020.1.1",
+            BumpType::Patch,
+            VersioningStrategy::CalverShort,
+            None
+        )
+        .is_ok()
+    );
+    assert!(
+        compute_next_version(
+            "2020.1.1",
+            BumpType::Patch,
+            VersioningStrategy::CalverSeq,
+            None
+        )
+        .is_ok()
     );
 }


### PR DESCRIPTION
Closes #885

Adds `versionTemplate`, a version format assembled from named variables, on both workspace and package. Same single-brace syntax as `tagTemplate`.

```jsonc
{ "workspace": { "versionTemplate": "{short_year}.{padded_month}.{seq}" } }
```

Verified against the real CLI, not just unit tests:

```
● app  0.0.0 → 26.08.1  (minor, bootstrapped)
```

Variables: `year` `short_year` `month` `padded_month` `day` `padded_day` `week` `padded_week` `quarter` `seq` `major` `minor` `patch`.

`{seq}` is read back off the current version rather than guessed: the template is compiled to a matcher, and the sequence increments only while every calendar variable still renders to the value it had. When the calendar rolls, or when the current version does not match the template at all, it resets to 1 instead of failing.

`{major}`/`{minor}`/`{patch}` come from the same read-back and then take the conventional-commit bump, so calendar and semver parts mix: `{year}.{minor}.{patch}` with a minor bump takes `2026.4.7` to `2026.5.0`.

## Not breaking

The six existing strategies are untouched and keep their exact behaviour. `versionTemplate` simply wins when set. Every existing config keeps working, so no `!` and no major.

The wasm export gained a fourth parameter typed `Option<String>`, which reaches JS as an optional argument. Existing three-argument calls, including the playground's, still work.

## Two failure modes are rejected at validation time rather than at release time

```
✗ workspace.versionTemplate: versionTemplate uses unknown variable {short_yaer}.
  Valid: year, short_year, month, padded_month, day, padded_day, week, padded_week,
  quarter, seq, major, minor, patch

✗ workspace.versionTemplate: versionTemplate puts {month} directly after another
  variable, which cannot be read back. Separate them with a literal, e.g. '.'
```

Adjacent variables are the one that matters: `{year}{month}` renders fine and then cannot be parsed back, so `{seq}` would silently reset on every release. Catching it in `validate` turns a silent wrong answer into a message.

## Scope

12 template tests plus the existing suite, 2017 tests green, clippy clean at `-D warnings`.

`ferrflow.ts` and `ferrflow.js` configs needed no work: the JS loader returns the same shape, so the field flows through.

`schema/ferrflow.json` is updated here, purely additive, 20 lines and no deletions, so the byte-identical copy in FerrFlow-Cloud can be a straight file copy. That PR has to land after this one merges, since the parity job compares against FerrFlow main.

Docs (EN + FR) and a changelog entry are tracked separately.