### PR TITLE
fix(deps): upgrade gix to 0.87 to drop the yanked bisync crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,21 +131,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
-name = "bisync"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5020822f6d6f23196ccaf55e228db36f9de1cf788052b37992e17cbc96ec41a7"
-dependencies = [
- "bisync_macros",
-]
-
-[[package]]
-name = "bisync_macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d21f40d350a700f6aa107e45fb26448cf489d34794b2ba4522181dc9f1173af6"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.86.0"
+version = "0.87.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb3790fd8981cba7949f1ba924ef865d902df731627bc5998d14164063892fce"
+checksum = "fdefc1465d8631807deaf504dacdeff628b978de515653b47976ca7c28ab2a7a"
 dependencies = [
  "gix-actor",
  "gix-attributes",
@@ -806,12 +791,14 @@ dependencies = [
  "gix-hashtable",
  "gix-index",
  "gix-lock",
+ "gix-note",
  "gix-object",
  "gix-odb",
  "gix-pack",
  "gix-path",
  "gix-pathspec",
  "gix-protocol",
+ "gix-quote",
  "gix-ref",
  "gix-refspec",
  "gix-revision",
@@ -834,9 +821,9 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.41.2"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33f9308ad6fd35b2a865cbe4117ac61b2be59e4a9ef1621c7a9794f7c8e52c5b"
+checksum = "e37efa99929ac62f980fb1a7dcd09dea85b3aa6ead6ba0498362add3f4e698de"
 dependencies = [
  "bstr",
  "gix-date",
@@ -845,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31c593692ebdc1e38858d9a2b56f6a594c501e24a38971fe6685571f5a07be0"
+checksum = "76b83782ac69ae28921a6e8fbcf2e24069613f1518030b97ae622b079abffa54"
 dependencies = [
  "bstr",
  "gix-features",
@@ -862,27 +849,27 @@ dependencies = [
 
 [[package]]
 name = "gix-bitmap"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd1d118d0f5d88b96e6f6e13b566475fef4797ead4a02c26fed36c1375066f7"
+checksum = "f17013c7ef5cb95ebb4bf4978201e6a8a42ffea9d666fd5388f1b7e742307d80"
 dependencies = [
  "gix-error",
 ]
 
 [[package]]
 name = "gix-chunk"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a871e5cab12ba568845714473505deefffb3c04eb47f4708ce344cd459c1cc"
+checksum = "00e32f938b3745ac93d73bc7490b6a15a661b2fc81973bfe90e275cc53c908e1"
 dependencies = [
  "gix-error",
 ]
 
 [[package]]
 name = "gix-command"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00706d4fef135ef4b01680d5218c6ee40cda8baf697b864296cbc887d19118f6"
+checksum = "0d96b8e8423ce2665232bda1b682a62541f07ab801ffad69a034ef962bed3244"
 dependencies = [
  "bstr",
  "gix-path",
@@ -893,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2cd7f054ae2727223fe46dd39c012f066b12f532962d336d29ee193261787da"
+checksum = "6b93c9fb1f5be01bba54a7a3b7455d359efc68555539c75ef74b8021bb6db497"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -907,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "gix-config"
-version = "0.59.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "103d11bef95c467577ecfa8b7b86a22e65af3507b2c9bfa3809a4afbae7df301"
+checksum = "f973c28c0a4871a7926fc90c8377d4458fd6cbb19692f56582b4d2022313ae90"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -926,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "gix-config-value"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f813e312a3f7f327187823cd4c754a3e4d948c98907d11e8f37554a2b6b8059"
+checksum = "6f6af5321bfd3711a279d6b244d58532ba1cfabf9eb6374791f19929d8970082"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -939,9 +926,9 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.15.6"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e47b9e8cdc688296609b706428de570f88b1e0eed7156dde7b4a89d26fa4567"
+checksum = "e63d9aa18f29facd571c8953e66224ee0075b9e16622024794555ed4acceea85"
 dependencies = [
  "bstr",
  "gix-error",
@@ -951,9 +938,9 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.66.0"
+version = "0.67.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee7d89a3c507491cdfc57a1d1e0e300214720b4f7709ebc253e422f99822bfc"
+checksum = "1b1689ff5ddeee4acfb2a43e875a1072a76d208624b15a9065c938b39cb0da2a"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -963,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "gix-discover"
-version = "0.54.0"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f517766fa1101dfe2606c1a19a8ffa699099030995a9194445446dfe261bdf"
+checksum = "ec32a30ec2934735599c2545f30067e80bd255fd3454b52a5d59bc02b52874a3"
 dependencies = [
  "bstr",
  "dunce",
@@ -978,18 +965,18 @@ dependencies = [
 
 [[package]]
 name = "gix-error"
-version = "0.2.5"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9292309fd944e71b2a3c96d3c03a6feb8852db646febdde7cbb9f79cb5f329"
+checksum = "e73b2794a6a746953c24d4ed51e4d408b83d8d599ed4e5c39a47736d75687cf0"
 dependencies = [
  "bstr",
 ]
 
 [[package]]
 name = "gix-features"
-version = "0.49.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20aa09e83a48dc02c5f5f08578aa79d3ab1bab4618b8c362f88684645a02bdcc"
+checksum = "39c0e59d9d253dcccc38c3a46b91bfb9b46bd63eed54fe1a719e12194884d52a"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1006,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "gix-filter"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e7b5dbf524d97e839f642930c76d7f011c0791e7d11d8148989ac5af7c76aa8"
+checksum = "9c30b28d957e2e6f1e1bbfbfd26b8e0bb0aab68d8a5e730fb4fd3049943575e3"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -1027,9 +1014,9 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865cf13fcaf5455220546cb9607c416bd1be9a6caafd143655a362fdeab64e80"
+checksum = "ebcfa9fd253f25350a3b21b3dd74034a446098e373c6123d4cee3519894f12ef"
 dependencies = [
  "bstr",
  "gix-features",
@@ -1040,9 +1027,9 @@ dependencies = [
 
 [[package]]
 name = "gix-glob"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421e92a711554fa5827d1b0599d3389acdd0f6729e97a8c5a57d79af1e50bf36"
+checksum = "b417cf515fd8c91468b578071f76d6cba716f8a1eccd853906bff4908b2c1413"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -1052,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hash"
-version = "0.26.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13adaa73415fd6c902310923f68d0b98e8cecf14b33ea58c02cc387cee56f54e"
+checksum = "380b9c423a54f0821064b954b5a5ab25c660812f6a91da03c3f1cb4b10762aa5"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -1075,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "gix-ignore"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cff8e8aa125e39377456073e63df3334d9e5741372ddcc226198015076dda2"
+checksum = "65859a2f7de5e159d4344a5486ebf53b6bac22d5ec6afa836e47c10ae88a7f0f"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -1088,9 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "gix-index"
-version = "0.54.0"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5009c4e7e9f9b4cfaaab1153e49133eb04d79c015b5702d6c3d2ab94271a89c6"
+checksum = "632e16cb48b0e88a747e106924cb2765194105d8070a7a961b0d080ed806c632"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -1126,10 +1113,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-object"
-version = "0.63.0"
+name = "gix-macros"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e48c235e7f886eb819fc878af75be889333dd3c38bee02ed7af48ae2cf596c4"
+checksum = "d3836b4b051393464a753c5a08fe19c7ce0d8b77574a92bd558972941d4553cb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "gix-note"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af6bbdb3f3c62b4920407c479af1cc0beb27fd75a762782d48baed53d330958"
+dependencies = [
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.64.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56fef799ca40cdeab4de5a3e74a696d8fa9b9c6264592646bf022e026f13ce2c"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -1146,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "gix-odb"
-version = "0.83.0"
+version = "0.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd494ffb5037e62b8220109e894d2861ff2150a2cacbfccdba57ae1ebab2b96"
+checksum = "cf45d195b71cb6363886e7b466821bf4dffd7aba1b6b814ff75488e0061d72a7"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -1168,11 +1178,12 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.73.0"
+version = "0.74.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d5446127b269706e85998065267ddd2ccc3550179da6780b22fe496175ccb20"
+checksum = "3d199d515cbdcf05f531f3859be9771fc12acac7b7fe0f5b581b2c1ab1c3a61e"
 dependencies = [
  "clru",
+ "crossbeam-deque",
  "gix-chunk",
  "gix-error",
  "gix-features",
@@ -1189,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline"
-version = "0.22.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3766025c72319c4accdd854a18e6f0dd176c8eb0f3bc8a60a7765be2b50cabf2"
+checksum = "792bd92bea390087e6223b18d4d023decc36467de31e6b066b69b94beea1b9e2"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -1201,9 +1212,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed3e8d7a82e886e17a72e03d4ba0c13db6f2219b6cd4e2900b4cae426ec20c9"
+checksum = "2b075e730586bba7341304d6fc1b4efc1d10cf64532622521c0e07f30e661046"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -1213,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "gix-pathspec"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f6fa5f8007f008187c3f60b4373209ca83d1cc947f35ede03e16cd15a4d137"
+checksum = "c92e44c63ba53bb55aa88ee48847664beae9446417621582fb14dfc69b2f8c72"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -1228,15 +1239,15 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.64.0"
+version = "0.65.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dede40e89c1e90f548415f50636bb051f6d9c60f68b8b710bc07825722d19588"
+checksum = "68878c37ae168b474c762d70adc8a8e0f9323ed0d80444a672e2eb561fa16691"
 dependencies = [
- "bisync",
  "bstr",
  "gix-date",
  "gix-features",
  "gix-hash",
+ "gix-macros",
  "gix-ref",
  "gix-shallow",
  "gix-transport",
@@ -1247,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "gix-quote"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e541fc33cc2b783b7979040d445a0c86a2eca747c8faea4ca84230d06ae6ef"
+checksum = "f74795eb76eab8313063849f9cbd2bbcdc6e4692f71c1d7d0244ab11cd777329"
 dependencies = [
  "bstr",
  "gix-error",
@@ -1258,9 +1269,9 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.66.0"
+version = "0.67.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb0c90a8f6202ceaaa22996cbf837c943ccb2d8af9ff3490f0758305e6b7883"
+checksum = "8328387e7ab354e1dc3afb63e6b4d1866f82d7ce035222bc9d5baaf36bc88020"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -1278,15 +1289,12 @@ dependencies = [
 
 [[package]]
 name = "gix-refspec"
-version = "0.44.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7406282cc0259b51f6aee299ca3d31279a020530363152a2e6c96e8a7f7bbc83"
+checksum = "7de280d46e8fd9e4d3e7e2ab4276b965e377ba68b2b9a8fce56371015e8bb059"
 dependencies = [
  "bstr",
- "gix-error",
- "gix-glob",
  "gix-hash",
- "gix-revision",
  "gix-validate",
  "smallvec",
  "thiserror",
@@ -1294,9 +1302,9 @@ dependencies = [
 
 [[package]]
 name = "gix-revision"
-version = "0.48.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55e09d4a1ecf2beecc8c09cafcad37979e805b31f588b0e957e191df5783681"
+checksum = "4577b864c3e134697e91564553e43230c2e401bb1bcc51cfa998edca21c95078"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -1313,9 +1321,9 @@ dependencies = [
 
 [[package]]
 name = "gix-revwalk"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c113c0a53294dc6280ffc06cbcc4f50f820397e97d6a00b429a44b8db26e29"
+checksum = "248823eefe405e2c0754b74f6f43ab6faab68670cdbf2d6e114cb0471f766450"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -1372,9 +1380,9 @@ checksum = "be3eb81d9dc914335923e50d52829c551feefd6a72d176c4130c546b67a60814"
 
 [[package]]
 name = "gix-transport"
-version = "0.58.0"
+version = "0.59.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c1bcf30081eb8ab04540a5795c67a2fcb22cb2e976e8b1a4ea657b1ed61469"
+checksum = "b1295b6ada647b5b4ac6eb123d95a82ee80aef11a7d9db6ea9cb38dcbd411362"
 dependencies = [
  "bstr",
  "gix-command",
@@ -1389,9 +1397,9 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.60.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008c5cd879e46e86b5c2469e633611978b18775d53d05668d691bc13088bd409"
+checksum = "9af3503668739f4de5dba57fe15cfd9adc443b08bcbbf195e5de16b648872245"
 dependencies = [
  "bitflags 2.13.1",
  "gix-commitgraph",
@@ -1406,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "gix-url"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d10e53b8eae21ee601687f47bbbd6cb2ed7162cb4c1cafdd422fb7ec64cbee"
+checksum = "5bda80ccb4bc81fb9fb07a975916eb0c7a889bcbcb0c8a239c3f82a9cc2abdda"
 dependencies = [
  "bstr",
  "gix-path",
@@ -1419,9 +1427,9 @@ dependencies = [
 
 [[package]]
 name = "gix-utils"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1795bd2a970ca8b2185318c2abb97d955c71992f1cf28de73ad3b593a9f3ce8"
+checksum = "0da1c46491b49458a446cc76f0085860f8164c2290742e0aa8c653ce67240a97"
 dependencies = [
  "bstr",
  "fastrand",
@@ -1431,18 +1439,18 @@ dependencies = [
 
 [[package]]
 name = "gix-validate"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a034e84d1e04e1b1f20f51f12491da230b6ac8b925d0c8e1b89bcd87a7c5ccc"
+checksum = "4dae8780f63ed8a803b8bdabbd7aa5f5c5d74592c8b50eed875c1bb4f6545a6a"
 dependencies = [
  "bstr",
 ]
 
 [[package]]
 name = "gix-worktree"
-version = "0.55.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31eb8e675122e83585e461fe28f68ff8c5ed55b49017b697e7e76423ff973424"
+checksum = "3ed36b627476e2072c129900a17c977a38052b5497e27308159bc881fbf4eecf"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -1458,9 +1466,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-stream"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b088c8724e7be120c4798dd86925cf05332c9d356a463542578600c50c7a549"
+checksum = "de5ec0ccbab39c9994656ea031ded8ffd90b370a3cc8e360fbe3c4ebe7c64964"
 dependencies = [
  "gix-attributes",
  "gix-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,9 +51,9 @@ glob-match = "0.2"
 clap = { version = "4", features = ["derive", "env"], optional = true }
 clap_complete = { version = "4", optional = true }
 colored = { version = "3", optional = true }
-gix = { version = "0.86", default-features = false, features = ["sha1", "max-performance-safe", "revision"], optional = true }
-gix-traverse = { version = "0.60", optional = true }
-gix-diff = { version = "0.66", default-features = false, features = ["sha1"], optional = true }
+gix = { version = "0.87", default-features = false, features = ["sha1", "max-performance-safe", "revision"], optional = true }
+gix-traverse = { version = "0.61", optional = true }
+gix-diff = { version = "0.67", default-features = false, features = ["sha1"], optional = true }
 ureq = { version = "3", features = ["json"], optional = true }
 # YAML source configs for `ferrflow migrate` (cli-only). Maintained serde_yaml fork.
 serde_norway = { version = "0.9", optional = true }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -53,7 +53,7 @@ end = "2027-07-17"
 
 [[trusted.base64]]
 criteria = "safe-to-deploy"
-user-id = 5563
+user-id = 5563 # Marshall Pierce (marshallpierce)
 start = "2019-10-25"
 end = "2027-08-22"
 
@@ -249,6 +249,12 @@ user-id = 980 # Sebastian Thiel (Byron)
 start = "2023-02-17"
 end = "2027-07-17"
 
+[[trusted.gix-ignore]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-04-26"
+end = "2027-08-27"
+
 [[trusted.gix-index]]
 criteria = "safe-to-deploy"
 user-id = 980 # Sebastian Thiel (Byron)
@@ -260,6 +266,18 @@ criteria = "safe-to-deploy"
 user-id = 980 # Sebastian Thiel (Byron)
 start = "2023-02-17"
 end = "2027-07-17"
+
+[[trusted.gix-macros]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-09-08"
+end = "2027-08-27"
+
+[[trusted.gix-note]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-08-17"
+end = "2027-08-27"
 
 [[trusted.gix-object]]
 criteria = "safe-to-deploy"
@@ -290,6 +308,12 @@ criteria = "safe-to-deploy"
 user-id = 980 # Sebastian Thiel (Byron)
 start = "2023-02-17"
 end = "2027-07-17"
+
+[[trusted.gix-pathspec]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-08-22"
+end = "2027-08-27"
 
 [[trusted.gix-protocol]]
 criteria = "safe-to-deploy"
@@ -380,6 +404,12 @@ criteria = "safe-to-deploy"
 user-id = 980 # Sebastian Thiel (Byron)
 start = "2023-02-17"
 end = "2027-07-17"
+
+[[trusted.gix-worktree]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-02-17"
+end = "2027-08-27"
 
 [[trusted.gix-worktree-stream]]
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -199,18 +199,6 @@ criteria = "safe-to-deploy"
 version = "0.4.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.gix-ignore]]
-version = "0.22.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-pathspec]]
-version = "0.19.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.gix-worktree]]
-version = "0.55.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.gix-zlib]]
 version = "0.1.0"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -57,6 +57,13 @@ user-id = 539
 user-login = "cuviper"
 user-name = "Josh Stone"
 
+[[publisher.base64]]
+version = "0.23.1"
+when = "2026-08-04"
+user-id = 5563
+user-login = "marshallpierce"
+user-name = "Marshall Pierce"
+
 [[publisher.bstr]]
 version = "1.13.0"
 when = "2026-07-14"
@@ -149,127 +156,127 @@ user-login = "cuviper"
 user-name = "Josh Stone"
 
 [[publisher.gix]]
-version = "0.86.0"
-when = "2026-07-23"
+version = "0.87.1"
+when = "2026-08-24"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-actor]]
-version = "0.41.2"
-when = "2026-07-23"
+version = "0.42.0"
+when = "2026-08-22"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-attributes]]
-version = "0.34.0"
-when = "2026-07-23"
+version = "0.35.0"
+when = "2026-08-22"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-bitmap]]
-version = "0.3.3"
-when = "2026-07-23"
+version = "0.4.0"
+when = "2026-08-22"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-chunk]]
-version = "0.7.3"
-when = "2026-07-23"
+version = "0.8.0"
+when = "2026-08-22"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-command]]
-version = "0.9.1"
-when = "2026-05-26"
+version = "0.10.0"
+when = "2026-08-22"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-commitgraph]]
-version = "0.38.0"
-when = "2026-07-23"
+version = "0.39.0"
+when = "2026-08-22"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-config]]
-version = "0.59.0"
-when = "2026-07-23"
+version = "0.60.0"
+when = "2026-08-22"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-config-value]]
-version = "0.19.0"
-when = "2026-07-23"
+version = "0.19.1"
+when = "2026-08-03"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-date]]
-version = "0.15.6"
-when = "2026-07-15"
+version = "0.16.0"
+when = "2026-08-22"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-diff]]
-version = "0.66.0"
-when = "2026-07-23"
+version = "0.67.1"
+when = "2026-08-24"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-discover]]
-version = "0.54.0"
-when = "2026-07-23"
+version = "0.55.0"
+when = "2026-08-22"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-error]]
-version = "0.2.5"
-when = "2026-07-15"
+version = "0.3.1"
+when = "2026-08-23"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-features]]
-version = "0.49.0"
-when = "2026-07-23"
+version = "0.49.1"
+when = "2026-08-22"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-filter]]
-version = "0.33.0"
-when = "2026-07-23"
+version = "0.34.0"
+when = "2026-08-22"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-fs]]
-version = "0.22.0"
-when = "2026-07-23"
+version = "0.22.1"
+when = "2026-08-22"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-glob]]
-version = "0.27.0"
-when = "2026-07-23"
+version = "0.27.1"
+when = "2026-08-22"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-hash]]
-version = "0.26.0"
-when = "2026-07-23"
+version = "0.26.2"
+when = "2026-08-23"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
@@ -281,9 +288,16 @@ user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
+[[publisher.gix-ignore]]
+version = "0.22.1"
+when = "2026-08-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
 [[publisher.gix-index]]
