### PR TITLE
fix(config): keep workspace defaults when the workspace block is omitted

### DIFF
--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1788,3 +1788,56 @@ fn publishers_unknown_kind_is_rejected() {
         "an unknown publisher kind must not silently parse"
     );
 }
+
+#[test]
+fn omitting_the_workspace_block_keeps_every_default() {
+    // `Config` carries #[serde(default)] on `workspace`, so an absent block goes
+    // through WorkspaceConfig::default() while an empty one goes through the
+    // per-field serde defaults. The two must not disagree: when they did, a
+    // config with no workspace block got remote: "" and failed every push.
+    let present: Config = serde_json::from_str(r#"{"workspace":{}}"#).unwrap();
+    let absent: Config = serde_json::from_str("{}").unwrap();
+
+    assert_eq!(absent.workspace.remote, present.workspace.remote);
+    assert_eq!(absent.workspace.branch, present.workspace.branch);
+    assert_eq!(
+        absent.workspace.anonymous_telemetry,
+        present.workspace.anonymous_telemetry
+    );
+    assert_eq!(
+        absent.workspace.auto_merge_releases,
+        present.workspace.auto_merge_releases
+    );
+}
+
+#[test]
+fn a_config_without_a_workspace_block_can_still_push() {
+    let config: Config =
+        serde_json::from_str(r#"{"package":[{"name":"app","path":".","versionedFiles":[]}]}"#)
+            .unwrap();
+
+    assert_eq!(
+        config.workspace.remote, "origin",
+        "an empty remote makes every push fail with `Remote '' has no URL`"
+    );
+    assert!(
+        !config.workspace.branch.is_empty(),
+        "an empty target branch silently feeds tag lookup and the release branch name"
+    );
+    assert!(
+        config.workspace.auto_merge_releases,
+        "auto-merge is documented as on by default"
+    );
+}
+
+#[test]
+fn the_derived_and_deserialized_workspace_defaults_agree_field_by_field() {
+    // Serialising both sides catches a new field whose custom serde default was
+    // added without updating the hand-written Default, which is the drift this
+    // whole impl exists to prevent.
+    let from_default = serde_json::to_value(WorkspaceConfig::default()).unwrap();
+    let from_empty: WorkspaceConfig = serde_json::from_str("{}").unwrap();
+    let from_empty = serde_json::to_value(from_empty).unwrap();
+
+    assert_eq!(from_default, from_empty);
+}

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -8,7 +8,7 @@ use super::types::{
 };
 use std::collections::BTreeMap;
 
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct WorkspaceConfig {
     #[serde(default = "default_remote")]
     pub remote: String,
@@ -68,6 +68,47 @@ pub struct WorkspaceConfig {
     pub linked: Vec<Vec<String>>,
     #[serde(default)]
     pub fixed: Vec<Vec<String>>,
+}
+
+/// Written by hand rather than derived, because `Config` carries
+/// `#[serde(default)]` on its `workspace` field: an absent `workspace` block
+/// takes this path instead of the per-field serde defaults. Deriving it gave
+/// `remote: ""` and `branch: ""`, so a config with no workspace block failed
+/// every push. Same shape as `CommitFormats` below.
+impl Default for WorkspaceConfig {
+    fn default() -> Self {
+        Self {
+            remote: default_remote(),
+            branch: default_branch(),
+            anonymous_telemetry: default_telemetry(),
+            versioning: Default::default(),
+            tag_template: Default::default(),
+            version_template: Default::default(),
+            recover_missed_releases: Default::default(),
+            release_commit_mode: Default::default(),
+            release_commit_scope: Default::default(),
+            release_commit_body: Default::default(),
+            commit_formats: Default::default(),
+            auto_merge_releases: default_auto_merge(),
+            skip_ci: Default::default(),
+            commit_skip_markers: Default::default(),
+            floating_tags: Default::default(),
+            latest_tag: Default::default(),
+            orphaned_tag_strategy: Default::default(),
+            version_source: Default::default(),
+            forge: Default::default(),
+            hooks: Default::default(),
+            branches: Default::default(),
+            registries: Default::default(),
+            defer_publish: Default::default(),
+            changelog: Default::default(),
+            manifest_file: Default::default(),
+            update_lockfiles: Default::default(),
+            update_dependents: Default::default(),
+            linked: Default::default(),
+            fixed: Default::default(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]


### PR DESCRIPTION
Closes #942.

A config file that omits the `workspace` block entirely lost every workspace default, most visibly failing the release at the push:

```
error[E2004]: Failed to push branch ''
  Remote '' has no URL
```

`Config` carries `#[serde(default)]` on `workspace`, so an absent key builds `WorkspaceConfig::default()` from the derived `Default`, while the per-field `#[serde(default = "...")]` attributes only run when the table is present. The two disagreed and the derived one won in the case nobody tested.

Before:

```
with block:    remote="origin" branch="main" auto_merge=true telemetry=true
without block: remote=""       branch=""     auto_merge=false telemetry=false
```

After, both paths agree.

## Fix

`WorkspaceConfig` now has a hand-written `Default` that calls the same `default_*` functions the serde attributes use, instead of deriving one. `CommitFormats` in the same module already does exactly this, so the fix follows the pattern the codebase had established rather than inventing one.

`branch` matters as much as `remote` and is quieter about it: `default_branch()` detects the branch from `origin/HEAD` and falls back to `main`, so the derived default replaced a real detection with an empty string that then fed tag lookup and the release branch name without complaint. `auto_merge_releases` silently flipped a documented default off.

## Tests

Three, in `src/config/tests.rs`:

- deserialising `{}` and `{"workspace":{}}` produce the same values for all four fields with custom defaults
- a realistic minimal config (packages only, no workspace block) has a usable `remote`, a non-empty `branch` and auto-merge on, each assertion naming the failure it prevents
- serialising `WorkspaceConfig::default()` and a `WorkspaceConfig` deserialised from `{}` produces identical JSON

The third is the one that earns its place long-term: it compares whole structures rather than the four fields I happened to know about, so a future field added with a custom serde default and forgotten in the hand-written `Default` fails immediately. That drift is the actual bug, not the four values.

Verified all three fail against the derived `Default`:

```
a_config_without_a_workspace_block_can_still_push ... FAILED
  assertion failed: an empty remote makes every push fail with `Remote '' has no URL`
omitting_the_workspace_block_keeps_every_default ... FAILED
the_derived_and_deserialized_workspace_defaults_agree_field_by_field ... FAILED
```

1210 bin and 924 lib tests passing over three consecutive runs, clippy clean, wasm surface builds.

## Scope

I checked the other types carrying custom serde defaults. `CommitFormats` was already correct. The remaining ones in `types.rs` sit inside `PublisherConfig` enum variants, which arrive through a `Vec` and never take a struct-level `#[serde(default)]` fallback, so they are not exposed to this. `WorkspaceConfig` was the only broken case.
