### PR TITLE
chore(deny): ban the six crates from the arrayref supply-chain attack

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -45,6 +45,12 @@ deny = [
     # ~5 MB to ~9 MB and we inherit OpenSSL's CVE cadence. Use rustls.
     { crate = "openssl-sys", reason = "Use rustls (via gix / ureq) instead." },
     { crate = "openssl-src", reason = "Vendoring OpenSSL bloats the binary." },
+    { crate = "proc-macro1", reason = "Malicious crate from the 2026-08-20 arrayref supply-chain attack." },
+    { crate = "proc-macro-en", reason = "Malicious crate from the 2026-08-20 arrayref supply-chain attack." },
+    { crate = "aovine", reason = "Malicious crate from the 2026-08-20 arrayref supply-chain attack." },
+    { crate = "arone", reason = "Malicious crate from the 2026-08-20 arrayref supply-chain attack." },
+    { crate = "aronenao", reason = "Malicious crate from the 2026-08-20 arrayref supply-chain attack." },
+    { crate = "tinymember", reason = "Malicious crate from the 2026-08-20 arrayref supply-chain attack." },
 ]
 skip = []
 skip-tree = []


### PR DESCRIPTION
Closes #890

Adds `proc-macro1`, `proc-macro-en`, `aovine`, `arone`, `aronenao` and `tinymember` to `[bans].deny`, the six attacker crates from the 2026-08-20 `arrayref` supply-chain attack.

FerrFlow was not affected: its `Cargo.lock` carries no `arrayref`, and the two lockfile commits inside the attack window were version bumps with no dependency resolution.

This is insurance, not a fix. The crates are deleted from crates.io and cannot resolve today; the entries only bite if a name gets reclaimed later. FerrFlow is nonetheless the only repo where a ban is enforced at all, since it is the only one with a live `deny.toml` (`ci.yml:53`) while every product sets `enable-deny: false`.

The load-bearing change is `--locked` on CI's cargo invocations, in FerrLabs/.github#272.