### PR TITLE
feat(cli): ferrflow graph shows the dependency graph, release order and cycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ ferrflow version api          # monorepo, specific package
 ferrflow tag
 ferrflow tag api
 
+# Print the dependency graph, the release order, and any cycle
+ferrflow graph
+ferrflow graph --json
+
 # JSON output (for scripting)
 ferrflow version --json
 ferrflow tag --json

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -84,6 +84,11 @@ pub enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Print the dependency graph, the release order it implies, and any cycle.
+    Graph {
+        #[arg(long)]
+        json: bool,
+    },
     Diff {
         #[arg(value_name = "SPEC", required = true, num_args = 1..=2)]
         spec: Vec<String>,
@@ -177,6 +182,7 @@ impl Commands {
             Commands::Init { .. } => "init",
             Commands::Status { .. } => "status",
             Commands::Why { .. } => "why",
+            Commands::Graph { .. } => "graph",
             Commands::Diff { .. } => "diff",
             Commands::Version { .. } => "version",
             Commands::Tag { .. } => "tag",
@@ -259,6 +265,7 @@ impl Cli {
                 channel.as_deref(),
                 json,
             ),
+            Commands::Graph { json } => crate::monorepo::graph(self.config.as_deref(), json),
             Commands::Version { package, json } => {
                 crate::query::version(self.config.as_deref(), package.as_deref(), json)
             }

--- a/src/monorepo/graph_report.rs
+++ b/src/monorepo/graph_report.rs
@@ -1,0 +1,216 @@
+use anyhow::Result;
+use colored::Colorize;
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use crate::config::{Config, PackageConfig};
+use crate::git::{get_repo_root, open_repo};
+use crate::monorepo::run::graph::release_order;
+
+#[derive(Serialize)]
+#[cfg_attr(test, derive(Debug))]
+struct GraphPackage {
+    name: String,
+    depends_on: Vec<String>,
+    dependents: Vec<String>,
+}
+
+#[derive(Serialize)]
+#[cfg_attr(test, derive(Debug))]
+struct GraphReport {
+    packages: Vec<GraphPackage>,
+    release_order: Vec<String>,
+    cycle: Option<Vec<String>>,
+}
+
+pub fn run(config_path: Option<&Path>, json: bool) -> Result<()> {
+    let repo = open_repo(&std::env::current_dir()?)?;
+    let root = get_repo_root(&repo)?;
+    let config = Config::load(&root, config_path)?;
+    let report = build_report(&config.packages);
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_text(&report);
+    }
+
+    if report.cycle.is_some() {
+        anyhow::bail!("dependency cycle detected");
+    }
+    Ok(())
+}
+
+fn build_report(packages: &[PackageConfig]) -> GraphReport {
+    let known: Vec<&str> = packages.iter().map(|p| p.name.as_str()).collect();
+
+    let mut dependents: BTreeMap<&str, Vec<String>> = BTreeMap::new();
+    for pkg in packages {
+        for dep in &pkg.depends_on {
+            if known.contains(&dep.name()) {
+                dependents
+                    .entry(dep.name())
+                    .or_default()
+                    .push(pkg.name.clone());
+            }
+        }
+    }
+
+    let entries: Vec<GraphPackage> = packages
+        .iter()
+        .map(|pkg| GraphPackage {
+            name: pkg.name.clone(),
+            depends_on: pkg
+                .depends_on
+                .iter()
+                .filter(|dep| known.contains(&dep.name()))
+                .map(|dep| dep.name().to_string())
+                .collect(),
+            dependents: dependents
+                .get(pkg.name.as_str())
+                .cloned()
+                .unwrap_or_default(),
+        })
+        .collect();
+
+    let (order, cycle) = match release_order(packages) {
+        Ok(order) => (
+            order.iter().map(|&i| packages[i].name.clone()).collect(),
+            None,
+        ),
+        Err(found) => {
+            let mut path = found.path().to_vec();
+            if let Some(first) = path.first().cloned() {
+                path.push(first);
+            }
+            (Vec::new(), Some(path))
+        }
+    };
+
+    GraphReport {
+        packages: entries,
+        release_order: order,
+        cycle,
+    }
+}
+
+fn print_text(report: &GraphReport) {
+    println!("{}", "FerrFlow — Dependency graph".bold());
+    println!();
+
+    for pkg in &report.packages {
+        println!("  {}", pkg.name.bold());
+        if pkg.depends_on.is_empty() {
+            println!("    depends on  {}", "—".dimmed());
+        } else {
+            println!("    depends on  {}", pkg.depends_on.join(", "));
+        }
+        if pkg.dependents.is_empty() {
+            println!("    required by {}", "—".dimmed());
+        } else {
+            println!("    required by {}", pkg.dependents.join(", "));
+        }
+    }
+
+    println!();
+    match &report.cycle {
+        Some(path) => {
+            println!("  {} cycle detected: {}", "✗".red(), path.join(" → ").red());
+            println!(
+                "  {}",
+                "no release order exists while this cycle stands".dimmed()
+            );
+        }
+        None => {
+            println!(
+                "  {} {}",
+                "release order".bold(),
+                report.release_order.join(" → ")
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pkg(name: &str, deps: &[&str]) -> PackageConfig {
+        PackageConfig {
+            version_source: None,
+            name: name.to_string(),
+            path: name.to_string(),
+            versioned_files: vec![],
+            changelog: None,
+            shared_paths: vec![],
+            depends_on: deps
+                .iter()
+                .map(|s| crate::config::Dependency::Name(s.to_string()))
+                .collect(),
+            update_lockfiles: None,
+            versioning: None,
+            tag_template: None,
+            version_template: None,
+            floating_tags: None,
+            latest_tag: None,
+            hooks: None,
+            publishers: vec![],
+        }
+    }
+
+    fn find<'a>(report: &'a GraphReport, name: &str) -> &'a GraphPackage {
+        report
+            .packages
+            .iter()
+            .find(|p| p.name == name)
+            .expect("package in report")
+    }
+
+    #[test]
+    fn dependents_are_the_reverse_of_depends_on() {
+        let report = build_report(&[
+            pkg("core", &[]),
+            pkg("api", &["core"]),
+            pkg("cli", &["api", "core"]),
+        ]);
+
+        assert_eq!(find(&report, "core").depends_on, Vec::<String>::new());
+        assert_eq!(find(&report, "core").dependents, vec!["api", "cli"]);
+        assert_eq!(find(&report, "cli").depends_on, vec!["api", "core"]);
+        assert_eq!(find(&report, "cli").dependents, Vec::<String>::new());
+    }
+
+    #[test]
+    fn release_order_puts_dependencies_before_dependents() {
+        let report = build_report(&[
+            pkg("cli", &["api"]),
+            pkg("api", &["core"]),
+            pkg("core", &[]),
+        ]);
+
+        assert_eq!(report.cycle, None);
+        let order = &report.release_order;
+        let at = |name: &str| order.iter().position(|n| n == name).expect("in order");
+        assert!(at("core") < at("api"), "{order:?}");
+        assert!(at("api") < at("cli"), "{order:?}");
+    }
+
+    #[test]
+    fn a_cycle_is_reported_with_a_closed_path_and_no_order() {
+        let report = build_report(&[pkg("a", &["b"]), pkg("b", &["a"])]);
+
+        let cycle = report.cycle.expect("cycle detected");
+        assert_eq!(cycle.first(), cycle.last(), "path should close: {cycle:?}");
+        assert!(cycle.contains(&"a".to_string()) && cycle.contains(&"b".to_string()));
+        assert!(report.release_order.is_empty());
+    }
+
+    #[test]
+    fn a_dependency_outside_the_workspace_is_left_out_rather_than_invented() {
+        let report = build_report(&[pkg("api", &["serde", "core"]), pkg("core", &[])]);
+
+        assert_eq!(find(&report, "api").depends_on, vec!["core"]);
+        assert_eq!(report.cycle, None);
+    }
+}

--- a/src/monorepo/mod.rs
+++ b/src/monorepo/mod.rs
@@ -6,7 +6,10 @@ mod types;
 mod util;
 mod version_source;
 
+mod graph_report;
+
 pub use check::check;
+pub use graph_report::run as graph;
 pub use release::release;
 pub use run::why;
 

--- a/src/monorepo/run/graph.rs
+++ b/src/monorepo/run/graph.rs
@@ -4,12 +4,16 @@ use crate::config::PackageConfig;
 use crate::error_code;
 
 #[derive(Debug)]
-pub(super) struct Cycle {
+pub(crate) struct Cycle {
     path: Vec<String>,
 }
 
 impl Cycle {
-    pub(super) fn into_error(self) -> anyhow::Error {
+    pub(crate) fn path(&self) -> &[String] {
+        &self.path
+    }
+
+    pub(crate) fn into_error(self) -> anyhow::Error {
         let mut rendered = self.path;
         if let Some(first) = rendered.first().cloned() {
             rendered.push(first);
@@ -19,7 +23,7 @@ impl Cycle {
     }
 }
 
-pub(super) fn release_order(packages: &[PackageConfig]) -> Result<Vec<usize>, Cycle> {
+pub(crate) fn release_order(packages: &[PackageConfig]) -> Result<Vec<usize>, Cycle> {
     let index_of: HashMap<&str, usize> = packages
         .iter()
         .enumerate()

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -30,7 +30,7 @@ mod execute;
 #[cfg(test)]
 mod execute_tests;
 mod forced;
-mod graph;
+pub(crate) mod graph;
 mod groups;
 mod lock;
 mod plan;


### PR DESCRIPTION
Closes #908

`graph::release_order` already built the graph and detected cycles, and only ran at release time. A cycle surfaced mid-release, after the tag decision. This exposes the same computation as a command.

```
FerrFlow — Dependency graph

  core
    depends on  —
    required by api, cli
  api
    depends on  core
    required by cli
  cli
    depends on  api, core
    required by —

  release order core → api → cli
```

And on a cycle, exiting non-zero:

```
  ✗ cycle detected: api → core → cli → api
  no release order exists while this cycle stands
Error: dependency cycle detected
```

`--json` emits `packages`, `release_order` and `cycle`, in snake_case to match `release_json.rs` and the other JSON outputs rather than the camelCase the config file uses.

## Notes

`release_order` and `Cycle` moved from `pub(super)` to `pub(crate)`, and `Cycle` gained a `path()` accessor so the command can render the cycle rather than only turn it into an error. The release path is untouched.

The report builder is a pure function over `&[PackageConfig]`, so the four tests cover it without a repo: reverse-index correctness, dependencies ordered before dependents, a cycle producing a closed path and an empty order, and a dependency on a package outside the workspace being dropped rather than invented. That last one mirrors what `release_order` already does with `filter_map`, and pins it: a `serde` entry in `dependsOn` is silently ignored, which is right but worth having a test say so.

Verified end to end on a three-package repo, both healthy and with an injected cycle. 2025 tests green, clippy clean at `-D warnings`.

README usage block updated. Docs on ferrflow.com are tracked separately.