-version = "0.54.0"
-when = "2026-07-23"
+version = "0.55.0"
+when = "2026-08-22"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
@@ -295,79 +309,100 @@ user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
+[[publisher.gix-macros]]
+version = "0.1.6"
+when = "2026-08-24"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-note]]
+version = "0.1.1"
+when = "2026-08-24"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
 [[publisher.gix-object]]
-version = "0.63.0"
-when = "2026-07-23"
+version = "0.64.1"
+when = "2026-08-23"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-odb]]
-version = "0.83.0"
-when = "2026-07-23"
+version = "0.84.0"
+when = "2026-08-22"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-pack]]
-version = "0.73.0"
-when = "2026-07-23"
+version = "0.74.2"
+when = "2026-08-24"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-packetline]]
-version = "0.22.0"
-when = "2026-07-23"
+version = "0.22.2"
+when = "2026-08-24"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-path]]
-version = "0.12.3"
-when = "2026-07-23"
+version = "0.12.5"
+when = "2026-08-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-pathspec]]
+version = "0.20.0"
+when = "2026-08-22"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-protocol]]
-version = "0.64.0"
-when = "2026-07-23"
+version = "0.65.1"
+when = "2026-08-24"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-quote]]
-version = "0.7.2"
-when = "2026-05-26"
+version = "0.8.0"
+when = "2026-08-22"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-ref]]
-version = "0.66.0"
-when = "2026-07-23"
+version = "0.67.1"
+when = "2026-08-23"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-refspec]]
-version = "0.44.0"
-when = "2026-07-23"
+version = "0.45.1"
+when = "2026-08-24"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-revision]]
-version = "0.48.0"
-when = "2026-07-23"
+version = "0.49.1"
+when = "2026-08-24"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-revwalk]]
-version = "0.34.0"
-when = "2026-07-23"
+version = "0.35.0"
+when = "2026-08-22"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
@@ -401,43 +436,50 @@ user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-transport]]
-version = "0.58.0"
-when = "2026-07-23"
+version = "0.59.1"
+when = "2026-08-24"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-traverse]]
-version = "0.60.0"
-when = "2026-07-23"
+version = "0.61.0"
+when = "2026-08-22"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-url]]
-version = "0.37.0"
-when = "2026-07-23"
+version = "0.38.0"
+when = "2026-08-22"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-utils]]
-version = "0.3.5"
-when = "2026-07-23"
+version = "0.3.6"
+when = "2026-08-22"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-validate]]
-version = "0.11.3"
-when = "2026-07-23"
+version = "0.11.4"
+when = "2026-08-22"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.gix-worktree]]
+version = "0.56.0"
+when = "2026-08-22"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
 
 [[publisher.gix-worktree-stream]]
