### PR TITLE
feat(bot): author release commits through createCommitOnBranch so they are verified

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,6 +644,7 @@ name = "ferrflow"
 version = "7.8.1"
 dependencies = [
  "anyhow",
+ "base64",
  "cargo-husky",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ serde_json = { version = "1", features = ["preserve_order"] }
 json5 = "1.0"
 toml_edit = { version = "0.25", features = ["serde"] }
 semver = "1"
+base64 = "0.23"
 regex = "1"
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -652,6 +652,12 @@ That is the whole job. No `setup-node`, no extra dependencies. FerrFlow's Rust b
 
 Three auth modes are supported: `bot: true` uses the hosted FerrFlow App (recommended); `token: <PAT>` uses a personal access token or your own GitHub App token (DIY); omitting both falls back to the workflow's `GITHUB_TOKEN` (simplest, but release events won't trigger downstream workflows).
 
+On GitHub, the release commit is authored through the forge rather than by local git when `bot: true` is set, which is what makes it show as **verified**. A GitHub App cannot register a signing key, so letting GitHub author the commit is the only way its commits are signed. GitHub does that only when the request carries no custom author, committer or signature, so the commit is attributed to `ferrflow[bot]` and nothing else.
+
+Everywhere else, and without `bot: true`, the commit is built by local git exactly as before. If you want verified commits under your own identity, set `commit.gpgsign` and FerrFlow will honour it, on every forge.
+
+Annotated tags are still created and pushed by git, so they are not covered by this. Only the commit is.
+
 ## License
 
 [MIT](LICENSE)

--- a/src/error_code.rs
+++ b/src/error_code.rs
@@ -151,6 +151,12 @@ pub const GITHUB_AUTO_MERGE_FAILED: ErrorCode = ErrorCode(3010);
 pub const GITHUB_FIND_PR: ErrorCode = ErrorCode(3011);
 #[allow(dead_code)]
 pub const GITHUB_UPDATE_PR: ErrorCode = ErrorCode(3012);
+#[allow(dead_code)]
+pub const GITHUB_GRAPHQL_REQUEST: ErrorCode = ErrorCode(3013);
+#[allow(dead_code)]
+pub const GITHUB_GRAPHQL_ERROR: ErrorCode = ErrorCode(3014);
+#[allow(dead_code)]
+pub const GITHUB_SET_BRANCH: ErrorCode = ErrorCode(3015);
 
 #[allow(dead_code)]
 pub const GITLAB_CREATE_RELEASE: ErrorCode = ErrorCode(3101);

--- a/src/forge/github.rs
+++ b/src/forge/github.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 
-use super::{Forge, MergeRequestResult, ReleaseResult};
+use super::{AuthoredCommit, Forge, MergeRequestResult, ReleaseResult};
 use crate::error_code::{self, ErrorCodeExt};
 
 const PER_PAGE: u32 = 100;
@@ -45,7 +45,144 @@ impl GitHubForge {
     }
 }
 
