### PR TITLE
perf(bench): add an end-to-end monorepo flow benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,6 +349,7 @@ jobs:
           - git_changed_since_tag
           - validate
           - full_check_flow
+          - full_monorepo_flow
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/benches/ferrflow_benchmarks.rs
+++ b/benches/ferrflow_benchmarks.rs
@@ -10,6 +10,7 @@ use ferrflow::git::{
     GitLog, collect_all_tags, find_last_tag_name, get_changed_files, get_changed_files_since_tag,
     get_commits_since_last_tag,
 };
+use ferrflow::versioning::compute_next_version;
 use tempfile::{NamedTempFile, TempDir};
 
 fn generate_commit_messages(count: usize) -> Vec<String> {
@@ -428,6 +429,122 @@ fn bench_full_check_flow(c: &mut Criterion) {
     }
 }
 
+fn create_monorepo_bench_repo(
+    num_packages: usize,
+    num_commits: usize,
+) -> (TempDir, gix::Repository) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path();
+    run_git(path, &["init", "-b", "main"]);
+    run_git(path, &["config", "user.name", "bench"]);
+    run_git(path, &["config", "user.email", "bench@test.com"]);
+    run_git(path, &["config", "commit.gpgsign", "false"]);
+
+    let types = ["feat", "fix", "refactor", "perf", "chore"];
+    let mut parent: Option<String> = None;
+
+    for i in 0..num_commits {
+        let pkg = (i % num_packages) + 1;
+        let t = types[i % types.len()];
+        let breaking = if i % 50 == 0 && i > 0 { "!" } else { "" };
+        let msg = format!("{t}(pkg-{pkg:03}){breaking}: change {i}");
+
+        let file_name = format!("packages/pkg-{pkg:03}/src/file_{i}.rs");
+        let content = format!(
+            "// commit {i}
+"
+        );
+        let blob_sha = run_git_with_stdin(
+            path,
+            &["hash-object", "-w", "--stdin"],
+            Some(content.as_bytes()),
+        )
+        .trim()
+        .to_string();
+        run_git(
+            path,
+            &[
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                &format!("100644,{blob_sha},{file_name}"),
+            ],
+        );
+        let tree_sha = run_git(path, &["write-tree"]).trim().to_string();
+        let mut commit_args: Vec<String> = vec!["commit-tree".into(), tree_sha, "-m".into(), msg];
+        if let Some(p) = &parent {
+            commit_args.push("-p".into());
+            commit_args.push(p.clone());
+        }
+        let arg_refs: Vec<&str> = commit_args.iter().map(String::as_str).collect();
+        let commit_sha = run_git(path, &arg_refs).trim().to_string();
+        run_git(path, &["update-ref", "refs/heads/main", &commit_sha]);
+        parent = Some(commit_sha.clone());
+
+        if i == 0 {
+            run_git(path, &["tag", "v1.0.0", &commit_sha]);
+        }
+    }
+
+    std::fs::write(path.join(".ferrflow"), generate_config_json(num_packages)).unwrap();
+    for i in 1..=num_packages {
+        let pkg_dir = path.join(format!("packages/pkg-{i:03}"));
+        std::fs::create_dir_all(&pkg_dir).unwrap();
+        std::fs::write(
+            pkg_dir.join("package.json"),
+            format!(r#"{{"name":"pkg-{i:03}","version":"1.0.0"}}"#),
+        )
+        .unwrap();
+    }
+
+    let repo = gix::discover(path).unwrap();
+    (dir, repo)
+}
+
+fn bench_full_monorepo_flow(c: &mut Criterion) {
+    for (label, num_packages, num_commits) in [
+        ("full_monorepo_flow/10_packages", 10, 500),
+        ("full_monorepo_flow/50_packages", 50, 500),
+    ] {
+        let (dir, repo) = create_monorepo_bench_repo(num_packages, num_commits);
+
+        c.bench_function(label, |b| {
+            b.iter(|| {
+                let config = Config::load(dir.path(), None).unwrap();
+                let changed =
+                    get_changed_files_since_tag(&repo, "v", OrphanedTagStrategy::Warn, None)
+                        .unwrap();
+                let commits = get_commits_since_last_tag(
+                    &repo,
+                    "v",
+                    OrphanedTagStrategy::Warn,
+                    &ferrflow::config::default_commit_skip_markers(),
+                    None,
+                )
+                .unwrap();
+
+                let bump = commits
+                    .iter()
+                    .map(|commit| determine_bump(&commit.message, &config.workspace.commit_formats))
+                    .max()
+                    .unwrap_or(BumpType::None);
+
+                let mut planned = 0usize;
+                for pkg in &config.packages {
+                    if !pkg.is_touched_by(&changed, true) {
+                        continue;
+                    }
+                    let strategy = pkg.effective_versioning(&config.workspace, Vec::new);
+                    let next = compute_next_version("1.0.0", bump, strategy, None).unwrap();
+                    black_box(&next);
+                    planned += 1;
+                }
+                black_box(planned);
+            });
+        });
+    }
+}
+
 criterion_group!(
     benches,
     bench_commit_parsing,
@@ -436,6 +553,7 @@ criterion_group!(
     bench_config_loading,
     bench_git_operations,
     bench_validate,
-    bench_full_check_flow
+    bench_full_check_flow,
+    bench_full_monorepo_flow
 );
 criterion_main!(benches);


### PR DESCRIPTION
Closes #892

The suite had six micro-benchmarks and one end-to-end flow, and that flow was single-package. The monorepo path, where the work is non-linear, was unmeasured.

`full_monorepo_flow` composes the real decision loop from the public API, the same way `full_check_flow` does, since `monorepo` is not exported from the lib: load the config, walk the commits, then per package run `is_touched_by`, `effective_versioning` and `compute_next_version`.

## What it already tells us

```
10 packages / 500 commits    156.0 ms
50 packages / 500 commits    174.6 ms
```

Five times the packages costs 12%. The per-package fan-out is cheap today and the commit walk dominates. That is worth knowing on its own, and it is the invariant the benchmark now guards: if someone makes `is_touched_by` quadratic, the 50-package number diverges from the 10-package one.

## One thing I got wrong first, and why the shape matters

My first version scaled packages and commits together, 10/200 and 50/1000. It produced a clean 5x-in, 5x-out result that looked fine and was useless: with both variables moving, a regression in either is indistinguishable from the other. Holding commits at 500 is what makes the delta attributable.

Worth stating because the misleading version is the one that looks better in a results table.

## Also

The CI matrix in `ci.yml` lists benchmark groups by name, so `full_monorepo_flow` is added there too. Without it the benchmark compiles and never runs, which is the quiet way for this to become dead code.

Honest limitation: since the commit walk dominates, a regression confined to the package loop moves the total by roughly a tenth of its own size. Detectable, not loud. Sharpening it would mean cutting the commit count until the package dimension dominates, at the cost of the scenario no longer resembling a real repository. I kept the realistic shape.