-version = "0.35.0"
-when = "2026-07-23"
+version = "0.36.1"
+when = "2026-08-24"
 user-id = 980
 user-login = "Byron"
 user-name = "Sebastian Thiel"
@@ -771,15 +813,15 @@ user-login = "Manishearth"
 user-name = "Manish Goregaokar"
 
 [[publisher.ureq]]
-version = "3.3.0"
-when = "2026-03-21"
+version = "3.4.0"
+when = "2026-08-08"
 user-id = 5441
 user-login = "algesten"
 user-name = "Martin Algesten"
 
 [[publisher.ureq-proto]]
-version = "0.6.0"
-when = "2026-03-21"
+version = "0.6.1"
+when = "2026-08-08"
 user-id = 5441
 user-login = "algesten"
 user-name = "Martin Algesten"
@@ -1080,12 +1122,6 @@ This is a trivial crate which only contains a singular macro definition which is
 intended to multiplex across the internal representation of a tinyvec,
 presumably. This trivially doesn't contain anything bad.
 """
-
-[[audits.google.audits.base64]]
-who = "amarjotgill <amarjotgill@google.com>"
-criteria = "safe-to-deploy"
-version = "0.22.1"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.bitflags]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"


### PR DESCRIPTION
`Cargo Security` is failing on every pull request, and `Cargo Security` is a required check, so nothing can merge:

```
error: 1 denied warning found!
Crate:     bisync
Version:   0.3.0
Warning:   yanked
```

The crate's author yanked the whole 0.3 line on 2026-08-24. Both versions are gone:

```
$ cargo update -p bisync
error: failed to select a version for the requirement `bisync = "^0.3.0"`
  version 0.3.0 is yanked
  version 0.3.1 is yanked
```

So a lockfile bump cannot fix it. `bisync` arrives through `gix-protocol 0.64.0`, which requires `^0.3.0`, and nothing satisfies that any more.

## Fix

Upgrade `gix` from 0.86 to 0.87, whose `gix-protocol` no longer depends on `bisync` at all. `bisync` is now absent from the lockfile entirely rather than merely updated.

`gix-traverse` and `gix-diff` are pinned directly as well, and the upgrade pulled newer copies of both through `gix`, leaving two versions of each in the tree. Both direct pins are moved to match (0.60 to 0.61, 0.66 to 0.67) so the tree carries one version of each rather than tripping the duplicate-version ban.

The lockfile change is scoped to what the new requirements force. A plain `cargo update` would have refreshed 184 versions and mixed a general dependency bump into a targeted CI unblock.

## Supply chain

`cargo vet` needed five gix-family crates covered: `gix-ignore`, `gix-macros`, `gix-note`, `gix-pathspec` and `gix-worktree`. All are published by Sebastian Thiel, who this project already trusts through 42 existing `[[trusted.gix*]]` entries pointing at the same user id, so `cargo vet trust` extends an established decision rather than making a new one.

```
Vetting Succeeded (175 fully audited, 1 partially audited, 139 exempted)
```

## Verified

No API breakage: `cargo clippy --all-targets` is clean, 1197 bin and 915 lib tests pass, and the no-cli wasm surface still builds.

`cargo audit` and `cargo deny` are not installed locally, so the check that was failing is confirmed only by `bisync` being gone from the lockfile. CI is the real verdict here.

Blocks #941 and every other open pull request until it lands.
