### PR TITLE
fix(ci): send the coverage report to SonarQube

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,25 +79,6 @@ jobs:
           path: target/release/ferrflow
           retention-days: 1
 
-  coverage:
-    name: Coverage
-    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
-      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2
-        with:
-          tool: cargo-tarpaulin
-      - name: Generate coverage
-        run: cargo tarpaulin --out xml --skip-clean
-      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
-        with:
-          files: cobertura.xml
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
-
   fixture-generate:
     name: Generate Fixtures
     needs: test

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -37,8 +37,35 @@ jobs:
           echo "version=${VERSION:-0.0.0}" >> "$GITHUB_OUTPUT"
           echo "Latest release tag: ${TAG:-<none>} -> projectVersion=${VERSION:-0.0.0}"
 
+  # Coverage lives here rather than in ci.yml because the reusable scan
+  # downloads the report from an artifact in the same run, and artifacts do
+  # not cross workflow runs. Tarpaulin is slow, so it runs once and feeds
+  # both Sonar and Codecov instead of once per workflow.
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2
+        with:
+          tool: cargo-tarpaulin
+      - name: Generate coverage
+        run: cargo tarpaulin --out xml --skip-clean
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: coverage-cobertura
+          path: cobertura.xml
+          retention-days: 1
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        with:
+          files: cobertura.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
   scan:
-    needs: version
+    needs: [version, coverage]
     # The reusable workflow declares `pull-requests: write` (it posts the diff
     # against the base project). The job would otherwise inherit the read-only
     # workflow-level block above, and GitHub rejects the run before it starts.
@@ -49,5 +76,8 @@ jobs:
     with:
       runner: ubuntu-latest
       project-key: ferrflow
-      args: -Dsonar.projectVersion=${{ needs.version.outputs.version }}
+      coverage-artifact: coverage-cobertura
+      args: >-
+        -Dsonar.projectVersion=${{ needs.version.outputs.version }}
+        -Dsonar.rust.cobertura.reportPaths=.sonarcov/cobertura.xml
     secrets: inherit


### PR DESCRIPTION
Closes #925

Sonar showed 0% because nothing sent it a report, not because the tests were missing. The coverage already existed and went only to Codecov.

```
before   ci.yml  tarpaulin → cobertura.xml → Codecov
                 sonarqube.yml  scan with -Dsonar.projectVersion only

after    sonarqube.yml  tarpaulin → cobertura.xml → Codecov
                                                  → artifact → scan
```

## Why the job moved instead of being duplicated

The reusable scan takes a report through `coverage-artifact`, but downloads it **from the same run**, and artifacts do not cross workflow runs. Coverage was in `ci.yml` and the scan in `sonarqube.yml`, so passing the input alone would have found nothing.

They had to share a run. Moving coverage into `sonarqube.yml` is the smaller move: `ci.yml` is already fifteen jobs, and tarpaulin instruments and re-runs the whole suite, so keeping a copy in each workflow would have doubled that on every PR to avoid touching two files. One run now feeds both Sonar and Codecov.

## No change to how coverage is produced

Sonar's Rust analyser reads Cobertura as well as LCOV, through `sonar.rust.cobertura.reportPaths`. Tarpaulin already emitted `cobertura.xml`; the same file now serves both consumers. No new flag, no second format, no extra run.

## Checked

Both workflows parse, and no job in `ci.yml` depended on the one that moved: `release` needs `test` and the fixture and benchmark jobs, never `coverage`.

Worth saying plainly: the first run after this merges is the proof. If the path resolution inside `.sonarcov` is off, Sonar will still show 0% and the fix is the property, not the plumbing.

Once a real number lands, the coverage badge #857 removed can go back on the README.