+const CREATE_COMMIT_MUTATION: &str = "\
+mutation($input: CreateCommitOnBranchInput!) { \
+  createCommitOnBranch(input: $input) { commit { oid } } \
+}";
+
+impl GitHubForge {
+    fn graphql(&self, body: serde_json::Value, what: &str) -> Result<serde_json::Value> {
+        let url = format!("{}/graphql", self.api_base);
+        let response: serde_json::Value = self
+            .agent
+            .post(&url)
+            .header("Authorization", &format!("Bearer {}", self.token))
+            .header("User-Agent", "ferrflow")
+            .send_json(body)
+            .with_context(|| format!("{what} failed"))
+            .error_code(error_code::GITHUB_GRAPHQL_REQUEST)?
+            .body_mut()
+            .read_json()
+            .with_context(|| "Failed to parse GraphQL response")
+            .error_code(error_code::GITHUB_GRAPHQL_PARSE)?;
+
+        if let Some(message) = graphql_error_message(&response) {
+            return Err(anyhow::anyhow!("{what} failed: {message}"))
+                .error_code(error_code::GITHUB_GRAPHQL_ERROR);
+        }
+        Ok(response)
+    }
+}
+
+pub(super) fn graphql_error_message(response: &serde_json::Value) -> Option<String> {
+    let errors = response.get("errors")?.as_array()?;
+    let first = errors.first()?;
+    Some(
+        first["message"]
+            .as_str()
+            .unwrap_or("unknown GraphQL error")
+            .to_string(),
+    )
+}
+
+pub(super) fn build_commit_input(
+    slug: &str,
+    commit: &crate::forge::AuthoredCommit<'_>,
+) -> serde_json::Value {
+    let additions: Vec<serde_json::Value> = commit
+        .additions
+        .iter()
+        .map(|a| serde_json::json!({ "path": a.path, "contents": a.base64_contents }))
+        .collect();
+    let deletions: Vec<serde_json::Value> = commit
+        .deletions
+        .iter()
+        .map(|path| serde_json::json!({ "path": path }))
+        .collect();
+
+    let (headline, body) = split_commit_message(commit.message);
+    let mut message = serde_json::json!({ "headline": headline });
+    if let Some(body) = body {
+        message["body"] = serde_json::Value::String(body);
+    }
+
+    serde_json::json!({
+        "branch": {
+            "repositoryNameWithOwner": slug,
+            "branchName": commit.branch,
+        },
+        "expectedHeadOid": commit.expected_head_oid,
+        "message": message,
+        "fileChanges": {
+            "additions": additions,
+            "deletions": deletions,
+        },
+    })
+}
+
+fn split_commit_message(message: &str) -> (String, Option<String>) {
+    match message.split_once('\n') {
+        Some((headline, rest)) => {
+            let body = rest.trim_start_matches('\n').trim_end();
+            let body = (!body.is_empty()).then(|| body.to_string());
+            (headline.trim_end().to_string(), body)
+        }
+        None => (message.trim_end().to_string(), None),
+    }
+}
+
 impl Forge for GitHubForge {
+    fn authors_verified_commits(&self) -> bool {
+        true
+    }
+
+    fn create_commit_on_branch(&self, commit: &AuthoredCommit<'_>) -> Result<String> {
+        let input = build_commit_input(&self.slug, commit);
+        let response = self.graphql(
+            serde_json::json!({
+                "query": CREATE_COMMIT_MUTATION,
+                "variables": { "input": input },
+            }),
+            "createCommitOnBranch",
+        )?;
+
+        response["data"]["createCommitOnBranch"]["commit"]["oid"]
+            .as_str()
+            .map(str::to_string)
+            .ok_or_else(|| anyhow::anyhow!("createCommitOnBranch returned no commit oid"))
+            .error_code(error_code::GITHUB_GRAPHQL_ERROR)
+    }
+
+    fn set_branch(&self, branch: &str, oid: &str) -> Result<()> {
+        let url = format!(
+            "{}/repos/{}/git/refs/heads/{branch}",
+            self.api_base, self.slug
+        );
+        let patched = self
+            .agent
+            .patch(&url)
+            .header("Authorization", &format!("Bearer {}", self.token))
+            .header("User-Agent", "ferrflow")
+            .send_json(serde_json::json!({ "sha": oid, "force": true }));
+
+        match patched {
+            Ok(_) => Ok(()),
+            Err(_) => {
+                let create_url = format!("{}/repos/{}/git/refs", self.api_base, self.slug);
+                self.agent
+                    .post(&create_url)
+                    .header("Authorization", &format!("Bearer {}", self.token))
+                    .header("User-Agent", "ferrflow")
+                    .send_json(serde_json::json!({
+                        "ref": format!("refs/heads/{branch}"),
+                        "sha": oid,
+                    }))
+                    .map(|_| ())
+                    .with_context(|| format!("Failed to point branch '{branch}' at {oid}"))
+                    .error_code(error_code::GITHUB_SET_BRANCH)
+            }
+        }
+    }
     fn create_release(
         &self,
         tag: &str,
@@ -431,6 +568,118 @@ mod tests {
         });
         assert_eq!(payload["head"], "release/v1.0.0");
         assert_eq!(payload["base"], "main");
+    }
+
+    fn authored<'a>(
+        branch: &'a str,
+        message: &'a str,
+        additions: Vec<(&str, &str)>,
+        deletions: Vec<&str>,
+    ) -> AuthoredCommit<'a> {
+        AuthoredCommit {
+            branch,
+            expected_head_oid: "deadbeef",
+            message,
+            additions: additions
+                .into_iter()
+                .map(|(path, contents)| crate::forge::FileAddition {
+                    path: path.to_string(),
+                    base64_contents: contents.to_string(),
+                })
+                .collect(),
+            deletions: deletions.into_iter().map(str::to_string).collect(),
+        }
+    }
+
+    #[test]
+    fn the_commit_input_carries_no_author_committer_or_signature() {
+        // GitHub only signs a bot's commit when the request has none of these,
+        // so their absence is the whole point rather than an omission.
+        let commit = authored("main", "chore(release): v1.1.0", vec![], vec![]);
+        let input = build_commit_input("owner/repo", &commit);
+
+        let rendered = input.to_string();
+        for forbidden in ["author", "committer", "signature"] {
+            assert!(
+                !rendered.contains(forbidden),
+                "`{forbidden}` in the input would cost us the verified mark: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_commit_input_targets_the_branch_and_pins_the_head() {
+        let commit = authored(
+            "ferrflow/release-main",
+            "chore(release): v1.1.0",
+            vec![],
+            vec![],
+        );
+        let input = build_commit_input("FerrLabs/FerrFlow", &commit);
+
+        assert_eq!(
+            input["branch"]["repositoryNameWithOwner"],
+            "FerrLabs/FerrFlow"
+        );
+        assert_eq!(input["branch"]["branchName"], "ferrflow/release-main");
+        assert_eq!(input["expectedHeadOid"], "deadbeef");
+    }
+
+    #[test]
+    fn additions_and_deletions_both_reach_the_payload() {
+        let commit = authored(
+            "main",
+            "chore(release): v1.1.0",
+            vec![("Cargo.toml", "dmVyc2lvbg==")],
+            vec!["old.txt"],
+        );
+        let input = build_commit_input("owner/repo", &commit);
+
+        assert_eq!(input["fileChanges"]["additions"][0]["path"], "Cargo.toml");
+        assert_eq!(
+            input["fileChanges"]["additions"][0]["contents"],
+            "dmVyc2lvbg=="
+        );
+        assert_eq!(input["fileChanges"]["deletions"][0]["path"], "old.txt");
+    }
+
+    #[test]
+    fn a_single_line_message_has_no_body() {
+        let commit = authored("main", "chore(release): v1.1.0", vec![], vec![]);
+        let input = build_commit_input("owner/repo", &commit);
+
+        assert_eq!(input["message"]["headline"], "chore(release): v1.1.0");
+        assert!(input["message"].get("body").is_none());
+    }
+
+    #[test]
+    fn a_message_body_is_split_off_the_headline() {
+        let commit = authored(
+            "main",
+            "chore(release): v1.1.0\n\n- app 1.1.0 (3 commits)\n- lib 2.0.0 (1 commit)",
+            vec![],
+            vec![],
+        );
+        let input = build_commit_input("owner/repo", &commit);
+
+        assert_eq!(input["message"]["headline"], "chore(release): v1.1.0");
+        assert_eq!(
+            input["message"]["body"],
+            "- app 1.1.0 (3 commits)\n- lib 2.0.0 (1 commit)"
+        );
+    }
+
+    #[test]
+    fn a_graphql_error_is_surfaced_rather_than_swallowed() {
+        let response = serde_json::json!({
+            "errors": [{ "message": "Expected branch head to be deadbeef" }]
+        });
+
+        assert_eq!(
+            graphql_error_message(&response).as_deref(),
+            Some("Expected branch head to be deadbeef")
+        );
+        assert!(graphql_error_message(&serde_json::json!({ "data": {} })).is_none());
     }
 
     #[test]

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -22,7 +22,47 @@ pub struct ReleaseResult {
     pub url: Option<String>,
 }
 
+/// A commit to be authored by the forge itself rather than by local git.
+///
+/// GitHub signs such a commit and marks it verified, but only when the request
+/// carries no custom author, committer or signature, so there is deliberately
+/// nowhere here to set one.
+pub struct AuthoredCommit<'a> {
+    pub branch: &'a str,
+    pub expected_head_oid: &'a str,
+    pub message: &'a str,
+    pub additions: Vec<FileAddition>,
+    pub deletions: Vec<String>,
+}
+
+pub struct FileAddition {
+    pub path: String,
+    pub base64_contents: String,
+}
+
 pub trait Forge: Send + Sync {
+    /// Whether this forge can author a commit itself and sign it.
+    ///
+    /// Only GitHub can, through `createCommitOnBranch`. Everywhere else the
+    /// release commit is built by local git, as it always has been.
+    fn authors_verified_commits(&self) -> bool {
+        false
+    }
+
+    /// Author `commit` on the forge, returning the new commit SHA.
+    fn create_commit_on_branch(&self, _commit: &AuthoredCommit<'_>) -> Result<String> {
+        Err(anyhow::anyhow!(
+            "this forge cannot author commits; use the git commit path"
+        ))
+    }
+
+    /// Point `branch` at `oid`, creating the branch when it does not exist.
+    fn set_branch(&self, _branch: &str, _oid: &str) -> Result<()> {
+        Err(anyhow::anyhow!(
+            "this forge cannot move branches; use the git push path"
+        ))
+    }
+
     fn create_release(
         &self,
         tag: &str,

--- a/src/monorepo/run/authored_commit.rs
+++ b/src/monorepo/run/authored_commit.rs
@@ -1,0 +1,116 @@
+use anyhow::{Context, Result};
+use base64::Engine;
+use std::path::Path;
+
+use crate::forge::{AuthoredCommit, FileAddition, Forge};
+use crate::git::Repository;
+
+pub(super) fn file_changes(
+    root: &Path,
+    files: &[&str],
+) -> Result<(Vec<FileAddition>, Vec<String>)> {
+    let mut additions = Vec::new();
+    let mut deletions = Vec::new();
+
+    for file in files {
+        let path = root.join(file);
+        if path.exists() {
+            let bytes = std::fs::read(&path).with_context(|| {
+                format!("Failed to read {} for the release commit", path.display())
+            })?;
+            additions.push(FileAddition {
+                path: to_forge_path(file),
+                base64_contents: base64::engine::general_purpose::STANDARD.encode(&bytes),
+            });
+        } else {
+            deletions.push(to_forge_path(file));
+        }
+    }
+
+    Ok((additions, deletions))
+}
+
+/// The API addresses files from the repository root with forward slashes,
+/// whatever the platform git handed us.
+fn to_forge_path(file: &str) -> String {
+    file.replace('\\', "/")
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn author_on_branch(
+    forge: &dyn Forge,
+    repo: &Repository,
+    root: &Path,
+    remote: &str,
+    branch: &str,
+    expected_head_oid: &str,
+    files: &[&str],
+    message: &str,
+) -> Result<String> {
+    let (additions, deletions) = file_changes(root, files)?;
+    let oid = forge.create_commit_on_branch(&AuthoredCommit {
+        branch,
+        expected_head_oid,
+        message,
+        additions,
+        deletions,
+    })?;
+
+    // The commit exists on the forge and not here. Everything downstream tags
+    // and pushes from the local repository, so without this the tag would land
+    // on the commit before the bump.
+    crate::git::reset_branch_to_remote(repo, remote, branch)?;
+    Ok(oid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_present_file_is_an_addition_and_a_missing_one_is_a_deletion() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("Cargo.toml"), "version = \"1.1.0\"").unwrap();
+
+        let (additions, deletions) = file_changes(dir.path(), &["Cargo.toml", "gone.txt"]).unwrap();
+
+        assert_eq!(additions.len(), 1);
+        assert_eq!(additions[0].path, "Cargo.toml");
+        assert_eq!(deletions, vec!["gone.txt".to_string()]);
+    }
+
+    #[test]
+    fn contents_are_base64_encoded_for_the_api() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("f.txt"), "hello").unwrap();
+
+        let (additions, _) = file_changes(dir.path(), &["f.txt"]).unwrap();
+
+        assert_eq!(additions[0].base64_contents, "aGVsbG8=");
+    }
+
+    #[test]
+    fn binary_contents_survive_the_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let bytes: Vec<u8> = (0u8..=255).collect();
+        std::fs::write(dir.path().join("blob.bin"), &bytes).unwrap();
+
+        let (additions, _) = file_changes(dir.path(), &["blob.bin"]).unwrap();
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(&additions[0].base64_contents)
+            .unwrap();
+
+        assert_eq!(decoded, bytes);
+    }
+
+    #[test]
+    fn nested_paths_are_sent_with_forward_slashes() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("crates/api")).unwrap();
+        std::fs::write(dir.path().join("crates/api/Cargo.toml"), "x").unwrap();
+
+        let (additions, _) = file_changes(dir.path(), &["crates/api/Cargo.toml"]).unwrap();
+
+        assert_eq!(additions[0].path, "crates/api/Cargo.toml");
+    }
+}

