### PR TITLE
feat(publishers): add a pypi publisher

### DIFF
--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -951,6 +951,35 @@
         },
         {
           "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "const": "pypi"
+            },
+            "registry": {
+              "type": "string",
+              "description": "Name of an entry under workspace.registries. Its url becomes twine --repository-url and its tokenEnv supplies TWINE_PASSWORD with username __token__. Omit to publish to pypi.org."
+            },
+            "build": {
+              "type": "boolean",
+              "default": true,
+              "description": "Run python -m build in the package directory before uploading. Set false when the distributions in dist/ are produced earlier in the pipeline."
+            },
+            "args": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Extra flags appended verbatim to the underlying twine upload invocation.",
+              "default": []
+            }
+          }
+        },
+        {
+          "type": "object",
           "required": [
             "kind",
             "url"

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -179,6 +179,10 @@ pub struct RegistryConfig {
 /// The kind is the externally-tagged discriminator (`{"kind":
 /// "cargo", ...}`) — keeps the JSON Schema readable and lets us add
 /// kinds without overloading existing fields.
+fn default_true() -> bool {
+    true
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(tag = "kind", rename_all = "kebab-case")]
 pub enum PublisherConfig {
@@ -231,6 +235,14 @@ pub enum PublisherConfig {
         #[serde(default)]
         args: Vec<String>,
     },
+    Pypi {
+        #[serde(default)]
+        registry: Option<String>,
+        #[serde(default = "default_true")]
+        build: bool,
+        #[serde(default)]
+        args: Vec<String>,
+    },
     Webhook {
         url: String,
         #[serde(default)]
@@ -275,6 +287,7 @@ impl PublisherConfig {
             PublisherConfig::Docker { .. } => "docker",
             PublisherConfig::Helm { .. } => "helm",
             PublisherConfig::GithubReleaseAsset { .. } => "github-release-asset",
+            PublisherConfig::Pypi { .. } => "pypi",
             PublisherConfig::Webhook { .. } => "webhook",
         }
     }
@@ -288,6 +301,10 @@ impl PublisherConfig {
             PublisherConfig::Cargo { registry, .. } => {
                 let reg = registry.as_deref().unwrap_or("crates-io");
                 format!("cargo publish {package_name}@{new_version} → {reg}")
+            }
+            PublisherConfig::Pypi { registry, .. } => {
+                let reg = registry.as_deref().unwrap_or("pypi.org");
+                format!("twine upload {package_name}@{new_version} → {reg}")
             }
             PublisherConfig::Npm { registry, tag, .. } => {
                 let reg = registry.as_deref().unwrap_or("npmjs.org");

--- a/src/publishers/mod.rs
+++ b/src/publishers/mod.rs
@@ -10,6 +10,7 @@ pub mod docker;
 pub mod github_release_asset;
 pub mod helm;
 pub mod npm;
+pub mod pypi;
 pub mod webhook;
 
 /// Inputs threaded into every publisher invocation. References the
@@ -114,6 +115,11 @@ pub fn run(p: &PublisherConfig, ctx: &PublishContext<'_>) -> Result<PublishOutco
             display_name,
             args,
         } => github_release_asset::run(path, display_name.as_deref(), args, ctx),
+        PublisherConfig::Pypi {
+            registry,
+            build,
+            args,
+        } => pypi::run(registry.as_deref(), *build, args, ctx),
         PublisherConfig::Webhook { url, body, headers } => {
             webhook::run(url, body.as_ref(), headers, ctx)
         }

--- a/src/publishers/pypi.rs
+++ b/src/publishers/pypi.rs
@@ -1,0 +1,265 @@
+use anyhow::{Context, Result, anyhow};
+use std::process::Command;
+
+use super::{PublishContext, PublishOutcome};
+use crate::error_code::{self, ErrorCodeExt};
+
+const MAX_PUBLISH_ATTEMPTS: u32 = 3;
+
+const PUBLISH_RETRY_BACKOFF_SECS: [u64; 2] = [5, 15];
+
+pub fn run(
+    registry: Option<&str>,
+    build: bool,
+    extra_args: &[String],
+    ctx: &PublishContext<'_>,
+) -> Result<PublishOutcome> {
+    let registry_label = registry.unwrap_or("pypi.org");
+
+    let resolved = match registry {
+        Some(name) => {
+            let r = ctx
+                .registries
+                .get(name)
+                .ok_or_else(|| anyhow!(
+                    "publisher pypi: registry `{name}` is not declared under `workspace.registries`"
+                ))
+                .error_code(error_code::CONFIG_INVALID_PATH)?;
+            if let Some(env_name) = &r.token_env
+                && std::env::var(env_name).is_err()
+            {
+                return Err(anyhow!(
+                    "publisher pypi:{name}: env var `{env_name}` is not set; \
+                     export the registry token before running `ferrflow release`"
+                ))
+                .error_code(error_code::CONFIG_INVALID_PATH);
+            }
+            Some(r)
+        }
+        None => None,
+    };
+
+    if ctx.dry_run {
+        return Ok(PublishOutcome::DryRun);
+    }
+
+    if build {
+        let output = Command::new("python")
+            .current_dir(ctx.package_path)
+            .args(["-m", "build"])
+            .output()
+            .with_context(|| {
+                format!(
+                    "spawn `python -m build` failed (is python with the `build` module in PATH?) for {}",
+                    ctx.package_name
+                )
+            })?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+            let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+            return Err(anyhow!(
+                "python -m build failed for {}: {}",
+                ctx.package_name,
+                first_meaningful_line(&stderr, &stdout)
+            ))
+            .error_code(error_code::CONFIG_INVALID_PATH);
+        }
+    }
+
+    let mut cmd = Command::new("twine");
+    cmd.current_dir(ctx.package_path).arg("upload");
+    if let Some(url) = resolved.and_then(|r| r.url.as_deref()) {
+        cmd.arg("--repository-url").arg(url);
+    }
+    if let Some(env_name) = resolved.and_then(|r| r.token_env.as_deref())
+        && let Ok(token) = std::env::var(env_name)
+    {
+        cmd.env("TWINE_USERNAME", "__token__");
+        cmd.env("TWINE_PASSWORD", token);
+    }
+    cmd.args(extra_args);
+    cmd.arg("dist/*");
+
+    let mut attempt: u32 = 0;
+    loop {
+        attempt += 1;
+        let output = cmd.output().with_context(|| {
+            format!(
+                "spawn `twine upload` failed (is twine in PATH?) for {}",
+                ctx.package_name
+            )
+        })?;
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+
+        if output.status.success() {
+            return Ok(PublishOutcome::Published {
+                url: derive_project_url(ctx.package_name, ctx.new_version, registry),
+            });
+        }
+
+        if classify_already_published(&stderr, &stdout) {
+            return Ok(PublishOutcome::Skipped {
+                reason: format!(
+                    "{}@{} already exists on {}",
+                    ctx.package_name, ctx.new_version, registry_label
+                ),
+            });
+        }
+
+        if attempt < MAX_PUBLISH_ATTEMPTS && classify_transient(&stderr) {
+            let backoff = PUBLISH_RETRY_BACKOFF_SECS
+                .get((attempt - 1) as usize)
+                .copied()
+                .unwrap_or(15);
+            tracing::warn!(
+                "  ↻ {} upload hit a transient registry error on {} (attempt {attempt}/{MAX_PUBLISH_ATTEMPTS}); \
+                 retrying in {backoff}s",
+                ctx.package_name,
+                registry_label
+            );
+            std::thread::sleep(std::time::Duration::from_secs(backoff));
+            continue;
+        }
+
+        return Err(anyhow!(
+            "twine upload failed for {} on {}: {}",
+            ctx.package_name,
+            registry_label,
+            first_meaningful_line(&stderr, &stdout)
+        ))
+        .error_code(error_code::CONFIG_INVALID_PATH);
+    }
+}
+
+fn classify_already_published(stderr: &str, stdout: &str) -> bool {
+    let needles = [
+        "file already exists",
+        "already exists",
+        "this filename has already been used",
+        "conflict",
+    ];
+    let haystack = format!("{stderr}\n{stdout}").to_lowercase();
+    needles.iter().any(|n| haystack.contains(n))
+}
+
+fn classify_transient(stderr: &str) -> bool {
+    let needles = [
+        "502 bad gateway",
+        "503 service unavailable",
+        "504 gateway timeout",
+        "connection reset",
+        "connection timed out",
+        "temporarily unavailable",
+    ];
+    let haystack = stderr.to_lowercase();
+    needles.iter().any(|n| haystack.contains(n))
+}
+
+fn first_meaningful_line(stderr: &str, stdout: &str) -> String {
+    for src in [stderr, stdout] {
+        for line in src.lines().rev() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with("\u{1b}[") {
+                continue;
+            }
+            if trimmed.starts_with("ERROR") || trimmed.starts_with("error") {
+                return trimmed.to_string();
+            }
+        }
+    }
+    stderr
+        .lines()
+        .rfind(|l| !l.trim().is_empty())
+        .unwrap_or("(no output)")
+        .to_string()
+}
+
+fn derive_project_url(name: &str, version: &str, registry: Option<&str>) -> Option<String> {
+    registry
+        .is_none()
+        .then(|| format!("https://pypi.org/project/{name}/{version}/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::RegistryConfig;
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    fn ctx(registries: &BTreeMap<String, RegistryConfig>, dry_run: bool) -> PublishContext<'_> {
+        PublishContext {
+            package_name: "ferrlabs-sdk",
+            package_path: Box::leak(Box::new(PathBuf::from("."))),
+            new_version: "0.1.0",
+            tag: "ferrlabs-sdk@v0.1.0",
+            registries,
+            dry_run,
+            verbose: false,
+        }
+    }
+
+    #[test]
+    fn missing_registry_definition_is_a_clear_error() {
+        let registries = BTreeMap::new();
+        let err =
+            run(Some("internal"), false, &[], &ctx(&registries, true)).expect_err("must error");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("not declared under `workspace.registries`"),
+            "expected helpful diagnostic, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn missing_token_env_var_blocks_before_invoking_twine() {
+        let mut registries = BTreeMap::new();
+        registries.insert(
+            "internal".to_string(),
+            RegistryConfig {
+                url: Some("https://pypi.internal/simple".to_string()),
+                token_env: Some("A_TOKEN_THAT_IS_NOT_SET_XYZ".to_string()),
+            },
+        );
+        let err =
+            run(Some("internal"), false, &[], &ctx(&registries, true)).expect_err("must error");
+        let msg = format!("{err:?}");
+        assert!(msg.contains("is not set"), "got: {msg}");
+    }
+
+    #[test]
+    fn dry_run_short_circuits_after_validation() {
+        let registries = BTreeMap::new();
+        let outcome = run(None, true, &[], &ctx(&registries, true)).expect("dry run is ok");
+        assert!(matches!(outcome, PublishOutcome::DryRun));
+    }
+
+    #[test]
+    fn an_existing_file_on_the_index_reads_as_already_published() {
+        let stderr = "ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/\n\
+                      File already exists. See https://pypi.org/help/#file-name-reuse";
+        assert!(classify_already_published(stderr, ""));
+        assert!(!classify_already_published("ERROR 401 Unauthorized", ""));
+    }
+
+    #[test]
+    fn a_gateway_error_is_transient_but_an_auth_failure_is_not() {
+        assert!(classify_transient("503 Service Unavailable"));
+        assert!(!classify_transient(
+            "403 Forbidden: invalid or non-existent authentication"
+        ));
+    }
+
+    #[test]
+    fn the_project_url_is_only_emitted_for_the_default_index() {
+        assert_eq!(
+            derive_project_url("ferrlabs-sdk", "1.0.0", None).as_deref(),
+            Some("https://pypi.org/project/ferrlabs-sdk/1.0.0/")
+        );
+        assert_eq!(
+            derive_project_url("ferrlabs-sdk", "1.0.0", Some("internal")),
+            None
+        );
+    }
+}


### PR DESCRIPTION
Closes #909

## Only PyPI needed building

The issue asked for three targets. Checking first, two of them already work through configuration:

- **GitHub Packages** and **GitLab Registry** for npm are the `npm` publisher with a `registry` entry pointing at `https://npm.pkg.github.com` or GitLab's index. `npm::run` already resolves a named registry from `workspace.registries` and enforces its `tokenEnv`.
- The same two for containers are the `docker` publisher, whose `image` is a full reference, so `ghcr.io/org/name` or `registry.gitlab.com/group/project/image` needs nothing new.

Adding publishers for those would have been three ways to spell what one already does. What was missing is PyPI, and that gap was the sharp one the issue described: FerrFlow reads and bumps `pyproject.toml` today, so it could take a Python project all the way to a tag and then not publish it.

## The publisher

```jsonc
{ "kind": "pypi" }
{ "kind": "pypi", "registry": "internal", "build": false }
```

`build` defaults to true and runs `python -m build` in the package directory first, since unlike `cargo publish` and `npm publish` there is no single Python command that builds and uploads. Set it false when the distributions are produced earlier in the pipeline.

A named `registry` supplies `--repository-url` from its `url` and sets `TWINE_PASSWORD` from its `tokenEnv` with username `__token__`, so the token stays in the runner's secret store and never reaches the config.

Follows the existing contract: validate before doing anything, short-circuit on dry run, classify an already-uploaded file as `Skipped` rather than an error so a resumed release is idempotent, and retry the same transient shapes cargo does.

## Verified end to end

```
→ 2 publishers:
  [pypi] twine upload ferrlabs-sdk@0.2.0 → pypi.org (dry-run)
  [pypi] ERROR E1018: publisher pypi:internal: env var `INTERNAL_PYPI_TOKEN` is not set
```

The second line is the intended behaviour: a missing token fails before anything runs, even in dry run, matching cargo.

Six tests, 2037 in the suite, clippy clean at `-D warnings`. Schema entry added, purely additive, 29 lines and no deletions, so the FerrFlow-Cloud copy is a straight file copy once this is on main.
