### PR TITLE
fix(docker): run as a non-root user in both images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN mkdir -p benches && echo 'fn main() {}' > benches/ferrflow_benchmarks.rs \
 # Runtime stage
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 RUN apk add --no-cache ca-certificates
+RUN adduser -D -u 1000 ferrflow
 COPY --from=builder /app/target/release/ferrflow /usr/local/bin/ferrflow
+USER ferrflow
+WORKDIR /repo
 ENTRYPOINT ["ferrflow"]
 CMD ["--help"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,6 +1,9 @@
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 RUN apk upgrade --no-cache && apk add --no-cache ca-certificates
+RUN adduser -D -u 1000 ferrflow
 ARG TARGETARCH
 COPY ferrflow-${TARGETARCH} /usr/local/bin/ferrflow
+USER ferrflow
+WORKDIR /repo
 ENTRYPOINT ["ferrflow"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -69,7 +69,14 @@ npm install -D ferrflow
 **Docker**
 
 ```bash
-docker run ghcr.io/ferrlabs/ferrflow:latest check
+docker run --rm -v "$PWD:/repo" ghcr.io/ferrlabs/ferrflow:latest check
+```
+
+The image runs as a non-root user (`ferrflow`, uid 1000) and works on `/repo`.
+If your checkout is owned by a different uid, pass your own:
+
+```bash
+docker run --rm -u "$(id -u):$(id -g)" -v "$PWD:/repo" ghcr.io/ferrlabs/ferrflow:latest check
 ```
 
 **Pre-built binaries**


### PR DESCRIPTION
Closes #923

Both images ran as uid 0. Neither had a `USER` directive.

```dockerfile
RUN adduser -D -u 1000 ferrflow
USER ferrflow
WORKDIR /repo
```

Verified by building `Dockerfile.release` and looking, rather than trusting the directive:

```
uid=1000(ferrflow) gid=1000(ferrflow) groups=1000(ferrflow)
/repo
```

## The bind mount is the real constraint

FerrFlow writes into a mounted checkout, so the container user has to be able to write there. uid 1000 matches the common Linux default; anyone whose checkout is owned differently passes `-u "$(id -u):$(id -g)"`.

Without documenting that, this would trade a scanner finding for a permission error with no obvious cause. So the README now says it.

## The README example was broken

It was:

```bash
docker run ghcr.io/ferrlabs/ferrflow:latest check
```

No volume, so `check` ran against an empty container. It cannot have worked for anyone who tried it. Now it mounts `$PWD` at `/repo`, which is also what makes the uid question concrete.
