### PR TITLE
fix(git): classify push failures by cause instead of the generic push error code

### DIFF
--- a/src/git/retry.rs
+++ b/src/git/retry.rs
@@ -86,6 +86,12 @@ pub(super) fn is_transient_git_error(err: &anyhow::Error) -> bool {
     {
         return true;
     }
+    if chain.contains("fatal error in commit_refs")
+        || chain.contains("internal server error")
+        || chain.contains("remote end hung up")
+    {
+        return true;
+    }
     if chain.contains("non-fast-forward")
         || chain.contains("branch protection")
         || chain.contains("rejected by remote")
@@ -98,15 +104,19 @@ pub(super) fn is_transient_git_error(err: &anyhow::Error) -> bool {
     false
 }
 
+/// Whether the push failed because the remote moved under us, which the release
+/// flow answers by regenerating the release commit against the new tip.
+///
+/// This deliberately does not match `GIT_PUSH_BRANCH` or `GIT_PUSH_TAGS`. Those
+/// are the generic "push failed" codes carried by every push error, transient
+/// and permanent alike, so matching them reported a stale branch for causes that
+/// were nothing of the sort and burned the regenerate attempts on errors no
+/// amount of regenerating could fix.
 pub fn is_push_rejected_error(err: &anyhow::Error) -> bool {
-    let push_codes: &[String] = &[
-        error_code::GIT_PUSH_REJECTED.to_string(),
-        error_code::GIT_PUSH_BRANCH.to_string(),
-        error_code::GIT_PUSH_TAGS.to_string(),
-    ];
+    let rejected_code = error_code::GIT_PUSH_REJECTED.to_string();
     err.chain().any(|cause| {
         let raw = cause.to_string();
-        if push_codes.iter().any(|c| raw == c.as_str()) {
+        if raw == rejected_code {
             return true;
         }
         let msg = raw.to_lowercase();
@@ -115,5 +125,11 @@ pub fn is_push_rejected_error(err: &anyhow::Error) -> bool {
             || msg.contains("non-fast-forward")
             || msg.contains("non-fastforward")
             || msg.contains("not fast forward")
+            // git says "fetch first" when the remote advanced and we have not
+            // fetched since, which is the usual shape in CI, and "stale info"
+            // when a --force-with-lease expectation is out of date.
+            || msg.contains("fetch first")
+            || msg.contains("stale info")
+            || msg.contains("already exist on remote pointing to a different commit")
     })
 }

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -1543,6 +1543,89 @@ fn is_push_rejected_error_recognises_known_signatures() {
     assert!(!is_push_rejected_error(&e));
 }
 
+fn push_branch_failure(detail: &str) -> anyhow::Error {
+    anyhow::anyhow!("Failed to push branch 'main': {detail}").context(error_code::GIT_PUSH_BRANCH)
+}
+
+#[test]
+fn a_github_side_push_failure_is_transient_not_a_stale_branch() {
+    let err = push_branch_failure(
+        "remote: fatal error in commit_refs\n\
+         To https://github.com/FerrLabs/FerrFlow\n \
+         ! [remote rejected] main -> main (failure)\n\
+         error: failed to push some refs",
+    );
+
+    assert!(
+        is_transient_git_error(&err),
+        "a server-side failure must be retried by the push layer"
+    );
+    assert!(
+        !is_push_rejected_error(&err),
+        "it is not a race, so it must not be reported as a stale branch \
+         nor burn the regenerate attempts"
+    );
+}
+
+#[test]
+fn a_remote_that_advanced_before_we_fetched_is_a_race() {
+    // This is the wording git actually produces in CI, where the release job
+    // pushes without having fetched the branch first.
+    let err = push_branch_failure(
+        " ! [rejected]        HEAD -> main (fetch first)\n\
+         error: failed to push some refs",
+    );
+
+    assert!(is_push_rejected_error(&err));
+    assert!(!is_transient_git_error(&err));
+}
+
+#[test]
+fn a_non_fast_forward_is_a_race() {
+    let err = push_branch_failure(" ! [rejected]        HEAD -> main (non-fast-forward)");
+
+    assert!(is_push_rejected_error(&err));
+}
+
+#[test]
+fn a_stale_force_with_lease_expectation_is_a_race() {
+    let err = push_branch_failure(" ! [rejected]        main -> main (stale info)");
+
+    assert!(is_push_rejected_error(&err));
+}
+
+#[test]
+fn a_permanent_push_failure_is_neither_retried_nor_regenerated() {
+    for detail in [
+        "remote: Permission to FerrLabs/FerrFlow.git denied to ferrflow[bot].\n\
+         fatal: unable to access ...: The requested URL returned error: 403",
+        "remote: Repository not found.\nfatal: repository not found",
+        "fatal: Authentication failed for 'https://github.com/FerrLabs/FerrFlow'",
+    ] {
+        let err = push_branch_failure(detail);
+        assert!(
+            !is_push_rejected_error(&err),
+            "must fail fast with the real cause instead of three misleading \
+             stale-branch attempts: {detail}"
+        );
+        assert!(!is_transient_git_error(&err), "{detail}");
+    }
+}
+
+#[test]
+fn a_divergent_remote_tag_still_routes_to_the_regenerate_path() {
+    let err = anyhow::anyhow!(
+        "Tag(s) already exist on remote pointing to a different commit: \
+         api@v3.13.3 (local 1e3ed96 != remote c3ae651)."
+    )
+    .context(error_code::GIT_PUSH_TAGS);
+
+    assert!(
+        is_push_rejected_error(&err),
+        "matched by its own wording now that the generic code no longer counts"
+    );
+}
+
 fn commit_file_at(dir: &Path, rel: &str, message: &str) -> String {
     let path = dir.join(rel);
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();


### PR DESCRIPTION
Closes #935.

Two classifiers, each wrong about the same error, in opposite directions.

`is_transient_git_error` did not recognise `fatal error in commit_refs`, so the push layer that exists precisely for server-side failures gave it zero retries. `is_push_rejected_error` then matched it through `GIT_PUSH_BRANCH`, the generic "push failed" code, so the release loop reported "pushed onto a stale 'main'" and regenerated the release commit three times against a race that never happened.

## What changed

`fatal error in commit_refs` joins the transient list, along with `internal server error` and `remote end hung up` from the same family.

`is_push_rejected_error` no longer matches `GIT_PUSH_BRANCH` or `GIT_PUSH_TAGS`. Those codes ride on every push error, so matching them meant every failure looked like a race. It still matches `GIT_PUSH_REJECTED`, which is specific by name, and decides everything else on the actual wording.

## The part that would have broken the fix

Dropping the generic codes removes the safety net those patterns were hiding behind, so the wording list has to actually cover a real race. It did not.

Reproduced an honest race locally, two clones pushing to the same bare remote:

```
without a prior fetch:   ! [rejected]  HEAD -> main (fetch first)
after fetching:          ! [rejected]  HEAD -> main (non-fast-forward)
```

The old list had `non-fast-forward` but not `fetch first`, and `fetch first` is the wording CI produces, since the release job pushes having fetched only tags. Removing the code match without adding it would have stopped retrying the exact case #321 was filed for.

Added `fetch first` and `stale info` (a `--force-with-lease` expectation gone out of date).

Also added `already exist on remote pointing to a different commit`. The divergent-remote-tag case is a genuine "remote moved" condition that wants the regenerate path, and it was reaching it only through `GIT_PUSH_TAGS`. It now matches on its own wording, which is the message `push.rs:329` actually produces.

## Tests

Six new cases in `src/git/tests.rs`, one per class rather than one per string:

- the GitHub server error is transient and is *not* a stale branch, asserting both directions
- a remote that advanced before we fetched (`fetch first`) is a race
- `non-fast-forward` is a race
- `stale info` is a race
- permission denied, repository not found and authentication failed are neither transient nor races, so they surface immediately with the real cause instead of three misleading attempts
- the divergent remote tag still routes to the regenerate path

Verified the tests actually catch the bug by restoring the old classifier: `a_github_side_push_failure_is_transient_not_a_stale_branch` and `a_permanent_push_failure_is_neither_retried_nor_regenerated` both fail against it.

The pre-existing `is_push_rejected_error_recognises_known_signatures` passes unchanged, including its `GIT_PUSH_TAGS` case, now via wording.

1197 bin and 915 lib tests passing, clippy clean, wasm surface builds.

## Effect on the run that prompted this

That push would have been retried with backoff by `retry_transient`, which is very likely to have succeeded given the previous release pushed fine sixteen minutes earlier. Failing that, it would have surfaced `fatal error in commit_refs` as itself rather than as a stale branch.
