### PR TITLE
feat(config): support per-package config files via an include key

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,38 @@ format = "json"
 
 </details>
 
+#### One file per package
+
+A large monorepo does not have to keep every package in the root config. List the per-package files
+under `include`, and each project owns its own settings:
+
+```json
+{
+  "workspace": { "versioning": "semver" },
+  "include": ["services/*/ferrflow.json", "frontend/ferrflow.json"]
+}
+```
+
+```json
+{
+  "name": "api",
+  "changelog": "CHANGELOG.md",
+  "sharedPaths": ["../shared/"],
+  "versionedFiles": [{ "path": "Cargo.toml", "format": "toml" }]
+}
+```
+
+Paths inside an included file are relative to that file, and `path` defaults to its directory. The
+example above needs no `path`: `services/api/ferrflow.json` describes the package in
+`services/api`, and moving the directory does not require editing anything.
+
+Included files use the same keys as a `package` entry, so `dependsOn` still refers to packages by
+name and works across files. They may use a different format than the root config, and they can be
+mixed with an inline `package` array while you migrate.
+
+The following are rejected rather than silently ignored: an `include` pattern matching no file, two
+packages sharing a name, and an included file declaring `workspace`, `include`, or `package`.
+
 ## Versioning Strategies
 
 Each package can use its own versioning strategy. Set a default at the workspace level and override per package:

--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -9,6 +9,13 @@
       "type": "string",
       "description": "JSON Schema reference for editor autocompletion."
     },
