### PR TITLE
feat(cli): ferrflow plan --interactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ Download from [Releases](https://github.com/FerrLabs/FerrFlow/releases).
 # Preview what would be bumped
 ferrflow check
 
+# Adjust the plan, then get the command that reproduces it
+ferrflow plan --interactive
+
 # Run a release
 ferrflow release
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -39,6 +39,8 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
+    /// Preview the release plan. Also available as `ferrflow plan`.
+    #[command(alias = "plan")]
     Check {
         #[arg(long)]
         json: bool,
@@ -46,6 +48,9 @@ pub enum Commands {
         channel: Option<String>,
         #[arg(long)]
         comment: bool,
+        /// Adjust bumps and exclusions, then print the command that reproduces the result.
+        #[arg(long, conflicts_with_all = ["json", "comment"])]
+        interactive: bool,
     },
     Release {
         #[arg(long)]
@@ -219,9 +224,18 @@ impl Cli {
     fn dispatch(self, timing: &mut Timing) -> Result<()> {
         match self.command {
             Commands::Check {
+                json: _,
+                channel,
+                comment: _,
+                interactive,
+            } if interactive => {
+                crate::monorepo::plan_interactive(self.config.as_deref(), channel.as_deref())
+            }
+            Commands::Check {
                 json,
                 channel,
                 comment,
+                interactive: _,
             } => crate::monorepo::check(
                 self.config.as_deref(),
                 self.verbose,
@@ -371,6 +385,7 @@ mod tests {
                 json: false,
                 channel: None,
                 comment: false,
+                interactive: false,
             }
         ));
     }

--- a/src/monorepo/check.rs
+++ b/src/monorepo/check.rs
@@ -94,3 +94,33 @@ fn print_cached(hit: &CachedRun) {
         tracing::info!("{line}");
     }
 }
+
+/// Run the same computation `check --json` does and hand back the JSON
+/// instead of printing it. Used by the interactive planner so it reads
+/// the published contract rather than the internal plan types.
+pub(super) fn plan_json(config_path: Option<&Path>, channel: Option<&str>) -> Result<String> {
+    let repo = open_repo(&std::env::current_dir()?)?;
+    let root = get_repo_root(&repo)?;
+    let config = Config::load(&root, config_path)?;
+    let mut timing = Timing::new(false);
+
+    let out = run_release_logic(
+        &root,
+        &config,
+        true,
+        false,
+        true,
+        false,
+        false,
+        &[],
+        &[],
+        channel,
+        false,
+        false,
+        &mut timing,
+    )?;
+
+    Ok(out
+        .and_then(|o| o.json)
+        .unwrap_or_else(|| r#"{"packages":[]}"#.to_string()))
+}

--- a/src/monorepo/mod.rs
+++ b/src/monorepo/mod.rs
@@ -8,8 +8,12 @@ mod version_source;
 
 mod graph_report;
 
+mod plan_interactive;
+
 pub use check::check;
+use check::plan_json;
 pub use graph_report::run as graph;
+pub use plan_interactive::run as plan_interactive;
 pub use release::release;
 pub use run::why;
 

--- a/src/monorepo/plan_interactive.rs
+++ b/src/monorepo/plan_interactive.rs
@@ -1,0 +1,281 @@
+use anyhow::Result;
+use colored::Colorize;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::io::{BufRead, Write};
+use std::path::Path;
+
+use crate::config::Config;
+use crate::conventional_commits::BumpType;
+use crate::git::{get_repo_root, open_repo};
+use crate::versioning::compute_next_version;
+
+/// Read off the release JSON rather than the internal plan types, so the
+/// session consumes the same contract external tooling does: if that
+/// shape changes, this breaks visibly instead of drifting.
+#[derive(Deserialize)]
+struct PlanJson {
+    packages: Vec<PlanEntry>,
+}
+
+#[derive(Deserialize)]
+struct PlanEntry {
+    name: String,
+    current_version: String,
+    next_version: String,
+    bump_type: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum Override {
+    Bump(BumpType),
+    Excluded,
+}
+
+struct Row {
+    package: String,
+    current: String,
+    planned: Option<String>,
+    reason: String,
+}
+
+/// The decisions a session produced, rendered as the flags that reproduce them.
+pub fn command_for(overrides: &BTreeMap<String, String>, excluded: &[String]) -> String {
+    let mut parts = vec!["ferrflow release".to_string()];
+    for (pkg, version) in overrides {
+        parts.push(format!("--force-version {pkg}@{version}"));
+    }
+    for pkg in excluded {
+        parts.push(format!("--exclude {pkg}"));
+    }
+    parts.join(" ")
+}
+
+fn parse_bump(word: &str) -> Option<BumpType> {
+    match word {
+        "major" => Some(BumpType::Major),
+        "minor" => Some(BumpType::Minor),
+        "patch" => Some(BumpType::Patch),
+        _ => None,
+    }
+}
+
+pub fn run(config_path: Option<&Path>, channel: Option<&str>) -> Result<()> {
+    let repo = open_repo(&std::env::current_dir()?)?;
+    let root = get_repo_root(&repo)?;
+    let config = Config::load(&root, config_path)?;
+
+    let json = super::plan_json(config_path, channel)?;
+    let plan: PlanJson = serde_json::from_str(&json)?;
+
+    let mut rows: Vec<Row> = plan
+        .packages
+        .iter()
+        .map(|p| Row {
+            package: p.name.clone(),
+            current: p.current_version.clone(),
+            planned: Some(p.next_version.clone()),
+            reason: p.bump_type.clone(),
+        })
+        .collect();
+    rows.sort_by(|a, b| a.package.cmp(&b.package));
+
+    if rows.is_empty() {
+        println!("Nothing to release.");
+        return Ok(());
+    }
+
+    let mut overrides: BTreeMap<String, Override> = BTreeMap::new();
+    let stdin = std::io::stdin();
+    let mut lines = stdin.lock().lines();
+
+    loop {
+        render(&rows, &overrides, &config)?;
+        print!("{} ", ">".cyan());
+        std::io::stdout().flush()?;
+
+        let Some(line) = lines.next() else { break };
+        let line = line?;
+        let words: Vec<&str> = line.split_whitespace().collect();
+
+        match words.as_slice() {
+            [] => continue,
+            ["done"] => break,
+            ["quit"] | ["q"] => {
+                println!("{}", "no command emitted".dimmed());
+                return Ok(());
+            }
+            [n, bump] if n.parse::<usize>().is_ok() && parse_bump(bump).is_some() => {
+                match index(&rows, n) {
+                    Some(pkg) => {
+                        overrides.insert(pkg, Override::Bump(parse_bump(bump).unwrap()));
+                    }
+                    None => println!("  {} no package {n}", "✗".red()),
+                }
+            }
+            ["exclude", n] => match index(&rows, n) {
+                Some(pkg) => {
+                    overrides.insert(pkg, Override::Excluded);
+                }
+                None => println!("  {} no package {n}", "✗".red()),
+            },
+            ["include", n] => match index(&rows, n) {
+                Some(pkg) => {
+                    overrides.remove(&pkg);
+                }
+                None => println!("  {} no package {n}", "✗".red()),
+            },
+            _ => println!(
+                "  {} commands: <n> major|minor|patch, exclude <n>, include <n>, done, quit",
+                "?".yellow()
+            ),
+        }
+    }
+
+    let mut forced = BTreeMap::new();
+    let mut excluded = Vec::new();
+    for (pkg, ov) in &overrides {
+        match ov {
+            Override::Excluded => excluded.push(pkg.clone()),
+            Override::Bump(bump) => {
+                if let Some(version) = resolved_version(&config, &rows, pkg, *bump) {
+                    forced.insert(pkg.clone(), version);
+                }
+            }
+        }
+    }
+
+    println!();
+    if forced.is_empty() && excluded.is_empty() {
+        println!("  {} plan unchanged, run:", "→".cyan());
+        println!("    ferrflow release");
+    } else {
+        println!("  {} run:", "→".cyan());
+        println!("    {}", command_for(&forced, &excluded).bold());
+    }
+    Ok(())
+}
+
+fn index(rows: &[Row], n: &str) -> Option<String> {
+    let i: usize = n.parse().ok()?;
+    rows.get(i.checked_sub(1)?).map(|r| r.package.clone())
+}
+
+fn resolved_version(
+    config: &Config,
+    rows: &[Row],
+    pkg_name: &str,
+    bump: BumpType,
+) -> Option<String> {
+    let row = rows.iter().find(|r| r.package == pkg_name)?;
+    let pkg = config.packages.iter().find(|p| p.name == pkg_name)?;
+    let strategy = pkg.effective_versioning(&config.workspace, Vec::new);
+    let template = pkg.effective_version_template(&config.workspace);
+    let current = if row.current.is_empty() {
+        "0.0.0"
+    } else {
+        &row.current
+    };
+    compute_next_version(current, bump, strategy, template).ok()
+}
+
+fn render(rows: &[Row], overrides: &BTreeMap<String, Override>, config: &Config) -> Result<()> {
+    println!();
+    println!("{}", "FerrFlow — Release plan (interactive)".bold());
+    println!();
+    for (i, row) in rows.iter().enumerate() {
+        let n = i + 1;
+        match overrides.get(&row.package) {
+            Some(Override::Excluded) => {
+                println!("  {n:>2}  {:<18} {}", row.package, "excluded".yellow());
+            }
+            Some(Override::Bump(bump)) => {
+                let version = resolved_version(config, rows, &row.package, *bump)
+                    .unwrap_or_else(|| "?".to_string());
+                println!(
+                    "  {n:>2}  {:<18} {} → {}  {}",
+                    row.package,
+                    row.current,
+                    version.green(),
+                    format!("{bump:?}").to_lowercase().green()
+                );
+            }
+            None => match &row.planned {
+                Some(next) => println!(
+                    "  {n:>2}  {:<18} {} → {}  {}",
+                    row.package, row.current, next, row.reason
+                ),
+                None => println!(
+                    "  {n:>2}  {:<18} {}",
+                    row.package,
+                    format!("skipped ({})", row.reason).dimmed()
+                ),
+            },
+        }
+    }
+    println!();
+    println!(
+        "  {}",
+        "<n> major|minor|patch, exclude <n>, include <n>, done, quit".dimmed()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rows() -> Vec<Row> {
+        vec![
+            Row {
+                package: "api".into(),
+                current: "1.0.0".into(),
+                planned: Some("1.1.0".into()),
+                reason: "minor".into(),
+            },
+            Row {
+                package: "core".into(),
+                current: "2.3.4".into(),
+                planned: Some("2.3.5".into()),
+                reason: "patch".into(),
+            },
+        ]
+    }
+
+    #[test]
+    fn the_emitted_command_carries_every_decision() {
+        let mut forced = BTreeMap::new();
+        forced.insert("api".to_string(), "2.0.0".to_string());
+        forced.insert("core".to_string(), "3.0.0".to_string());
+        let cmd = command_for(&forced, &["web".to_string(), "docs".to_string()]);
+        assert_eq!(
+            cmd,
+            "ferrflow release --force-version api@2.0.0 --force-version core@3.0.0 \
+             --exclude web --exclude docs"
+        );
+    }
+
+    #[test]
+    fn no_decisions_emit_no_flags() {
+        assert_eq!(command_for(&BTreeMap::new(), &[]), "ferrflow release");
+    }
+
+    #[test]
+    fn indices_are_one_based_and_reject_anything_outside_the_list() {
+        let r = rows();
+        assert_eq!(index(&r, "1").as_deref(), Some("api"));
+        assert_eq!(index(&r, "2").as_deref(), Some("core"));
+        assert_eq!(index(&r, "0"), None, "0 must not wrap to the last row");
+        assert_eq!(index(&r, "3"), None);
+        assert_eq!(index(&r, "x"), None);
+    }
+
+    #[test]
+    fn only_the_three_bump_words_parse() {
+        assert_eq!(parse_bump("major"), Some(BumpType::Major));
+        assert_eq!(parse_bump("minor"), Some(BumpType::Minor));
+        assert_eq!(parse_bump("patch"), Some(BumpType::Patch));
+        assert_eq!(parse_bump("Major"), None);
+        assert_eq!(parse_bump("none"), None);
+    }
+}


### PR DESCRIPTION
Closes #911

Builds on #916, which is what made the output expressible. Merge that first.

```
FerrFlow — Release plan (interactive)

   1  api                1.0.0 → 2.0.0  major
   2  core               1.0.0 → 1.1.0  minor
   3  web                excluded

  <n> major|minor|patch, exclude <n>, include <n>, done, quit
>

  → run:
    ferrflow release --force-version api@2.0.0 --exclude web
```

## It prints a command, it does not release

That is the whole design. The session ends by handing over the invocation that reproduces what was chosen, and stops. Nothing is tagged, nothing is published, and the decision can be pasted into a PR, committed to a script, or run by CI.

Verified by replaying the emitted command:

```
○ web — excluded by --exclude
● core  1.0.0 → 1.1.0  (minor, from packages/core/package.json)
● api  1.0.0 → 2.0.0  (forced, from packages/api/package.json)
```

Byte for byte the plan the session showed. That closes the loop this issue asked for.

## No new dependency

The repo has no interactive crate, and adding one is not free: every crate goes through the `cargo vet` gate. A line-based prompt over stdin needs nothing new, works over ssh and inside a container, and is drivable from a pipe, which is how the end-to-end check above runs.

## It reads the published JSON, not the internal types

The session deserialises the same `check --json` contract external tooling consumes. If that shape changes, this breaks visibly rather than drifting out of agreement with what users see. It cost one round trip to discover: `check --json` is `{packages:[…]}`, not the `{released,skipped}` that `release` emits.

That also settled a scope question. Only packages already in the plan are listed, because excluding one that is not releasing means nothing.

## Also

`ferrflow plan` is now an alias of `check`, so the name from this issue and from the roadmap resolves. `--interactive` conflicts with `--json` and `--comment` at the parser level, since a prompt and a machine-readable dump cannot both own stdout.

Four tests on the pure parts: the emitted command carrying every decision, the empty case, one-based indices rejecting `0` and out-of-range, and only the three exact bump words parsing. 2039 in the suite, clippy clean at `-D warnings`.
