### PR TITLE
fix(wasm): put api_check behind the cli feature and build the no-cli surface in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
         run: cargo fmt --check
       - name: Clippy
         run: cargo clippy -- -D warnings
+      # The wasm package builds the library with default-features off, a
+      # configuration nothing else in CI compiles. Without this, a module
+      # that reaches for a cli-gated dependency only fails at publish time.
+      - name: Check the no-cli build surface
+        run: cargo check -p ferrflow-wasm
       - name: Tests (nextest)
         run: cargo nextest run --no-fail-fast
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub mod api_check;
 pub mod changelog;
 pub mod config;
 pub mod conventional_commits;
@@ -11,6 +10,8 @@ pub mod schema;
 pub mod validate;
 pub mod versioning;
 
+#[cfg(feature = "cli")]
+pub mod api_check;
 #[cfg(feature = "cli")]
 pub mod cache;
 #[cfg(feature = "cli")]


### PR DESCRIPTION
`Publish @ferrflow/wasm` failed on v7.7.0:

```
error[E0432]: unresolved import `crate::git`
  --> src/api_check.rs:10:12
error[E0432]: unresolved import `colored`
error[E0599]: no method named `bold` found for reference `&'static str`
```

My bug, from #915. `api_check` was declared in the unconditional block of `lib.rs` while using `crate::git` and `colored`, both of which live behind `#[cfg(feature = "cli")]`. It now sits with them.

## Why it only appeared at publish

`ferrflow-wasm` is the one consumer that takes the library with `default-features = false`, and the only place it gets built is the `publish-wasm` job. Every CI job builds the CLI, where `git` and `colored` are present, so the configuration that breaks was never compiled before the release ran.

That is the part worth fixing beyond the one-line move. CI now builds it:

```yaml
- name: Check the no-cli build surface
  run: cargo check -p ferrflow-wasm
```

Verified by reintroducing the bug with the step in place, which reproduces all three errors, then restoring the fix.

One `cargo check` on a crate that is already a workspace member, so the cost is a few seconds on a job that already compiles everything else.

## Note for the release

v7.7.0 published crates.io, Docker and the npm CLI packages; only `@ferrflow/wasm` failed. Once this lands, that job can be re-run on the existing tag rather than cutting a new version, since the failure was a build error rather than anything published.
