### PR TITLE
perf(bench): make the validate benchmark measure validation

### DIFF
--- a/benches/ferrflow_benchmarks.rs
+++ b/benches/ferrflow_benchmarks.rs
@@ -1,7 +1,7 @@
 use std::hint::black_box;
 use std::io::Write;
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use ferrflow::changelog::{ChangelogRender, build_section_with, update_changelog};
 use ferrflow::config::{Config, FileFormat, OrphanedTagStrategy};
 use ferrflow::conventional_commits::{BumpType, determine_bump};
@@ -10,6 +10,7 @@ use ferrflow::git::{
     GitLog, collect_all_tags, find_last_tag_name, get_changed_files, get_changed_files_since_tag,
     get_commits_since_last_tag,
 };
+use ferrflow::validate::local_entries;
 use ferrflow::versioning::compute_next_version;
 use tempfile::{NamedTempFile, TempDir};
 
@@ -74,21 +75,33 @@ fn bench_changelog(c: &mut Criterion) {
         });
 
         c.bench_function(&format!("changelog/update_{size}"), |b| {
-            b.iter(|| {
-                let mut f = NamedTempFile::new().unwrap();
-                f.write_all(b"# Changelog\n\n## v0.9.0\n\n- old entry\n")
+            b.iter_batched(
+                || {
+                    let mut f = NamedTempFile::new().unwrap();
+                    f.write_all(
+                        b"# Changelog
+
+## v0.9.0
+
+- old entry
+",
+                    )
                     .unwrap();
-                let path = f.path().to_path_buf();
-                update_changelog(
-                    black_box(&path),
-                    "myapp",
-                    "1.0.0",
-                    &commits,
-                    BumpType::Minor,
-                    false,
-                )
-                .unwrap();
-            });
+                    f
+                },
+                |f| {
+                    update_changelog(
+                        black_box(f.path()),
+                        "myapp",
+                        "1.0.0",
+                        &commits,
+                        BumpType::Minor,
+                        false,
+                    )
+                    .unwrap();
+                },
+                BatchSize::SmallInput,
+            );
         });
     }
 }
@@ -376,14 +389,9 @@ fn bench_validate(c: &mut Criterion) {
                 .output()
                 .unwrap();
 
+            let config = Config::load(dir.path(), None).unwrap();
             b.iter(|| {
-                let config = Config::load(dir.path(), None).unwrap();
-                for pkg in &config.packages {
-                    for vf in &pkg.versioned_files {
-                        let handler = get_handler(&vf.format);
-                        black_box(handler.read_version(&dir.path().join(&vf.path)).unwrap());
-                    }
-                }
+                black_box(local_entries(black_box(&config), black_box(dir.path())));
             });
         });
     }


### PR DESCRIPTION
Closes #894

## The real fix

`bench_validate` never called `ferrflow::validate`. It measured `Config::load` plus a `read_version` per file, which is `config_loading` with extra steps. The CI job named "Micro Benchmark - validate" was reporting on something else entirely.

It now calls `validate::local_entries`, with `Config::load` hoisted out of the timed loop so the measurement isolates validation instead of blending it with config parsing.

```
validate/single       83.6 µs
validate/mono_50       4.22 ms
validate/mono_100      8.39 ms
```

Linear in package count, 50x the packages for 50x the time. That is the line that now moves if a validation check goes quadratic, and both `check_tag_templates` and `check_version_templates` loop over packages.

## The other change, and a correction

`changelog/update_*` built its `NamedTempFile` inside `b.iter()`, so per-iteration setup was timed. That is worth fixing on principle and `iter_batched` is the mechanism for it.

But I predicted it would matter a lot, and I was wrong. Measured:

```
                    before      after
update_50          1.3065 ms   1.2416 ms
update_500         3.2755 ms   3.3687 ms
```

About 5% at 50, and within noise at 500.

My reasoning was that the ~1.1 ms constant gap between `build_N` and `update_N` was tempfile creation. It is not. `update_changelog` does its own `read_to_string` and `fs::write`, and that is the constant. The temp file was cheap all along.

Keeping the change because timing setup is still wrong, but it is a tidy-up, not a correctness fix. Recording the numbers so nobody re-derives the same wrong hypothesis from the same suspicious-looking gap.

## Not changed

`validate`, `full_check_flow` and `full_monorepo_flow` all still call `Config::load` inside their loops. For the two flow benchmarks that is correct, it is part of the flow. It does mean a `Config::load` regression surfaces in several jobs at once, so `config_loading` is the one to read first when they redden together.