### PR TITLE
fix(publish): name cosign bundles .sigstore.json so they are recognised as signatures

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -202,12 +202,12 @@ jobs:
         # is the workflow's OIDC token, recorded in the Rekor transparency
         # log. Verify with:
         #   cosign verify-blob \
-        #     --bundle ferrflow-linux-x64.tar.gz.bundle \
+        #     --bundle ferrflow-linux-x64.tar.gz.sigstore.json \
         #     --certificate-identity-regexp "https://github.com/FerrLabs/FerrFlow/.*" \
         #     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
         #     ferrflow-linux-x64.tar.gz
         #
-        # One `.bundle` per artifact replaces the `.sig` + `.crt` pair as of
+        # One `.sigstore.json` per artifact replaces the `.sig` + `.crt` pair as of
         # cosign v3: `--use-signing-config` now defaults to true and requires
         # `--bundle`, and `--output-signature` / `--output-certificate` are
         # deprecated. Releases up to v5.47.4 carry the old pair.
@@ -223,7 +223,7 @@ jobs:
             local artifact="$1" attempt
             for attempt in 1 2 3; do
               if cosign sign-blob --yes \
-                  --bundle "${artifact}.bundle" \
+                  --bundle "${artifact}.sigstore.json" \
                   "$artifact"; then
                 return 0
               fi
@@ -268,7 +268,7 @@ jobs:
           set -euo pipefail
           for attempt in 1 2 3; do
             if cosign sign-blob --yes \
-                --bundle artifacts/sbom.cdx.json.bundle \
+                --bundle artifacts/sbom.cdx.json.sigstore.json \
                 artifacts/sbom.cdx.json; then
               exit 0
             fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -211,6 +211,11 @@ jobs:
         # cosign v3: `--use-signing-config` now defaults to true and requires
         # `--bundle`, and `--output-signature` / `--output-certificate` are
         # deprecated. Releases up to v5.47.4 carry the old pair.
+        #
+        # The extension is `.sigstore.json`, the canonical name for the
+        # Sigstore bundle format, not `.bundle`. Do not shorten it: OpenSSF
+        # Scorecard matches signatures by extension and does not know
+        # `.bundle`, which scored these releases as unsigned for months.
         env:
           COSIGN_EXPERIMENTAL: "1"
         run: |

--- a/docs/verifying-releases.md
+++ b/docs/verifying-releases.md
@@ -10,12 +10,12 @@ log.
 
 | Artifact | Sidecar |
 |---|---|
-| `ferrflow-linux-x64.tar.gz` | `.bundle` |
-| `ferrflow-linux-arm64.tar.gz` | `.bundle` |
-| `ferrflow-darwin-x64.tar.gz` | `.bundle` |
-| `ferrflow-darwin-arm64.tar.gz` | `.bundle` |
-| `ferrflow-windows-x64.zip` | `.bundle` |
-| `sbom.cdx.json` | `.bundle` |
+| `ferrflow-linux-x64.tar.gz` | `.sigstore.json` |
+| `ferrflow-linux-arm64.tar.gz` | `.sigstore.json` |
+| `ferrflow-darwin-x64.tar.gz` | `.sigstore.json` |
+| `ferrflow-darwin-arm64.tar.gz` | `.sigstore.json` |
+| `ferrflow-windows-x64.zip` | `.sigstore.json` |
+| `sbom.cdx.json` | `.sigstore.json` |
 | `ghcr.io/ferrlabs/ferrflow:vX.Y.Z` | Cosign signature recorded in
 GHCR + Rekor |
 
@@ -23,7 +23,7 @@ All sidecars are downloadable from the GitHub Release page next to the
 binary.
 
 > **Releases up to v5.47.4** ship a `.sig` + `.crt` pair instead of a single
-> `.bundle`. Verify those with `--certificate <file>.crt --signature <file>.sig`
+> `.sigstore.json`. Verify those with `--certificate <file>.crt --signature <file>.sig`
 > in place of `--bundle`. The switch came with cosign v3, which deprecated the
 > separate signature and certificate outputs in favour of one bundle.
 
@@ -41,7 +41,7 @@ gh release download "$TAG" --repo FerrLabs/FerrFlow \
 
 # verify
 cosign verify-blob \
-  --bundle ferrflow-linux-x64.tar.gz.bundle \
+  --bundle ferrflow-linux-x64.tar.gz.sigstore.json \
   --certificate-identity-regexp "https://github.com/FerrLabs/FerrFlow/.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   ferrflow-linux-x64.tar.gz


### PR DESCRIPTION
Closes #928

The releases were always signed. Scorecard matches signatures by extension and does not know `.bundle`, so it read every release since v5.47.4 as unsigned.

```
before   ferrflow-linux-x64.tar.gz.bundle
after    ferrflow-linux-x64.tar.gz.sigstore.json
```

`.sigstore.json` is the canonical extension for the Sigstore bundle format, so this is the right name regardless of Scorecard. Being on its list is a consequence, not the reason. Signing itself is untouched: `cosign sign-blob --bundle` takes any path.

## Why it regressed

Not by accident, and `publish.yml` already documented the move: cosign v3 deprecated `--output-signature` / `--output-certificate` in favour of `--bundle`, so the `.sig` + `.crt` pair became a single bundle. The old pair was on Scorecard's list. The new name was not. A correct upgrade quietly cost the score.

The workflow comment now says why the extension has to stay as it is, so the next person shortening it to `.bundle` has to read the reason first.

## Stopping at 8, not 10

Scorecard awards 10 only for `*.intoto.jsonl`. FerrFlow does attest provenance, but `actions/attest-build-provenance` puts it in GitHub's attestation store and its output is a Sigstore bundle, not a JSONL of in-toto statements.

Attaching that under an `.intoto.jsonl` name would match the pattern while naming the file wrongly, and the check never opens it to notice. Worth staying at 8.

## Asset names change

`docs/verifying-releases.md` is updated in the same diff. The site copy and a changelog entry are tracked separately, since anyone scripting against `.bundle` on a release after v5.47.4 needs to know.
