### PR TITLE
fix(git): honour commit.gpgsign on the commit-tree path

### DIFF
--- a/src/git/commits.rs
+++ b/src/git/commits.rs
@@ -233,8 +233,15 @@ pub fn create_branch_and_commits(
 
 /// Whether this repository is configured to sign commits. Mirrors what
 /// `git commit` consults, so the two commit paths agree.
+///
+/// `--type=bool` is what makes that true: git accepts `yes`, `on` and `1`
+/// as well as `true`, and normalises all of them here rather than leaving
+/// us to match spellings.
 pub(crate) fn commit_signing_enabled(workdir: &std::path::Path) -> bool {
-    run_git(workdir, &["config", "--get", "commit.gpgsign"])
-        .map(|v| v.trim().eq_ignore_ascii_case("true"))
-        .unwrap_or(false)
+    run_git(
+        workdir,
+        &["config", "--get", "--type=bool", "commit.gpgsign"],
+    )
+    .map(|v| v.trim() == "true")
+    .unwrap_or(false)
 }

--- a/src/git/commits.rs
+++ b/src/git/commits.rs
@@ -178,6 +178,11 @@ pub fn create_branch_and_commits(
     run_git(workdir, &["branch", "-f", branch_name])
         .with_context(|| format!("git branch -f {branch_name} failed"))?;
 
+    // `git commit` reads commit.gpgsign; `commit-tree` does not, and signs
+    // only when passed -S. Without this the PR path silently produces
+    // unsigned commits for a repo that asked for signing.
+    let signing_enabled = commit_signing_enabled(workdir);
+
     for (files, message) in commits {
         let mut add_args: Vec<&str> = vec!["add", "--"];
         add_args.extend_from_slice(files);
@@ -194,13 +199,15 @@ pub fn create_branch_and_commits(
         .with_context(|| format!("rev-parse {branch_name} failed"))?
         .trim()
         .to_string();
-        let commit_sha = run_git(
-            workdir,
-            &["commit-tree", &tree_sha, "-p", &parent_sha, "-m", message],
-        )
-        .with_context(|| "git commit-tree failed")?
-        .trim()
-        .to_string();
+        let mut commit_args: Vec<&str> =
+            vec!["commit-tree", &tree_sha, "-p", &parent_sha, "-m", message];
+        if signing_enabled {
+            commit_args.push("-S");
+        }
+        let commit_sha = run_git(workdir, &commit_args)
+            .with_context(|| "git commit-tree failed")?
+            .trim()
+            .to_string();
         run_git(
             workdir,
             &[
@@ -222,4 +229,12 @@ pub fn create_branch_and_commits(
 
     let _ = repo;
     Ok(())
+}
+
+/// Whether this repository is configured to sign commits. Mirrors what
+/// `git commit` consults, so the two commit paths agree.
+pub(crate) fn commit_signing_enabled(workdir: &std::path::Path) -> bool {
+    run_git(workdir, &["config", "--get", "commit.gpgsign"])
+        .map(|v| v.trim().eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
 }

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -1584,3 +1584,29 @@ fn changed_files_for_the_root_commit_is_its_whole_tree() {
 
     assert_eq!(files, vec!["packages/api/main.rs".to_string()]);
 }
+
+#[test]
+fn signing_is_off_when_the_repo_does_not_ask_for_it() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo_at(dir.path());
+
+    assert!(
+        !crate::git::commits::commit_signing_enabled(dir.path()),
+        "a repo with commit.gpgsign=false must not be treated as signing"
+    );
+}
+
+#[test]
+fn signing_follows_commit_gpgsign_so_both_commit_paths_agree() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo_at(dir.path());
+
+    git(dir.path(), &["config", "commit.gpgsign", "true"]);
+    assert!(
+        crate::git::commits::commit_signing_enabled(dir.path()),
+        "commit.gpgsign=true must reach the commit-tree path, which ignores it on its own"
+    );
+
+    git(dir.path(), &["config", "commit.gpgsign", "false"]);
+    assert!(!crate::git::commits::commit_signing_enabled(dir.path()));
+}

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -1610,3 +1610,25 @@ fn signing_follows_commit_gpgsign_so_both_commit_paths_agree() {
     git(dir.path(), &["config", "commit.gpgsign", "false"]);
     assert!(!crate::git::commits::commit_signing_enabled(dir.path()));
 }
+
+#[test]
+fn signing_follows_every_spelling_git_accepts_for_a_boolean() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo_at(dir.path());
+
+    for truthy in ["true", "yes", "on", "1"] {
+        git(dir.path(), &["config", "commit.gpgsign", truthy]);
+        assert!(
+            crate::git::commits::commit_signing_enabled(dir.path()),
+            "commit.gpgsign={truthy} means signing to git, so it must here too"
+        );
+    }
+
+    for falsy in ["false", "no", "off", "0"] {
+        git(dir.path(), &["config", "commit.gpgsign", falsy]);
+        assert!(
+            !crate::git::commits::commit_signing_enabled(dir.path()),
+            "commit.gpgsign={falsy} must not enable signing"
+        );
+    }
+}


### PR DESCRIPTION
Closes #920

`git commit` reads `commit.gpgsign`. `git commit-tree` does not, and signs only when passed `-S`. FerrFlow used both, so a repo that configured signing got it on one path and silently lost it on the other.

`create_branch_and_commits` serves the PR release mode, so a repo on `releaseCommitMode: "pr"` had nothing signed at all while believing it was set up.

## Demonstrated rather than reasoned about

On a repo with `commit.gpgsign=true` and an SSH signing key, counting `gpgsig` headers on the resulting commit object:

```
git commit                        1
commit-tree without -S            0     ← what FerrFlow did
commit-tree with -S               1     ← what it does now
```

The middle line is the bug: exit 0, no output, and an unsigned artefact the user asked not to have. A failure would have been fine.

## The change

One predicate, `commit_signing_enabled`, reading the same `commit.gpgsign` that `git commit` consults, and `-S` passed through when it is on. Git resolves the key itself, so FerrFlow configures nothing and never touches key material.

## On the tests

Two tests cover the predicate, which is the decision point: signing off by default, and following `commit.gpgsign` when set.

I did not write a test asserting the produced commit carries a signature. It would need a real key generated in the test, so it would depend on `ssh-keygen` or `gpg` being present and would fail spuriously wherever they are not. The evidence for that half is the measurement above, run by hand. Worth saying plainly rather than papering over with a test that proves less than it appears to.

## Scope

This covers every forge and every auth mode: anyone with a signing key gets verified commits under their own identity, with no GitHub App and no API. #921 is the separate and narrower case of the `ferrflow[bot]` identity, which no key can solve because GitHub Apps cannot register one.