--- a/src/monorepo/run/execute.rs
+++ b/src/monorepo/run/execute.rs
@@ -184,6 +184,14 @@ fn release_branch_name(target_branch: &str) -> String {
     format!("ferrflow/release-{}", target_branch.replace('/', "-"))
 }
 
+fn authoring_forge(plan: &ReleasePlan<'_>) -> Option<Box<dyn crate::forge::Forge>> {
+    if !crate::bot_token::bot_mode_enabled() {
+        return None;
+    }
+    let forge = build_forge_instance(plan.repo, plan.config)?;
+    forge.authors_verified_commits().then_some(forge)
+}
+
 fn run_commit_or_pr(
     plan: &mut ReleasePlan<'_>,
     mode: ReleaseCommitMode,
@@ -209,6 +217,20 @@ fn run_commit_or_pr(
                 }
                 plan.shared_outputs
                     .push("✓ Committed release changes (per-package)".to_string());
+            } else if let Some(forge) = authoring_forge(plan) {
+                let head = plan.repo.head_id()?.to_string();
+                super::authored_commit::author_on_branch(
+                    forge.as_ref(),
+                    plan.repo,
+                    plan.root,
+                    &plan.config.workspace.remote,
+                    plan.target_branch,
+                    &head,
+                    file_refs,
+                    commit_msg,
+                )?;
+                plan.shared_outputs
+                    .push("✓ Committed release changes as ferrflow[bot] (verified)".to_string());
             } else {
                 create_commit(plan.repo, file_refs, commit_msg)?;
                 plan.shared_outputs
@@ -240,6 +262,7 @@ fn run_commit_or_pr(
                 ),
             }
 
