### PR TITLE
chore(ci): trust the maintainers of ureq, ureq-proto and base64

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -51,6 +51,12 @@ user-id = 539 # Josh Stone (cuviper)
 start = "2019-05-22"
 end = "2027-07-17"
 
+[[trusted.base64]]
+criteria = "safe-to-deploy"
+user-id = 5563
+start = "2019-10-25"
+end = "2027-08-22"
+
 [[trusted.bstr]]
 criteria = "safe-to-deploy"
 user-id = 189 # Andrew Gallant (BurntSushi)
@@ -662,6 +668,18 @@ criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)
 start = "2021-10-02"
 end = "2027-07-17"
+
+[[trusted.ureq]]
+criteria = "safe-to-deploy"
+user-id = 5441 # Martin Algesten (algesten)
+start = "2019-03-30"
+end = "2027-08-22"
+
+[[trusted.ureq-proto]]
+criteria = "safe-to-deploy"
+user-id = 5441 # Martin Algesten (algesten)
+start = "2024-11-06"
+end = "2027-08-22"
 
 [[trusted.walkdir]]
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -479,14 +479,6 @@ criteria = "safe-to-deploy"
 version = "0.9.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.ureq]]
-version = "3.3.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.ureq-proto]]
-version = "0.6.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.url]]
 version = "2.5.8"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -770,6 +770,20 @@ user-id = 1139
 user-login = "Manishearth"
 user-name = "Manish Goregaokar"
 
+[[publisher.ureq]]
+version = "3.3.0"
+when = "2026-03-21"
+user-id = 5441
+user-login = "algesten"
+user-name = "Martin Algesten"
+
+[[publisher.ureq-proto]]
+version = "0.6.0"
+when = "2026-03-21"
+user-id = 5441
+user-login = "algesten"
+user-name = "Martin Algesten"
+
 [[publisher.utf8_iter]]
 version = "1.0.4"
 when = "2023-12-01"


### PR DESCRIPTION
Closes #898

Unblocks #827, which is a single-dependency bump that `cargo vet` rejects on three crates.

```
main            Vetting Succeeded (170 audited, 144 exempted)   was 146
#827 branch     Vetting Succeeded                               was 3 unvetted
```

Verified both ways: the entries keep main green and they make #827's lockfile pass. Two more exemptions became unnecessary as a side effect.

## What is being asserted

Unlike #884, which imported trust that mozilla and bytecode-alliance already publish, this is our own assertion. So it is worth writing down what it rests on, checked against crates.io rather than assumed:

| Publisher | Crate | Basis |
|---|---|---|
| algesten (Martin Algesten) | ureq, ureq-proto | listed owner of both, repos under his account, author |
| marshallpierce (Marshall Pierce) | base64 | listed owner, repo marshallpierce/rust-base64, 1.46B downloads |

Each is the crate's own maintainer publishing their own crate. Entries are per-crate rather than blanket-trusting every crate a publisher owns, so the trust stays scoped to what was actually checked. A new crate from either publisher still needs a fresh decision.

## What this does not fix

#769, the lockfile-maintenance PR, still fails. It needs the other four publishers, mostly `sffc` for the ICU crates, plus the ten crates published through crates.io trusted publishing where there is no person to trust at all. That gap is described in #884 and is not solved by adding publishers.

#827 needs a rebase after this lands to pick the entries up.