+    "include": {
+      "type": "array",
+      "description": "Files that each declare one package, merged into `package`. Paths and globs are relative to this config file. A package path inside an included file is relative to that file, and defaults to its directory.",
+      "items": {
+        "type": "string"
+      }
+    },
     "workspace": {
       "type": "object",
       "description": "Workspace-level settings.",

--- a/src/config/format.rs
+++ b/src/config/format.rs
@@ -16,6 +16,7 @@ pub enum ConfigFileFormat {
 pub trait ConfigFormatHandler {
     fn filename(&self) -> &str;
     fn parse(&self, content: &str) -> Result<Config>;
+    fn parse_value(&self, content: &str) -> Result<serde_json::Value>;
     fn serialize(&self, config: &Config) -> Result<String>;
 }
 
@@ -100,6 +101,11 @@ impl ConfigFormatHandler for JsonFormat {
             .with_context(|| "Failed to parse ferrflow.json")
             .error_code(error_code::CONFIG_PARSE_JSON)
     }
+    fn parse_value(&self, content: &str) -> Result<serde_json::Value> {
+        serde_json::from_str(content)
+            .with_context(|| "Failed to parse ferrflow.json")
+            .error_code(error_code::CONFIG_PARSE_JSON)
+    }
     fn serialize(&self, config: &Config) -> Result<String> {
         let value = serde_json::to_value(config)?;
         let camel = to_camel_case_keys(value);
@@ -114,6 +120,11 @@ impl ConfigFormatHandler for Json5Format {
         "ferrflow.json5"
     }
     fn parse(&self, content: &str) -> Result<Config> {
+        json5::from_str(content)
+            .with_context(|| "Failed to parse ferrflow.json5")
+            .error_code(error_code::CONFIG_PARSE_JSON5)
+    }
+    fn parse_value(&self, content: &str) -> Result<serde_json::Value> {
         json5::from_str(content)
             .with_context(|| "Failed to parse ferrflow.json5")
             .error_code(error_code::CONFIG_PARSE_JSON5)
@@ -136,6 +147,11 @@ impl ConfigFormatHandler for TomlFormat {
             .with_context(|| "Failed to parse ferrflow.toml")
             .error_code(error_code::CONFIG_PARSE_TOML)
     }
+    fn parse_value(&self, content: &str) -> Result<serde_json::Value> {
+        toml_edit::de::from_str(content)
+            .with_context(|| "Failed to parse ferrflow.toml")
+            .error_code(error_code::CONFIG_PARSE_TOML)
+    }
     fn serialize(&self, config: &Config) -> Result<String> {
         toml_edit::ser::to_string_pretty(config)
             .with_context(|| "Failed to serialize to TOML")
@@ -149,6 +165,11 @@ impl ConfigFormatHandler for DotfileFormat {
     }
     fn parse(&self, content: &str) -> Result<Config> {
         ConfigFormatHandler::parse(&JsonFormat, content)
+            .with_context(|| "Failed to parse .ferrflow")
+            .error_code(error_code::CONFIG_PARSE_DOTFILE)
+    }
+    fn parse_value(&self, content: &str) -> Result<serde_json::Value> {
+        ConfigFormatHandler::parse_value(&JsonFormat, content)
             .with_context(|| "Failed to parse .ferrflow")
             .error_code(error_code::CONFIG_PARSE_DOTFILE)
     }

--- a/src/config/include.rs
+++ b/src/config/include.rs
@@ -1,0 +1,554 @@
+use anyhow::{Context, Result};
+use std::collections::HashMap;
+use std::path::{Component, Path, PathBuf};
+
+use crate::error_code::{self, ErrorCodeExt};
+
+use super::format::{DotfileFormat, Json5Format, JsonFormat, TomlFormat};
+use super::{Config, ConfigFormatHandler, PackageConfig};
+
+const SKIP_DIRS: &[&str] = &[
+    "node_modules",
+    ".git",
+    "target",
+    "dist",
+    "build",
+    ".next",
+    ".turbo",
+    "coverage",
+    "vendor",
+];
+
+const MAX_DEPTH: usize = 8;
+
+const FRAGMENT_ONLY_KEYS: &[&str] = &["workspace", "include", "package"];
+
+pub(super) fn resolve(config: &mut Config, config_path: &Path, repo_root: &Path) -> Result<()> {
+    if config.include.is_empty() {
+        return Ok(());
+    }
+
+    let config_dir = config_path.parent().unwrap_or(repo_root);
+    let patterns = std::mem::take(&mut config.include);
+    let mut included = Vec::new();
+
+    for pattern in &patterns {
+        let matches = expand(pattern, config_dir, config_path);
+        if matches.is_empty() {
+            Err(anyhow::anyhow!(
+                "include pattern matched no file: {pattern}\n\
+                 Remove the pattern, or fix the path relative to {}.",
+                config_dir.display()
+            ))
+            .error_code(error_code::CONFIG_INCLUDE_NOT_FOUND)?;
+        }
+        for path in matches {
+            included.push(load_fragment(&path, repo_root)?);
+        }
+    }
+
+    config.packages.extend(included);
+    reject_duplicate_names(&config.packages)?;
+    Ok(())
+}
+
+fn load_fragment(path: &Path, repo_root: &Path) -> Result<PackageConfig> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read {}", path.display()))
+        .error_code(error_code::CONFIG_READ_FAILED)?;
+
+    let handler = handler_for(path);
+    let value = handler
+        .parse_value(&content)
+        .with_context(|| format!("in included file {}", path.display()))?;
+
+    let object = value.as_object().ok_or_else(|| {
+        anyhow::anyhow!(
+            "included file {} must contain a single package object",
+            path.display()
+        )
+    })?;
+
+    for key in FRAGMENT_ONLY_KEYS {
+        if object.contains_key(*key) {
+            Err(anyhow::anyhow!(
+                "included file {} declares `{key}`, which only belongs in the root config.\n\
+                 An included file describes one package, using the same keys as a `package` entry.",
+                path.display()
+            ))
+            .error_code(error_code::CONFIG_INCLUDE_INVALID)?;
+        }
+    }
+
+    let mut package: PackageConfig = serde_json::from_value(value)
+        .with_context(|| format!("in included file {}", path.display()))
+        .error_code(error_code::CONFIG_INCLUDE_INVALID)?;
+
+    let fragment_dir = path.parent().unwrap_or(repo_root);
+    package.path = fragment_path(&package.path, fragment_dir, repo_root, path)?;
+    Ok(package)
+}
+
+fn fragment_path(
+    declared: &str,
+    fragment_dir: &Path,
+    repo_root: &Path,
+    fragment: &Path,
+) -> Result<String> {
+    let joined = if declared.is_empty() {
+        fragment_dir.to_path_buf()
+    } else {
+        fragment_dir.join(declared)
+    };
+
+    let normalised = normalise(&joined);
+    let root = normalise(repo_root);
+
+    let relative = normalised.strip_prefix(&root).map_err(|_| {
+        anyhow::anyhow!(
+            "included file {} resolves to {}, which is outside the repository root {}",
+            fragment.display(),
+            normalised.display(),
+            root.display()
+        )
+    });
+
+    let relative = match relative {
+        Ok(rel) => rel,
+        Err(err) => return Err(err).error_code(error_code::CONFIG_INCLUDE_OUTSIDE_ROOT),
+    };
+
+    Ok(to_slash(relative))
+}
+
+pub(super) fn reject_duplicate_names(packages: &[PackageConfig]) -> Result<()> {
+    let mut seen: HashMap<&str, &str> = HashMap::new();
+    for package in packages {
+        if let Some(first) = seen.insert(&package.name, &package.path) {
+            Err(anyhow::anyhow!(
+                "duplicate package name `{}`, declared at both `{first}` and `{}`",
+                package.name,
+                package.path
+            ))
+            .error_code(error_code::CONFIG_DUPLICATE_PACKAGE)?;
+        }
+    }
+    Ok(())
+}
+
+fn handler_for(path: &Path) -> &'static dyn ConfigFormatHandler {
+    let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    match path.extension().and_then(|e| e.to_str()).unwrap_or("") {
+        "json5" => &Json5Format,
+        "toml" => &TomlFormat,
+        _ if filename == ".ferrflow" => &DotfileFormat,
+        _ => &JsonFormat,
+    }
+}
+
+fn is_glob(pattern: &str) -> bool {
+    pattern.contains(['*', '?', '[', '{'])
+}
+
+fn expand(pattern: &str, base: &Path, own_path: &Path) -> Vec<PathBuf> {
+    if !is_glob(pattern) {
+        let candidate = base.join(pattern);
+        return if candidate.is_file() {
+            vec![candidate]
+        } else {
+            Vec::new()
+        };
+    }
+
+    let mut found = Vec::new();
+    collect(base, base, 0, pattern, own_path, &mut found);
+    found.sort();
+    found
+}
+
+fn collect(
+    base: &Path,
+    dir: &Path,
+    depth: usize,
+    pattern: &str,
+    own_path: &Path,
+    found: &mut Vec<PathBuf>,
+) {
+    if depth > MAX_DEPTH {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if path.is_dir() {
+            if name.starts_with('.') || SKIP_DIRS.contains(&name) {
+                continue;
+            }
+            collect(base, &path, depth + 1, pattern, own_path, found);
+        } else if path != own_path
+            && let Ok(rel) = path.strip_prefix(base)
+            && glob_match::glob_match(pattern, &to_slash(rel))
+        {
+            found.push(path);
+        }
+    }
+}
+
+fn to_slash(path: &Path) -> String {
+    path.components()
+        .filter_map(|c| c.as_os_str().to_str())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn normalise(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(root: &Path, rel: &str, contents: &str) {
+        let path = root.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    fn load(root: &Path) -> Result<Config> {
+        Config::load(root, None)
+    }
+
+    fn names_and_paths(config: &Config) -> Vec<(String, String)> {
+        config
+            .packages
+            .iter()
+            .map(|p| (p.name.clone(), p.path.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn glob_collects_one_package_per_fragment() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(
+            root,
+            "ferrflow.json",
+            r#"{"include":["projects/*/ferrflow.json"]}"#,
+        );
+        write(root, "projects/api/ferrflow.json", r#"{"name":"api"}"#);
+        write(root, "projects/web/ferrflow.json", r#"{"name":"web"}"#);
+
+        let config = load(root).unwrap();
+
+        assert_eq!(
+            names_and_paths(&config),
+            vec![
+                ("api".to_string(), "projects/api".to_string()),
+                ("web".to_string(), "projects/web".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn fragment_path_defaults_to_its_own_directory_not_the_repo_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(
+            root,
+            "ferrflow.json",
+            r#"{"include":["a/b/c/ferrflow.json"]}"#,
+        );
+        write(root, "a/b/c/ferrflow.json", r#"{"name":"deep"}"#);
+
+        let config = load(root).unwrap();
+
+        assert_eq!(config.packages[0].path, "a/b/c");
+    }
+
+    #[test]
+    fn fragment_path_is_relative_to_the_fragment_not_the_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(
+            root,
+            "ferrflow.json",
+            r#"{"include":["tools/ferrflow.json"]}"#,
+        );
+        write(
+            root,
+            "tools/ferrflow.json",
+            r#"{"name":"cli","path":"cli"}"#,
+        );
+
+        let config = load(root).unwrap();
+
+        assert_eq!(config.packages[0].path, "tools/cli");
+    }
+
+    #[test]
+    fn fragment_escaping_the_repo_root_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(
+            root,
+            "ferrflow.json",
+            r#"{"include":["pkg/ferrflow.json"]}"#,
+        );
+        write(
+            root,
+            "pkg/ferrflow.json",
+            r#"{"name":"escapee","path":"../../outside"}"#,
+        );
+
+        let err = format!("{:#}", load(root).unwrap_err());
+
+        assert!(err.contains("outside the repository root"), "{err}");
+    }
+
+    #[test]
+    fn a_pattern_matching_nothing_is_an_error_rather_than_a_silent_no_op() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(
+            root,
+            "ferrflow.json",
+            r#"{"include":["projects/*/ferrflow.json"]}"#,
+        );
+
+        let err = format!("{:#}", load(root).unwrap_err());
+
+        assert!(err.contains("matched no file"), "{err}");
+    }
+
+    #[test]
+    fn a_missing_literal_path_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(
+            root,
+            "ferrflow.json",
+            r#"{"include":["projects/api/ferrflow.json"]}"#,
+        );
+
+        let err = format!("{:#}", load(root).unwrap_err());
+
+        assert!(err.contains("matched no file"), "{err}");
+    }
+
+    #[test]
+    fn duplicate_names_across_fragments_are_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(
+            root,
+            "ferrflow.json",
+            r#"{"include":["projects/*/ferrflow.json"]}"#,
+        );
+        write(root, "projects/one/ferrflow.json", r#"{"name":"dup"}"#);
+        write(root, "projects/two/ferrflow.json", r#"{"name":"dup"}"#);
+
+        let err = format!("{:#}", load(root).unwrap_err());
+
+        assert!(err.contains("duplicate package name `dup`"), "{err}");
+    }
+
+    #[test]
+    fn a_fragment_colliding_with_an_inline_package_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(
+            root,
+            "ferrflow.json",
+            r#"{"include":["projects/*/ferrflow.json"],"package":[{"name":"api","path":"legacy"}]}"#,
+        );
+        write(root, "projects/api/ferrflow.json", r#"{"name":"api"}"#);
+
+        let err = format!("{:#}", load(root).unwrap_err());
+
+        assert!(err.contains("duplicate package name `api`"), "{err}");
+    }
+
+    #[test]
+    fn a_fragment_declaring_workspace_settings_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(
+            root,
+            "ferrflow.json",
+            r#"{"include":["pkg/ferrflow.json"]}"#,
+        );
+        write(
+            root,
+            "pkg/ferrflow.json",
+            r#"{"name":"api","workspace":{"versioning":"semver"}}"#,
+        );
+
+        let err = format!("{:#}", load(root).unwrap_err());
+
+        assert!(err.contains("declares `workspace`"), "{err}");
+    }
+
+    #[test]
+    fn a_fragment_using_the_root_package_array_shape_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(
+            root,
+            "ferrflow.json",
+            r#"{"include":["pkg/ferrflow.json"]}"#,
+        );
+        write(root, "pkg/ferrflow.json", r#"{"package":[{"name":"api"}]}"#);
+
+        let err = format!("{:#}", load(root).unwrap_err());
+
+        assert!(err.contains("declares `package`"), "{err}");
+    }
+
+    #[test]
+    fn nested_includes_are_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(
+            root,
+            "ferrflow.json",
+            r#"{"include":["pkg/ferrflow.json"]}"#,
+        );
+        write(
+            root,
+            "pkg/ferrflow.json",
+            r#"{"name":"api","include":["deeper/ferrflow.json"]}"#,
+        );
+
+        let err = format!("{:#}", load(root).unwrap_err());
+
+        assert!(err.contains("declares `include`"), "{err}");
+    }
+
+    #[test]
+    fn inline_and_included_packages_merge() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(
+            root,
+            "ferrflow.json",
+            r#"{"include":["projects/*/ferrflow.json"],"package":[{"name":"root-pkg","path":"."}]}"#,
+        );
+        write(root, "projects/api/ferrflow.json", r#"{"name":"api"}"#);
+
+        let config = load(root).unwrap();
+
+        assert_eq!(
+            names_and_paths(&config),
+            vec![
+                ("root-pkg".to_string(), ".".to_string()),
+                ("api".to_string(), "projects/api".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn fragments_may_use_a_different_format_than_the_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(
+            root,
+            "ferrflow.json",
+            r#"{"include":["api/ferrflow.toml"]}"#,
+        );
+        write(root, "api/ferrflow.toml", "name = \"api\"\n");
+
+        let config = load(root).unwrap();
+
+        assert_eq!(
+            names_and_paths(&config),
+            vec![("api".to_string(), "api".to_string())]
+        );
+    }
+
+    #[test]
+    fn fragments_keep_package_level_settings_and_dependencies() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(
+            root,
+            "ferrflow.json",
+            r#"{"include":["projects/*/ferrflow.json"]}"#,
+        );
+        write(root, "projects/api/ferrflow.json", r#"{"name":"api"}"#);
+        write(
+            root,
+            "projects/web/ferrflow.json",
+            r#"{"name":"web","dependsOn":["api"],"versioning":"calver"}"#,
+        );
+
+        let config = load(root).unwrap();
+        let web = config.packages.iter().find(|p| p.name == "web").unwrap();
+
+        assert_eq!(web.depends_on.len(), 1);
+        assert_eq!(web.depends_on[0].name(), "api");
+        assert!(web.versioning.is_some());
+    }
+
+    #[test]
+    fn skipped_directories_are_not_scanned() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(root, "ferrflow.json", r#"{"include":["**/ferrflow.json"]}"#);
+        write(root, "projects/api/ferrflow.json", r#"{"name":"api"}"#);
+        write(
+            root,
+            "node_modules/evil/ferrflow.json",
+            r#"{"name":"evil"}"#,
+        );
+
+        let config = load(root).unwrap();
+        let names: Vec<&str> = config.packages.iter().map(|p| p.name.as_str()).collect();
+
+        assert_eq!(names, vec!["api"]);
+    }
+
+    #[test]
+    fn an_inline_package_without_a_path_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(root, "ferrflow.json", r#"{"package":[{"name":"api"}]}"#);
+
+        let err = format!("{:#}", load(root).unwrap_err());
+
+        assert!(err.contains("has no `path`"), "{err}");
+    }
+
+    #[test]
+    fn a_config_without_include_is_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(
+            root,
+            "ferrflow.json",
+            r#"{"package":[{"name":"api","path":"api"}]}"#,
+        );
+
+        let config = load(root).unwrap();
+
+        assert_eq!(
+            names_and_paths(&config),
+            vec![("api".to_string(), "api".to_string())]
+        );
+    }
+}

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -228,6 +228,7 @@ pub fn init(format: Option<ConfigFileFormat>, manifest: bool) -> Result<()> {
     }
 
     let config = Config {
+        include: Vec::new(),
         workspace,
         packages,
     };

--- a/src/config/migrate.rs
+++ b/src/config/migrate.rs
@@ -330,6 +330,7 @@ pub fn build_config_from_releaserc(raw: &str) -> Result<(Config, MigrationReport
 
     Ok((
         Config {
+            include: Vec::new(),
             workspace,
             packages: vec![package],
         },

--- a/src/config/migrate/changesets.rs
+++ b/src/config/migrate/changesets.rs
@@ -120,6 +120,7 @@ pub(super) fn build(raw: &str, root: &Path) -> Result<(Config, MigrationReport)>
 
     Ok((
         Config {
+            include: Vec::new(),
             workspace,
             packages,
         },

--- a/src/config/migrate/release_please.rs
+++ b/src/config/migrate/release_please.rs
@@ -125,6 +125,7 @@ pub(super) fn build(raw: &str) -> Result<(Config, MigrationReport)> {
 
     Ok((
         Config {
+            include: Vec::new(),
             workspace,
             packages,
         },

--- a/src/config/migrate/standard_version.rs
+++ b/src/config/migrate/standard_version.rs
@@ -163,6 +163,7 @@ pub(super) fn build(raw: &str) -> Result<(Config, MigrationReport)> {
 
     Ok((
         Config {
+            include: Vec::new(),
             workspace,
             packages: vec![package],
         },

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,6 +7,7 @@ use crate::error_code::{self, ErrorCodeExt};
 mod commit_formats;
 mod format;
 mod groups;
+mod include;
 #[cfg(feature = "cli")]
 mod init;
 #[cfg(feature = "cli")]
@@ -52,6 +53,8 @@ use loader_js::{JS_CONFIG_FILENAME, TS_CONFIG_FILENAME, load_js_ts_config};
 pub struct Config {
     #[serde(default)]
     pub workspace: WorkspaceConfig,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub include: Vec<String>,
     #[serde(default, rename = "package")]
     pub packages: Vec<PackageConfig>,
 }
@@ -64,7 +67,9 @@ impl Config {
             } else {
                 path.to_path_buf()
             };
-            return Self::load_explicit(&resolved_path);
+            let mut config = Self::load_explicit(&resolved_path)?;
+            config.finish(&resolved_path, repo_root)?;
+            return Ok(config);
         }
 
         let found = Self::discover(repo_root);
@@ -85,7 +90,24 @@ impl Config {
             .error_code(error_code::CONFIG_MULTIPLE_FILES)?;
         }
 
-        Self::load_from_path(&found[0])
+        let mut config = Self::load_from_path(&found[0])?;
+        config.finish(&found[0], repo_root)?;
+        Ok(config)
+    }
+
+    fn finish(&mut self, config_path: &Path, repo_root: &Path) -> Result<()> {
+        include::resolve(self, config_path, repo_root)?;
+
+        if let Some(package) = self.packages.iter().find(|p| p.path.is_empty()) {
+            Err(anyhow::anyhow!(
+                "package `{}` has no `path`.
+                 Set it relative to the repository root, or move the package into its own                  file listed under `include`, where `path` defaults to that file's directory.",
+                package.name
+            ))
+            .error_code(error_code::CONFIG_MISSING_PACKAGE_PATH)?;
+        }
+
+        include::reject_duplicate_names(&self.packages)
     }
 
     fn discover(repo_root: &Path) -> Vec<PathBuf> {
@@ -226,6 +248,7 @@ impl Config {
             .to_string();
 
         Config {
+            include: Vec::new(),
             workspace: WorkspaceConfig::default(),
             packages: if versioned_files.is_empty() {
                 vec![]

--- a/src/config/package.rs
+++ b/src/config/package.rs
@@ -8,6 +8,7 @@ use super::workspace::WorkspaceConfig;
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PackageConfig {
     pub name: String,
+    #[serde(default)]
     pub path: String,
     #[serde(default, alias = "versionedFiles")]
     pub versioned_files: Vec<VersionedFile>,

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -436,6 +436,7 @@ fn tag_template_name_placeholder() {
 #[test]
 fn is_monorepo_single() {
     let config = Config {
+        include: Vec::new(),
         workspace: WorkspaceConfig::default(),
         packages: vec![make_pkg("a", None)],
     };
@@ -445,6 +446,7 @@ fn is_monorepo_single() {
 #[test]
 fn is_monorepo_multi() {
     let config = Config {
+        include: Vec::new(),
         workspace: WorkspaceConfig::default(),
         packages: vec![make_pkg("a", None), make_pkg("b", None)],
     };
@@ -551,6 +553,7 @@ fn load_explicit_not_found() {
 fn json_roundtrip() {
     let handler = JsonFormat;
     let config = Config {
+        include: Vec::new(),
         workspace: WorkspaceConfig::default(),
         packages: vec![make_pkg("test", None)],
     };
@@ -563,6 +566,7 @@ fn json_roundtrip() {
 fn json_serializes_camel_case() {
     let handler = JsonFormat;
     let config = Config {
+        include: Vec::new(),
         workspace: WorkspaceConfig {
             tag_template: Some("v{version}".into()),
             version_template: None,
@@ -615,6 +619,7 @@ fn json_serializes_camel_case() {
 fn toml_keeps_snake_case() {
     let handler = TomlFormat;
     let config = Config {
+        include: Vec::new(),
         workspace: WorkspaceConfig {
             tag_template: Some("v{version}".into()),
             version_template: None,
@@ -662,6 +667,7 @@ fn toml_keeps_snake_case() {
 fn toml_roundtrip() {
     let handler = TomlFormat;
     let config = Config {
+        include: Vec::new(),
         workspace: WorkspaceConfig::default(),
         packages: vec![make_pkg("test", None)],
     };
@@ -959,6 +965,7 @@ fn to_camel_case_keys_nested() {
 fn json5_roundtrip() {
     let handler = Json5Format;
     let config = Config {
+        include: Vec::new(),
         workspace: WorkspaceConfig::default(),
         packages: vec![make_pkg("test", None)],
     };
@@ -971,6 +978,7 @@ fn json5_roundtrip() {
 fn dotfile_roundtrip() {
     let handler = DotfileFormat;
     let config = Config {
+        include: Vec::new(),
         workspace: WorkspaceConfig::default(),
         packages: vec![make_pkg("test", None)],
     };
@@ -1077,6 +1085,7 @@ fn format_handler_returns_correct_filenames() {
 #[test]
 fn is_monorepo_empty() {
     let config = Config {
+        include: Vec::new(),
         workspace: WorkspaceConfig::default(),
         packages: vec![],
     };

--- a/src/error_code.rs
+++ b/src/error_code.rs
@@ -72,6 +72,16 @@ pub const CONFIG_MULTIPLE_FILES: ErrorCode = ErrorCode(1016);
 pub const CONFIG_ALREADY_EXISTS: ErrorCode = ErrorCode(1017);
 #[allow(dead_code)]
 pub const CONFIG_INVALID_PATH: ErrorCode = ErrorCode(1018);
+#[allow(dead_code)]
+pub const CONFIG_INCLUDE_NOT_FOUND: ErrorCode = ErrorCode(1019);
+#[allow(dead_code)]
+pub const CONFIG_INCLUDE_INVALID: ErrorCode = ErrorCode(1020);
+#[allow(dead_code)]
+pub const CONFIG_INCLUDE_OUTSIDE_ROOT: ErrorCode = ErrorCode(1021);
+#[allow(dead_code)]
+pub const CONFIG_DUPLICATE_PACKAGE: ErrorCode = ErrorCode(1022);
+#[allow(dead_code)]
+pub const CONFIG_MISSING_PACKAGE_PATH: ErrorCode = ErrorCode(1023);
 
 #[allow(dead_code)]
 pub const VALIDATE_INVALID_REPO_SPEC: ErrorCode = ErrorCode(1100);

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -37,6 +37,27 @@ mod tests {
         assert_eq!(value["$id"], "https://ferrflow.com/schema/ferrflow.json");
         assert!(value["properties"]["workspace"].is_object());
         assert!(value["properties"]["package"].is_object());
+        assert!(value["properties"]["include"].is_object());
+    }
+
+    #[test]
+    fn schema_covers_every_key_the_root_config_accepts() {
+        let value: serde_json::Value =
+            serde_json::from_str(BUNDLED_SCHEMA).expect("bundled schema must parse");
+        let documented = value["properties"]
+            .as_object()
+            .expect("properties must be an object");
+
+        assert!(
+            value["additionalProperties"] == serde_json::Value::Bool(false),
+            "the schema must stay strict, otherwise this test proves nothing"
+        );
+        for key in ["workspace", "include", "package"] {
+            assert!(
+                documented.contains_key(key),
+                "`{key}` is accepted by Config but absent from the schema, so editors reject it"
+            );
+        }
     }
 
     #[test]

--- a/src/validate/tests.rs
+++ b/src/validate/tests.rs
@@ -7,6 +7,7 @@ use tempfile::TempDir;
 
 fn make_config(packages: Vec<PackageConfig>) -> Config {
     Config {
+        include: Vec::new(),
         workspace: WorkspaceConfig::default(),
         packages,
     }


### PR DESCRIPTION
Closes #931.

Adds an `include` key so a monorepo can keep one config file per package instead of one long root
file that every team edits.

```json
{
  "workspace": { "versioning": "semver" },
  "include": ["projects/*/ferrflow.json"]
}
```

```json
{ "name": "api", "dependsOn": ["core"] }
```

`Config` gains one field and resolution happens during `Config::load`, so the merged result is the
same two-field shape everything downstream already consumes. The graph, the plan, `execute.rs` and
`publish.rs` are untouched.

## Path resolution

A package path inside an included file is relative to that file, and defaults to its directory. So
`projects/api/ferrflow.json` needs no `path` at all, and moving the directory does not require
editing anything. The loader normalises to a root-relative path during the merge, which is what
`plan.root.join(&pkg.path)` has always expected.

## What is rejected rather than silently ignored

Every one of these is a case where the old behaviour would have been to do nothing and exit 0,
which on a release tool is how you find out weeks later that nothing shipped.

- An `include` pattern matching no file.
- Two packages sharing a name, whether from two fragments or against an inline `package` entry.
- An included file declaring `workspace`, `include`, or `package`, so nested includes and misplaced
  workspace settings fail loudly.
- An included file resolving to a path outside the repository root.
- A package with no `path`. `path` became `#[serde(default)]` to let fragments omit it, so this is
  now checked explicitly instead of by serde. Same rejection, better message.

## Self-inclusion

Worth calling out because it only showed up under test: a pattern like `**/ferrflow.json` matches
the root config itself, which made the config include itself as a package. Expansion now skips the
file it was read from.

## Verified end to end

Beyond the unit tests, against a real repo with the built binary:

```
$ ferrflow graph
  api
    depends on  —
    required by web
  web
    depends on  api
    required by —

  release order api → web

$ ferrflow release --dry-run
● api  0.0.0 → 0.1.0  (minor, bootstrapped)
```

`dependsOn` crosses fragments because dependencies reference packages by name, and only `api` bumps
from a commit touching `projects/api/`, which is the proof that the defaulted path drives change
detection.

## Tests

17 new tests in `src/config/include.rs` covering glob and literal patterns, the path defaulting and
relative resolution, root escape, mixed formats, inline plus included merging, cross-fragment
`dependsOn`, skipped directories, and each rejection above. Full suite 909 passing, clippy clean,
and `cargo check -p ferrflow-wasm` still builds the no-cli surface.

`src/schema.rs` gains a test asserting the schema documents every key the root config accepts, so a
future field cannot be added to `Config` without the schema noticing.

## Follow-ups, not in this PR

- The served schema copy in `FerrFlow-Cloud/site/public/schema/ferrflow.json` needs the same
  addition. Separate repo, separate PR, and the parity job there stays red until this merges. Worth
  knowing: the two copies had already drifted before this change (49221 vs 48136 bytes), so that
  sync is owed regardless.
- The root schema is `additionalProperties: false`, so an included file named `ferrflow.json` gets
  flagged by editors that map the filename to the root schema. A small standalone fragment schema
  would fix that. I left it out to keep this PR to the issue's scope, but it is a real papercut for
  anyone adopting the feature.