+            let authored;
             if scope == ReleaseCommitScope::PerPackage && plan.tags_to_create.len() > 1 {
                 let commit_list: Vec<(Vec<&str>, String)> = plan
                     .tags_to_create
@@ -264,10 +287,33 @@ fn run_commit_or_pr(
                     .map(|(f, m)| (f.as_slice(), m.as_str()))
                     .collect();
                 create_branch_and_commits(plan.repo, &branch_name, &commit_refs)?;
+                authored = false;
+            } else if let Some(forge) = authoring_forge(plan) {
+                // The branch has to exist before the mutation can commit onto
+                // it, and it is recreated from the target branch on every run.
+                let head = plan.repo.head_id()?.to_string();
+                forge.set_branch(&branch_name, &head)?;
+                super::authored_commit::author_on_branch(
+                    forge.as_ref(),
+                    plan.repo,
+                    plan.root,
+                    remote,
+                    &branch_name,
+                    &head,
+                    file_refs,
+                    commit_msg,
+                )?;
+                // author_on_branch leaves the checkout on the release branch;
+                // the rest of the run expects the target branch.
+                crate::git::reset_branch_to_remote(plan.repo, remote, plan.target_branch)?;
+                authored = true;
             } else {
                 create_branch_and_commit(plan.repo, &branch_name, file_refs, commit_msg)?;
+                authored = false;
             }
-            force_push_branch(plan.repo, remote, &branch_name)?;
+            if !authored {
+                force_push_branch(plan.repo, remote, &branch_name)?;
+            }
             plan.shared_outputs
                 .push(format!("✓ Pushed branch {}", branch_name.cyan()));
 

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -22,6 +22,7 @@ use crate::versioning::truncate_version;
 use super::types::{CheckCommit, CheckPackage, CheckResult, RunOutput};
 use super::util::{auto_stage_new_files, collect_dirty_files};
 
+mod authored_commit;
 mod cascade;
 pub(super) mod checkpoint;
 mod commit_body;


### PR DESCRIPTION
Closes #921.

When `bot: true` is set and the forge is GitHub, the release commit is authored through `createCommitOnBranch` instead of by local git. GitHub signs such a commit and marks it verified, which is the only route available to a GitHub App: an App cannot register a GPG or SSH key.

Everywhere else, and without `bot: true`, nothing changes. The commit is built by local git exactly as before.

## Shape

`Forge` gains three methods, all defaulted, so the other four forges compile untouched:

- `authors_verified_commits()` returns false everywhere but GitHub
- `create_commit_on_branch(&AuthoredCommit)` performs the mutation
- `set_branch(branch, oid)` points a branch at a commit, needed because the mutation requires the branch to exist

`AuthoredCommit` deliberately has no author, committer or signature field. GitHub signs a bot's commit only when the request carries none of the three, so their absence is the contract rather than an omission, and a test asserts the rendered payload contains none of those words.

Both release modes are covered. In `commit` mode the commit is authored onto the target branch; in `pr` mode the release branch is first pointed at the target branch's head, then the commit is authored onto it.

## The part that would have gone wrong quietly

The commit exists on the forge and not in the local repository. Everything downstream, tagging especially, works from local refs. Without resynchronising, the tag would land on the commit before the bump, which is exactly the bug #934 was about. `author_on_branch` therefore resets the local branch to the remote through the existing `reset_branch_to_remote`, and `pr` mode additionally returns the checkout to the target branch afterwards.

## Dependencies

`base64` was added as a direct dependency. It was already in the tree through `ureq` at the same version, so `cargo tree` shows no new crate, only a second edge.

## Tests

Eleven new tests.

On the payload: that no author, committer or signature reaches the input; that the branch and `expectedHeadOid` are set; that additions and deletions both land; that a single-line message produces no body while a multi-line one splits headline from body; and that a GraphQL error is surfaced rather than swallowed.

On the file changes: a present file becomes an addition and a missing one a deletion, contents are base64 encoded, binary content survives the round trip for all 256 byte values, and nested paths are sent with forward slashes whatever the platform.

1207 bin and 921 lib tests passing, clippy clean, wasm surface builds.

Also verified by running a real release with no `FERRFLOW_BOT` set: output still reads "✓ Committed release changes", the tag lands on the release commit, and the push goes through git. The default path is untouched.

## What is not verified

The mutation itself has never been executed against GitHub. That needs an App installation on a real repository, which I cannot exercise from here. What is tested is everything up to the request body and everything after the response. The call in between is written from the documented schema and should be exercised on a throwaway repository before this is relied on.

Two known gaps, both called out in the README rather than left to be discovered:

- Annotated tags are still created and pushed by git, so they remain unverified. Only the commit is covered. Whether an API equivalent exists for tags is still an open question.
- The per-package commit scope in `commit` mode still uses the git path. Authoring several commits in sequence through the API needs each to pin the previous one's oid, which is worth doing separately rather than folding in here.

## Unrelated bug found while testing

A config file with no `workspace` block at all gets `remote: ""` instead of `"origin"`, so every push fails with `Remote '' has no URL`. `remote` carries `#[serde(default = "default_remote")]`, but when the whole `workspace` key is absent serde uses the derived `Default` for the struct, which gives an empty string. Reproduced on unmodified `main`, so it predates this change. Not touched here; happy to file it.
