### PR TITLE
feat(cli): add ferrflow rollback to undo a partially-failed release

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,9 +519,10 @@ subset; with none, it rolls back everything the run touched.
 
 Three things it deliberately refuses to do.
 
-It never deletes a tag that has moved. Each tag is recorded with the commit it pointed at, and one
-that no longer matches is reported and skipped, because a tag someone else recreated in the meantime
-is not this run's to remove.
+It never deletes a tag that has moved. Each tag is recorded with the commit it pointed at, and the
+remote is queried at rollback time to check it still points there. One that no longer matches, or
+that this checkout cannot resolve on the remote at all, is reported and skipped: a tag someone else
+recreated in the meantime is not this run's to remove.
 
 It stops on a package already published to a registry that cannot be unpublished. crates.io and PyPI
 keep every version forever, and npm refuses to republish an unpublished one, so deleting the tag

--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ ferrflow release --exclude web --exclude docs
 # Pre-release
 ferrflow release --channel beta
 
+# Undo a release that failed partway
+ferrflow rollback                    # prints the plan, changes nothing
+ferrflow rollback --yes              # applies it
+ferrflow rollback --yes api web      # only these packages
+
 # Scaffold a config file
 ferrflow init
 
@@ -498,6 +503,38 @@ cannot cascade into a further bump. Squash merges and merge commits both work.
 
 A package declared without `versionedFiles` has no version to read, so it is not finalised this way.
 Use `commit` mode for tag-only packages.
+
+## Rollback
+
+A release that fails partway leaves tags pushed, forge releases created and a release commit on the
+branch. `ferrflow rollback` undoes exactly what that run did, reading the checkpoint it left behind
+rather than guessing from the log.
+
+```bash
+ferrflow rollback
+```
+
+It prints the plan and changes nothing. Add `--yes` to apply it. Name packages to narrow it to a
+subset; with none, it rolls back everything the run touched.
+
+Three things it deliberately refuses to do.
+
+It never deletes a tag that has moved. Each tag is recorded with the commit it pointed at, and one
+that no longer matches is reported and skipped, because a tag someone else recreated in the meantime
+is not this run's to remove.
+
+It stops on a package already published to a registry that cannot be unpublished. crates.io and PyPI
+keep every version forever, and npm refuses to republish an unpublished one, so deleting the tag
+would leave a version anyone can install with nothing pointing at it. The right answer there is a new
+patch version, and rollback says so instead of doing half the job. Docker tags, Helm charts, release
+assets and webhooks are replaceable, so they do not block anything.
+
+It reverts the release commit only on a whole-run rollback with nothing blocked. That commit carries
+every package's version bump, so reverting it while one package stays released would silently undo
+that package's version too.
+
+The revert is left uncommitted to the remote on purpose. Rollback has just deleted remote refs, and
+forcing a branch update on top of that is a decision worth taking with the branch in front of you.
 
 ## Floating Tags
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -135,6 +135,14 @@ pub enum Commands {
         #[command(subcommand)]
         command: CacheCommand,
     },
+    /// Undo a partially-failed release, using the checkpoint that run left behind.
+    Rollback {
+        /// Packages to roll back. Defaults to everything the failed run touched.
+        packages: Vec<String>,
+        /// Apply the plan. Without it, the plan is printed and nothing changes.
+        #[arg(long)]
+        yes: bool,
+    },
     SyncManifest,
     Migrate {
         #[arg(long, value_enum)]
@@ -205,6 +213,7 @@ impl Commands {
             Commands::Validate { .. } => "validate",
             Commands::Completions { .. } => "completions",
             Commands::Cache { .. } => "cache",
+            Commands::Rollback { .. } => "rollback",
             Commands::SyncManifest => "sync-manifest",
             Commands::Migrate { .. } => "migrate",
             Commands::Doctor { .. } => "doctor",
@@ -324,6 +333,9 @@ impl Cli {
             Commands::Cache { command } => match command {
                 CacheCommand::Clear => crate::cache::clear_cwd(),
             },
+            Commands::Rollback { packages, yes } => {
+                crate::rollback::run(&packages, yes, self.config.as_deref())
+            }
             Commands::SyncManifest => crate::manifest::sync_cwd(self.config.as_deref()),
             Commands::Migrate { from } => crate::config::migrate(from.map(Into::into)),
             Commands::Doctor { format, online } => {

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -277,9 +277,6 @@ fn default_helm_chart_path() -> String {
 }
 
 impl PublisherConfig {
-    /// Short human-friendly name (`"cargo"`, `"docker"`, …) for log
-    /// lines, dry-run output, and step summaries. Stable enough to be
-    /// pattern-matched in CI scripts.
     /// Whether a successful publish through this publisher cannot be undone.
     ///
     /// crates.io never removes a version (yanking hides it, the artefact stays),
@@ -296,6 +293,9 @@ impl PublisherConfig {
         )
     }
 
+    /// Short human-friendly name (`"cargo"`, `"docker"`, …) for log
+    /// lines, dry-run output, and step summaries. Stable enough to be
+    /// pattern-matched in CI scripts.
     pub fn kind_name(&self) -> &'static str {
         match self {
             PublisherConfig::Cargo { .. } => "cargo",

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -280,6 +280,22 @@ impl PublisherConfig {
     /// Short human-friendly name (`"cargo"`, `"docker"`, …) for log
     /// lines, dry-run output, and step summaries. Stable enough to be
     /// pattern-matched in CI scripts.
+    /// Whether a successful publish through this publisher cannot be undone.
+    ///
+    /// crates.io never removes a version (yanking hides it, the artefact stays),
+    /// PyPI is the same, and npm refuses to republish an unpublished version.
+    /// Rolling a release back past one of these would delete the tag for a
+    /// version anyone can still install, so `ferrflow rollback` stops instead.
+    /// Docker tags, Helm charts, release assets and webhooks are all replaceable.
+    pub fn is_immutable_publish(&self) -> bool {
+        matches!(
+            self,
+            PublisherConfig::Cargo { .. }
+                | PublisherConfig::Npm { .. }
+                | PublisherConfig::Pypi { .. }
+        )
+    }
+
     pub fn kind_name(&self) -> &'static str {
         match self {
             PublisherConfig::Cargo { .. } => "cargo",

--- a/src/error_code.rs
+++ b/src/error_code.rs
@@ -126,6 +126,10 @@ pub const GIT_LOCKED: ErrorCode = ErrorCode(2011);
 pub const GIT_FORCE_PUSH_BRANCH: ErrorCode = ErrorCode(2012);
 #[allow(dead_code)]
 pub const GIT_INSPECT_RELEASE_BRANCH: ErrorCode = ErrorCode(2013);
+#[allow(dead_code)]
+pub const GIT_DELETE_TAG: ErrorCode = ErrorCode(2014);
+#[allow(dead_code)]
+pub const GIT_REVERT: ErrorCode = ErrorCode(2015);
 
 #[allow(dead_code)]
 pub const GITHUB_CREATE_RELEASE: ErrorCode = ErrorCode(3001);
@@ -157,6 +161,8 @@ pub const GITHUB_GRAPHQL_REQUEST: ErrorCode = ErrorCode(3013);
 pub const GITHUB_GRAPHQL_ERROR: ErrorCode = ErrorCode(3014);
 #[allow(dead_code)]
 pub const GITHUB_SET_BRANCH: ErrorCode = ErrorCode(3015);
+#[allow(dead_code)]
+pub const GITHUB_DELETE_RELEASE: ErrorCode = ErrorCode(3016);
 
 #[allow(dead_code)]
 pub const GITLAB_CREATE_RELEASE: ErrorCode = ErrorCode(3101);
@@ -398,3 +404,6 @@ mod tests {
         assert!(code_from_error(&err).is_none());
     }
 }
+
+#[allow(dead_code)]
+pub const ROLLBACK_BLOCKED: ErrorCode = ErrorCode(10000);

--- a/src/forge/github.rs
+++ b/src/forge/github.rs
@@ -219,6 +219,18 @@ impl Forge for GitHubForge {
         })
     }
 
+    fn delete_release(&self, id: u64) -> Result<()> {
+        let url = format!("{}/repos/{}/releases/{id}", self.api_base, self.slug);
+        self.agent
+            .delete(&url)
+            .header("Authorization", &format!("Bearer {}", self.token))
+            .header("User-Agent", "ferrflow")
+            .call()
+            .map(|_| ())
+            .with_context(|| format!("Failed to delete release #{id}"))
+            .error_code(error_code::GITHUB_DELETE_RELEASE)
+    }
+
     fn find_draft_release(&self, tag: &str) -> Result<Option<u64>> {
         let base_url = format!("{}/repos/{}/releases", self.api_base, self.slug);
         let releases = self

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -71,6 +71,16 @@ pub trait Forge: Send + Sync {
         draft: bool,
     ) -> Result<ReleaseResult>;
     fn find_draft_release(&self, tag: &str) -> Result<Option<u64>>;
+
+    /// Deletes a release by id, for `ferrflow rollback`.
+    ///
+    /// Defaulted so a forge that cannot do it says so rather than silently
+    /// reporting a rollback it did not perform.
+    fn delete_release(&self, _id: u64) -> Result<()> {
+        Err(anyhow::anyhow!(
+            "this forge cannot delete releases; remove it by hand"
+        ))
+    }
     fn publish_release(&self, release_id: u64) -> Result<()>;
     fn create_merge_request(
         &self,

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -29,8 +29,8 @@ pub use diff::{
 pub use fetch::fetch_tags;
 #[allow(unused_imports)]
 pub use push::{
-    force_push_branch, force_push_tags, push, push_tags, release_branch_foreign_commit,
-    reset_branch_to_remote, verify_remote_branch,
+    delete_tag_if_unchanged, force_push_branch, force_push_tags, push, push_tags,
+    release_branch_foreign_commit, reset_branch_to_remote, revert_commit, verify_remote_branch,
 };
 pub use repo::{Repository, get_repo_root, open_repo, resolve_current_branch};
 pub use retry::is_push_rejected_error;

--- a/src/git/push.rs
+++ b/src/git/push.rs
@@ -460,3 +460,77 @@ pub fn push(repo: &Repository, remote_name: &str, branch: &str) -> Result<()> {
 
     Ok(())
 }
+
+/// Deletes `tag` locally and on the remote, but only while the remote still
+/// points at `expected_sha`.
+///
+/// The check is the whole point: a rollback runs after a failure, possibly much
+/// later, and a tag someone else has since moved or recreated is not ours to
+/// delete. Mismatches are reported and skipped rather than forced.
+pub fn delete_tag_if_unchanged(
+    repo: &Repository,
+    remote_name: &str,
+    tag: &str,
+    expected_sha: &str,
+) -> Result<()> {
+    super::validate::ensure_safe_refname_fragment(remote_name, "remote name")?;
+    super::validate::ensure_safe_refname_fragment(tag, "tag name")?;
+    let workdir = repo
+        .workdir()
+        .ok_or_else(|| anyhow!("bare repos are not supported"))?;
+
+    match local_tag_target_sha(repo, tag) {
+        Ok(actual) if actual != expected_sha => {
+            tracing::warn!(
+                "{}",
+                format!(
+                    "  skipped tag {tag}: points at {} now, not the {} this run created",
+                    &actual[..actual.len().min(7)],
+                    &expected_sha[..expected_sha.len().min(7)]
+                )
+            );
+            return Ok(());
+        }
+        _ => {}
+    }
+
+    let url = get_remote_url(repo, remote_name)
+        .ok_or_else(|| anyhow!("Remote '{remote_name}' has no URL"))?;
+    let mut cmd = std::process::Command::new("git");
+    cmd.current_dir(workdir);
+    configure_git_command(&mut cmd, &url);
+    cmd.args(["push", "--delete", &url, &format!("refs/tags/{tag}")]);
+    let out = cmd
+        .output()
+        .with_context(|| format!("spawn `git push --delete` for tag '{tag}' failed"))
+        .error_code(error_code::GIT_DELETE_TAG)?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        // A tag already absent from the remote is the desired end state.
+        if !stderr.contains("remote ref does not exist") {
+            return Err(anyhow!(
+                "Failed to delete remote tag '{tag}': {}",
+                stderr.trim()
+            ))
+            .error_code(error_code::GIT_DELETE_TAG);
+        }
+    }
+
+    run_git(workdir, &["tag", "-d", tag]).ok();
+    Ok(())
+}
+
+/// Reverts `sha` on the current branch without pushing.
+///
+/// Deliberately leaves the push to the operator: a rollback already deleted
+/// remote refs, and forcing a branch update on top of that is a decision that
+/// should be taken with the branch in front of you.
+pub fn revert_commit(repo: &Repository, sha: &str) -> Result<()> {
+    let workdir = repo
+        .workdir()
+        .ok_or_else(|| anyhow!("bare repos are not supported"))?;
+    run_git(workdir, &["revert", "--no-edit", sha])
+        .with_context(|| format!("Failed to revert {sha}"))
+        .error_code(error_code::GIT_REVERT)?;
+    Ok(())
+}

--- a/src/git/push.rs
+++ b/src/git/push.rs
@@ -461,12 +461,18 @@ pub fn push(repo: &Repository, remote_name: &str, branch: &str) -> Result<()> {
     Ok(())
 }
 
-/// Deletes `tag` locally and on the remote, but only while the remote still
+/// Deletes `tag` locally and on the remote, but only while the **remote** still
 /// points at `expected_sha`.
 ///
-/// The check is the whole point: a rollback runs after a failure, possibly much
-/// later, and a tag someone else has since moved or recreated is not ours to
-/// delete. Mismatches are reported and skipped rather than forced.
+/// The check has to hit the remote, not the local ref. A rollback runs after a
+/// failure, possibly from a fresh checkout that never fetched the tag, or from
+/// one whose copy is older than whatever the remote holds now. Trusting the
+/// local ref would delete a tag someone else recreated in the meantime, which
+/// is the one thing this function exists to prevent.
+///
+/// Anything that leaves the remote state unknown skips the tag rather than
+/// guessing: the cost of skipping is a leftover tag, the cost of guessing wrong
+/// is deleting someone else's.
 pub fn delete_tag_if_unchanged(
     repo: &Repository,
     remote_name: &str,
@@ -478,24 +484,45 @@ pub fn delete_tag_if_unchanged(
     let workdir = repo
         .workdir()
         .ok_or_else(|| anyhow!("bare repos are not supported"))?;
+    let url = get_remote_url(repo, remote_name)
+        .ok_or_else(|| anyhow!("Remote '{remote_name}' has no URL"))?;
 
-    match local_tag_target_sha(repo, tag) {
-        Ok(actual) if actual != expected_sha => {
+    // The glob matters: `refs/tags/<tag>` alone filters out the `^{}` line, so
+    // an annotated tag would come back as its tag object rather than the commit
+    // the checkpoint recorded, and every annotated tag would look moved.
+    let pattern = format!("{tag}*");
+    let remote_shas = match remote_tag_target_shas(workdir, &url, &[&pattern]) {
+        Ok(shas) => shas,
+        Err(err) => {
+            tracing::warn!(
+                "{}",
+                format!("  skipped tag {tag}: could not read it from the remote ({err:#})")
+            );
+            return Ok(());
+        }
+    };
+
+    match remote_shas.get(tag) {
+        Some(actual) if actual != expected_sha => {
             tracing::warn!(
                 "{}",
                 format!(
-                    "  skipped tag {tag}: points at {} now, not the {} this run created",
+                    "  skipped tag {tag}: the remote has it at {} now, not the {} this run created",
                     &actual[..actual.len().min(7)],
                     &expected_sha[..expected_sha.len().min(7)]
                 )
             );
             return Ok(());
         }
-        _ => {}
+        // Absent from the remote: nothing to delete there, but a local ref from
+        // the failed run may still be lying around, so fall through to clean it.
+        None => {
+            run_git(workdir, &["tag", "-d", tag]).ok();
+            return Ok(());
+        }
+        Some(_) => {}
     }
 
-    let url = get_remote_url(repo, remote_name)
-        .ok_or_else(|| anyhow!("Remote '{remote_name}' has no URL"))?;
     let mut cmd = std::process::Command::new("git");
     cmd.current_dir(workdir);
     configure_git_command(&mut cmd, &url);
@@ -506,7 +533,7 @@ pub fn delete_tag_if_unchanged(
         .error_code(error_code::GIT_DELETE_TAG)?;
     if !out.status.success() {
         let stderr = String::from_utf8_lossy(&out.stderr);
-        // A tag already absent from the remote is the desired end state.
+        // Raced with someone else deleting it; the end state is what we wanted.
         if !stderr.contains("remote ref does not exist") {
             return Err(anyhow!(
                 "Failed to delete remote tag '{tag}': {}",

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -7,7 +7,7 @@ use super::*;
 use crate::config::OrphanedTagStrategy;
 use crate::error_code;
 use crate::test_utils::{git, git_with_env, init_repo_at};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[test]
 fn is_transient_classifies_network_errors_as_retryable() {
@@ -1716,14 +1716,14 @@ fn signing_follows_every_spelling_git_accepts_for_a_boolean() {
     }
 }
 
-#[test]
-fn a_tag_moved_since_the_failed_run_is_left_alone() {
-    let dir = tempfile::tempdir().unwrap();
-    let remote = dir.path().join("remote.git");
+/// Local clone plus a bare remote it can push to, which is the only shape that
+/// can tell a local-ref check from a remote one.
+fn repo_with_remote(dir: &Path) -> (PathBuf, PathBuf) {
+    let remote = dir.join("remote.git");
     std::fs::create_dir_all(&remote).unwrap();
     git(&remote, &["init", "--bare", "-b", "main"]);
 
-    let local = dir.path().join("local");
+    let local = dir.join("local");
     std::fs::create_dir_all(&local).unwrap();
     init_repo_at(&local);
     git(
@@ -1731,83 +1731,142 @@ fn a_tag_moved_since_the_failed_run_is_left_alone() {
         &["remote", "add", "origin", remote.to_str().unwrap()],
     );
     commit_file_at(&local, "a.txt", "feat: first");
+    git(&local, &["push", "origin", "main:main"]);
+    (local, remote)
+}
+
+#[test]
+fn a_tag_the_remote_has_moved_is_left_alone_even_when_the_local_ref_still_matches() {
+    let dir = tempfile::tempdir().unwrap();
+    let (local, remote) = repo_with_remote(dir.path());
+
     git(&local, &["tag", "v1.0.0"]);
-    git(&local, &["push", "origin", "main:main", "--tags"]);
+    git(&local, &["push", "origin", "v1.0.0"]);
+    let repo = open_repo(&local).unwrap();
+    let recorded = local_tag_target_sha(&repo, "v1.0.0").unwrap();
+
+    // Someone else recreates the tag on a different commit. Our local ref is
+    // untouched and still equals `recorded`, so a local-only check would pass.
+    let other = dir.path().join("other");
+    std::fs::create_dir_all(&other).unwrap();
+    init_repo_at(&other);
+    git(
+        &other,
+        &["remote", "add", "origin", remote.to_str().unwrap()],
+    );
+    commit_file_at(&other, "b.txt", "feat: theirs");
+    git(&other, &["push", "--force", "origin", "HEAD:main"]);
+    git(&other, &["tag", "-f", "v1.0.0"]);
+    git(&other, &["push", "--force", "origin", "v1.0.0"]);
+
+    assert_eq!(
+        local_tag_target_sha(&repo, "v1.0.0").unwrap(),
+        recorded,
+        "precondition: the local ref must still look unchanged"
+    );
+
+    delete_tag_if_unchanged(&repo, "origin", "v1.0.0", &recorded).unwrap();
+
+    let remote_tags = git(&remote, &["tag", "-l"]);
+    assert!(
+        remote_tags.contains("v1.0.0"),
+        "the remote tag someone else recreated must survive, got {remote_tags:?}"
+    );
+}
+
+#[test]
+fn a_tag_absent_from_this_checkout_is_not_deleted_from_the_remote() {
+    let dir = tempfile::tempdir().unwrap();
+    let (local, remote) = repo_with_remote(dir.path());
+
+    // Tag pushed by someone else, never fetched here.
+    let other = dir.path().join("other");
+    std::fs::create_dir_all(&other).unwrap();
+    init_repo_at(&other);
+    git(
+        &other,
+        &["remote", "add", "origin", remote.to_str().unwrap()],
+    );
+    git(&other, &["fetch", "origin", "main"]);
+    git(&other, &["checkout", "-f", "FETCH_HEAD"]);
+    git(&other, &["tag", "theirs-v9.9.9"]);
+    git(&other, &["push", "origin", "theirs-v9.9.9"]);
 
     let repo = open_repo(&local).unwrap();
+    assert!(!tag_exists(&repo, "theirs-v9.9.9"), "precondition");
 
-    // Someone moved the tag after the failed run recorded it.
     delete_tag_if_unchanged(
         &repo,
         "origin",
-        "v1.0.0",
-        "0000000000000000000000000000000000000000",
+        "theirs-v9.9.9",
+        "deadbeefdeadbeefdeadbeefdeadbeef",
     )
     .unwrap();
 
-    assert!(
-        tag_exists(&repo, "v1.0.0"),
-        "a tag that no longer matches the recorded sha must survive"
-    );
-}
-
-#[test]
-fn a_tag_still_at_the_recorded_sha_is_deleted() {
-    let dir = tempfile::tempdir().unwrap();
-    let remote = dir.path().join("remote.git");
-    std::fs::create_dir_all(&remote).unwrap();
-    git(&remote, &["init", "--bare", "-b", "main"]);
-
-    let local = dir.path().join("local");
-    std::fs::create_dir_all(&local).unwrap();
-    init_repo_at(&local);
-    git(
-        &local,
-        &["remote", "add", "origin", remote.to_str().unwrap()],
-    );
-    commit_file_at(&local, "a.txt", "feat: first");
-    git(&local, &["tag", "v1.0.0"]);
-    git(&local, &["push", "origin", "main:main", "--tags"]);
-
-    let repo = open_repo(&local).unwrap();
-    let sha = local_tag_target_sha(&repo, "v1.0.0").unwrap();
-
-    delete_tag_if_unchanged(&repo, "origin", "v1.0.0", &sha).unwrap();
-
-    assert!(!tag_exists(&repo, "v1.0.0"));
     let remote_tags = git(&remote, &["tag", "-l"]);
     assert!(
-        remote_tags.trim().is_empty(),
-        "the remote tag must go too, got {remote_tags:?}"
+        remote_tags.contains("theirs-v9.9.9"),
+        "a tag this checkout never saw must not be deleted, got {remote_tags:?}"
     );
 }
 
 #[test]
-fn deleting_a_tag_that_is_already_gone_from_the_remote_succeeds() {
+fn an_annotated_tag_still_at_its_recorded_commit_is_deleted() {
+    // FerrFlow creates annotated tags, so `refs/tags/x` is the tag object while
+    // the checkpoint records the commit. Getting this wrong makes every real
+    // rollback refuse itself.
     let dir = tempfile::tempdir().unwrap();
-    let remote = dir.path().join("remote.git");
-    std::fs::create_dir_all(&remote).unwrap();
-    git(&remote, &["init", "--bare", "-b", "main"]);
+    let (local, remote) = repo_with_remote(dir.path());
 
-    let local = dir.path().join("local");
-    std::fs::create_dir_all(&local).unwrap();
-    init_repo_at(&local);
-    git(
-        &local,
-        &["remote", "add", "origin", remote.to_str().unwrap()],
+    git(&local, &["tag", "-a", "v1.0.0", "-m", "Release v1.0.0"]);
+    git(&local, &["push", "origin", "v1.0.0"]);
+    let repo = open_repo(&local).unwrap();
+    let commit = local_tag_target_sha(&repo, "v1.0.0").unwrap();
+
+    delete_tag_if_unchanged(&repo, "origin", "v1.0.0", &commit).unwrap();
+
+    let remote_tags = git(&remote, &["tag", "-l"]);
+    assert!(
+        !remote_tags.contains("v1.0.0"),
+        "an annotated tag at its recorded commit must be deleted, got {remote_tags:?}"
     );
-    commit_file_at(&local, "a.txt", "feat: first");
-    git(&local, &["tag", "v1.0.0"]);
-    git(&local, &["push", "origin", "main:main"]);
+}
 
+#[test]
+fn a_tag_still_at_the_recorded_sha_on_the_remote_is_deleted() {
+    let dir = tempfile::tempdir().unwrap();
+    let (local, remote) = repo_with_remote(dir.path());
+
+    git(&local, &["tag", "v1.0.0"]);
+    git(&local, &["push", "origin", "v1.0.0"]);
     let repo = open_repo(&local).unwrap();
     let sha = local_tag_target_sha(&repo, "v1.0.0").unwrap();
 
-    // Never pushed, so the remote has no such ref. Rollback should still reach
-    // the desired end state rather than failing on it.
     delete_tag_if_unchanged(&repo, "origin", "v1.0.0", &sha).unwrap();
 
-    assert!(!tag_exists(&repo, "v1.0.0"));
+    assert!(!tag_exists(&repo, "v1.0.0"), "the local tag should go");
+    let remote_tags = git(&remote, &["tag", "-l"]);
+    assert!(
+        !remote_tags.contains("v1.0.0"),
+        "the remote tag should go too, got {remote_tags:?}"
+    );
+}
+
+#[test]
+fn a_tag_that_never_reached_the_remote_is_cleaned_up_locally() {
+    let dir = tempfile::tempdir().unwrap();
+    let (local, _remote) = repo_with_remote(dir.path());
+
+    git(&local, &["tag", "v1.0.0"]);
+    let repo = open_repo(&local).unwrap();
+    let sha = local_tag_target_sha(&repo, "v1.0.0").unwrap();
+
+    delete_tag_if_unchanged(&repo, "origin", "v1.0.0", &sha).unwrap();
+
+    assert!(
+        !tag_exists(&repo, "v1.0.0"),
+        "a tag the failed run created but never pushed should still be cleaned up"
+    );
 }
 
 #[test]

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -1715,3 +1715,121 @@ fn signing_follows_every_spelling_git_accepts_for_a_boolean() {
         );
     }
 }
+
+#[test]
+fn a_tag_moved_since_the_failed_run_is_left_alone() {
+    let dir = tempfile::tempdir().unwrap();
+    let remote = dir.path().join("remote.git");
+    std::fs::create_dir_all(&remote).unwrap();
+    git(&remote, &["init", "--bare", "-b", "main"]);
+
+    let local = dir.path().join("local");
+    std::fs::create_dir_all(&local).unwrap();
+    init_repo_at(&local);
+    git(
+        &local,
+        &["remote", "add", "origin", remote.to_str().unwrap()],
+    );
+    commit_file_at(&local, "a.txt", "feat: first");
+    git(&local, &["tag", "v1.0.0"]);
+    git(&local, &["push", "origin", "main:main", "--tags"]);
+
+    let repo = open_repo(&local).unwrap();
+
+    // Someone moved the tag after the failed run recorded it.
+    delete_tag_if_unchanged(
+        &repo,
+        "origin",
+        "v1.0.0",
+        "0000000000000000000000000000000000000000",
+    )
+    .unwrap();
+
+    assert!(
+        tag_exists(&repo, "v1.0.0"),
+        "a tag that no longer matches the recorded sha must survive"
+    );
+}
+
+#[test]
+fn a_tag_still_at_the_recorded_sha_is_deleted() {
+    let dir = tempfile::tempdir().unwrap();
+    let remote = dir.path().join("remote.git");
+    std::fs::create_dir_all(&remote).unwrap();
+    git(&remote, &["init", "--bare", "-b", "main"]);
+
+    let local = dir.path().join("local");
+    std::fs::create_dir_all(&local).unwrap();
+    init_repo_at(&local);
+    git(
+        &local,
+        &["remote", "add", "origin", remote.to_str().unwrap()],
+    );
+    commit_file_at(&local, "a.txt", "feat: first");
+    git(&local, &["tag", "v1.0.0"]);
+    git(&local, &["push", "origin", "main:main", "--tags"]);
+
+    let repo = open_repo(&local).unwrap();
+    let sha = local_tag_target_sha(&repo, "v1.0.0").unwrap();
+
+    delete_tag_if_unchanged(&repo, "origin", "v1.0.0", &sha).unwrap();
+
+    assert!(!tag_exists(&repo, "v1.0.0"));
+    let remote_tags = git(&remote, &["tag", "-l"]);
+    assert!(
+        remote_tags.trim().is_empty(),
+        "the remote tag must go too, got {remote_tags:?}"
+    );
+}
+
+#[test]
+fn deleting_a_tag_that_is_already_gone_from_the_remote_succeeds() {
+    let dir = tempfile::tempdir().unwrap();
+    let remote = dir.path().join("remote.git");
+    std::fs::create_dir_all(&remote).unwrap();
+    git(&remote, &["init", "--bare", "-b", "main"]);
+
+    let local = dir.path().join("local");
+    std::fs::create_dir_all(&local).unwrap();
+    init_repo_at(&local);
+    git(
+        &local,
+        &["remote", "add", "origin", remote.to_str().unwrap()],
+    );
+    commit_file_at(&local, "a.txt", "feat: first");
+    git(&local, &["tag", "v1.0.0"]);
+    git(&local, &["push", "origin", "main:main"]);
+
+    let repo = open_repo(&local).unwrap();
+    let sha = local_tag_target_sha(&repo, "v1.0.0").unwrap();
+
+    // Never pushed, so the remote has no such ref. Rollback should still reach
+    // the desired end state rather than failing on it.
+    delete_tag_if_unchanged(&repo, "origin", "v1.0.0", &sha).unwrap();
+
+    assert!(!tag_exists(&repo, "v1.0.0"));
+}
+
+#[test]
+fn reverting_the_release_commit_undoes_its_changes() {
+    let dir = tempfile::tempdir().unwrap();
+    let local = dir.path().join("local");
+    std::fs::create_dir_all(&local).unwrap();
+    init_repo_at(&local);
+    commit_file_at(&local, "Cargo.toml", "chore: initial");
+    std::fs::write(local.join("Cargo.toml"), "version = \"1.1.0\"").unwrap();
+    git(&local, &["add", "-A"]);
+    git(&local, &["commit", "-m", "chore(release): v1.1.0"]);
+    let release_sha = git(&local, &["rev-parse", "HEAD"]).trim().to_string();
+
+    let repo = open_repo(&local).unwrap();
+    revert_commit(&repo, &release_sha).unwrap();
+
+    let content = std::fs::read_to_string(local.join("Cargo.toml")).unwrap();
+    assert!(
+        !content.contains("1.1.0"),
+        "the bump must be undone, got {content:?}"
+    );
+    let head_subject = git(&local, &["log", "-1", "--format=%s"]);
+    assert!(head_subject.starts_with("Revert"), "{head_subject}");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod prerelease;
 mod publish;
 mod publishers;
 mod query;
+mod rollback;
 mod schema;
 mod status;
 mod timing;

--- a/src/monorepo/mod.rs
+++ b/src/monorepo/mod.rs
@@ -1,7 +1,7 @@
 mod check;
-mod preview;
+pub(crate) mod preview;
 mod release;
-mod run;
+pub(crate) mod run;
 mod types;
 mod util;
 mod version_source;

--- a/src/monorepo/preview.rs
+++ b/src/monorepo/preview.rs
@@ -6,7 +6,7 @@ use crate::git::{Repository, get_remote_url};
 
 use super::types::{CheckPackage, CheckResult};
 
-pub(super) fn build_forge_instance(
+pub(crate) fn build_forge_instance(
     repo: &Repository,
     config: &Config,
 ) -> Option<Box<dyn forge::Forge>> {

--- a/src/monorepo/run/checkpoint.rs
+++ b/src/monorepo/run/checkpoint.rs
@@ -6,7 +6,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::error_code::{self, ErrorCodeExt};
 
 const CHECKPOINT_FILENAME: &str = "ferrflow.checkpoint.json";
-const CHECKPOINT_SCHEMA: u32 = 1;
+const CHECKPOINT_SCHEMA: u32 = 2;
 
 /// Coarse-grained sequence of release phases, ordered by the side
 /// effects they produce. The checkpoint records the highest phase that
@@ -46,6 +46,35 @@ pub enum Phase {
 /// the checkpoint manually or rerun against the recorded commit. This
 /// avoids the worst failure mode (replaying old tags onto a new commit
 /// graph). See #549.
+/// A tag this run created, pinned to the commit it pointed at.
+///
+/// `rollback` deletes a tag only when the remote still points at this sha, so a
+/// tag someone else moved or recreated in the meantime is left alone.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecordedTag {
+    pub name: String,
+    pub sha: String,
+}
+
+/// A forge release this run created, kept by id so rollback deletes the exact
+/// release rather than whatever currently answers to that tag name.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecordedRelease {
+    pub tag: String,
+    pub id: u64,
+}
+
+/// A package whose publishers ran to completion.
+///
+/// `immutable` marks a registry that refuses to unpublish. Rollback stops on
+/// those rather than deleting the tag for a version the world can download.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecordedPublish {
+    pub package: String,
+    pub kind: String,
+    pub immutable: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Checkpoint {
     pub schema_version: u32,
@@ -54,6 +83,14 @@ pub struct Checkpoint {
     pub phase: Phase,
     pub commit_sha: Option<String>,
     pub tag_names: Vec<String>,
+    /// Tags actually created, as opposed to `tag_names` which is only what the
+    /// run planned. Only these are candidates for deletion.
+    #[serde(default)]
+    pub created_tags: Vec<RecordedTag>,
+    #[serde(default)]
+    pub forge_releases: Vec<RecordedRelease>,
+    #[serde(default)]
+    pub published: Vec<RecordedPublish>,
 }
 
 impl Checkpoint {
@@ -68,6 +105,9 @@ impl Checkpoint {
             phase: Phase::Pending,
             commit_sha: None,
             tag_names,
+            created_tags: Vec::new(),
+            forge_releases: Vec::new(),
+            published: Vec::new(),
         }
     }
 

--- a/src/monorepo/run/execute.rs
+++ b/src/monorepo/run/execute.rs
@@ -400,6 +400,17 @@ fn run_commit_or_pr(
 fn create_release_tags(plan: &mut ReleasePlan<'_>) -> Result<()> {
     for t in plan.tags_to_create {
         create_tag(plan.repo, &t.tag, &t.message)?;
+        // Pin the tag to the commit it points at, so `ferrflow rollback` can
+        // tell a tag this run created from one someone else has since moved.
+        if let Some(sha) = crate::git::resolve_tag_name_to_commit(plan.repo, &t.tag)
+            && let Some(cp) = plan.checkpoint.as_mut()
+        {
+            cp.created_tags
+                .push(crate::monorepo::run::checkpoint::RecordedTag {
+                    name: t.tag.clone(),
+                    sha: sha.to_string(),
+                });
+        }
         if let Some((_, lines)) = plan
             .pkg_outputs
             .iter_mut()
@@ -608,6 +619,13 @@ fn publish_releases_with(plan: &mut ReleasePlan<'_>, forge: &dyn Forge) -> Resul
             }
         }
         if let Some(result) = outcome.result {
+            if let (Some(id), Some(cp)) = (result.id, plan.checkpoint.as_mut()) {
+                cp.forge_releases
+                    .push(crate::monorepo::run::checkpoint::RecordedRelease {
+                        tag: tag_name.clone(),
+                        id,
+                    });
+            }
             plan.forge_results.push((tag_name, result));
         }
         if let Some(line) = outcome.success_line
@@ -737,7 +755,7 @@ fn run_post_publish_hooks(plan: &mut ReleasePlan<'_>) -> Result<()> {
 }
 
 fn run_publishers_for_package(
-    plan: &ReleasePlan<'_>,
+    plan: &mut ReleasePlan<'_>,
     pkg: &crate::config::PackageConfig,
     package_name: &str,
     new_version: &str,
@@ -756,10 +774,31 @@ fn run_publishers_for_package(
         dry_run: plan.dry_run,
         verbose: plan.verbose,
     };
-    crate::publishers::run_all(&pkg.publishers, &pub_ctx)
+
+    let mut published: Vec<(&'static str, bool)> = Vec::new();
+    let outcome = crate::publishers::run_all(&pkg.publishers, &pub_ctx, &mut published);
+
+    // Recorded whether or not the batch succeeded: a publisher that already
+    // pushed to crates.io is a fact rollback has to respect even when a later
+    // one in the same package failed.
+    if !plan.dry_run
+        && let Some(cp) = plan.checkpoint.as_mut()
+    {
+        for (kind, immutable) in published {
+            cp.published
+                .push(crate::monorepo::run::checkpoint::RecordedPublish {
+                    package: package_name.to_string(),
+                    kind: kind.to_string(),
+                    immutable,
+                });
+        }
+        cp.save(plan.root)?;
+    }
+
+    outcome
 }
 
-pub(super) fn print_dry_run_hooks(plan: &ReleasePlan<'_>) -> Result<()> {
+pub(super) fn print_dry_run_hooks(plan: &mut ReleasePlan<'_>) -> Result<()> {
     for (ctx, pkg_idx) in plan.hook_contexts {
         let pkg = &plan.config.packages[*pkg_idx];
         let ws_hooks = plan.config.workspace.hooks.as_ref();

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -24,7 +24,7 @@ use super::util::{auto_stage_new_files, collect_dirty_files};
 
 mod authored_commit;
 mod cascade;
-pub(super) mod checkpoint;
+pub(crate) mod checkpoint;
 mod commit_body;
 mod drafts;
 mod execute;
@@ -812,7 +812,7 @@ pub(super) fn run_release_logic(
             }
         }
     } else if dry_run && any_bumped {
-        let plan = ReleasePlan {
+        let mut plan = ReleasePlan {
             repo: &repo,
             config,
             root,
@@ -832,7 +832,7 @@ pub(super) fn run_release_logic(
             checkpoint: None,
             forge: None,
         };
-        print_dry_run_hooks(&plan)?;
+        print_dry_run_hooks(&mut plan)?;
         timing.skip("release commit phase", "dry-run");
     }
 

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -52,7 +52,7 @@ pub fn run(
             dry_run,
             verbose,
         };
-        publishers::run_all(&pkg.publishers, &ctx)?;
+        publishers::run_all(&pkg.publishers, &ctx, &mut Vec::new())?;
         ran += 1;
     }
 

--- a/src/publishers/mod.rs
+++ b/src/publishers/mod.rs
@@ -41,7 +41,17 @@ pub enum PublishOutcome {
 /// `ferrflow release` post-publish phase and the standalone `ferrflow
 /// publish` command so both surface publishers identically. Returns the
 /// first executor error, after which remaining publishers are skipped.
-pub fn run_all(publishers: &[PublisherConfig], ctx: &PublishContext<'_>) -> Result<()> {
+/// Runs every publisher for one package, reporting each success into
+/// `published` as it happens.
+///
+/// The reporting is incremental on purpose: when publisher 3 of 5 fails, the
+/// two that already succeeded are facts on a registry somewhere, and
+/// `ferrflow rollback` has to know about them even though this returns `Err`.
+pub fn run_all(
+    publishers: &[PublisherConfig],
+    ctx: &PublishContext<'_>,
+    published: &mut Vec<(&'static str, bool)>,
+) -> Result<()> {
     if publishers.is_empty() {
         return Ok(());
     }
@@ -57,6 +67,7 @@ pub fn run_all(publishers: &[PublisherConfig], ctx: &PublishContext<'_>) -> Resu
             Ok(PublishOutcome::Published { url }) => {
                 let suffix = url.as_deref().unwrap_or("");
                 tracing::info!("    [{kind}] {preview} → {} {suffix}", "published".green());
+                published.push((kind, p.is_immutable_publish()));
             }
             Ok(PublishOutcome::Skipped { reason }) => {
                 tracing::info!("    [{kind}] {preview} → {} ({reason})", "skipped".yellow());

--- a/src/rollback/mod.rs
+++ b/src/rollback/mod.rs
@@ -1,0 +1,141 @@
+mod plan;
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use std::path::Path;
+
+use crate::config::Config;
+use crate::error_code::{self, ErrorCodeExt};
+use crate::git::{Repository, get_repo_root, open_repo};
+use crate::monorepo::run::checkpoint::Checkpoint;
+
+pub use plan::{RollbackPlan, Step};
+
+pub fn run(packages: &[String], yes: bool, config_path: Option<&Path>) -> Result<()> {
+    let repo = open_repo(&std::env::current_dir()?)?;
+    let root = get_repo_root(&repo)?;
+    let config = Config::load(&root, config_path)?;
+
+    let Some(checkpoint) = Checkpoint::load(&root)? else {
+        tracing::info!(
+            "{}",
+            "No release checkpoint found: there is no failed run to roll back.".dimmed()
+        );
+        return Ok(());
+    };
+
+    let has_manifest = crate::manifest::manifest_path(&config, &root).is_some();
+    let plan = plan::plan(&checkpoint, packages, has_manifest, |tag| {
+        tag_owner(&config, tag)
+    });
+
+    print_plan(&plan);
+
+    if !plan.blocked.is_empty() && plan.is_empty() {
+        return Err(anyhow::anyhow!(
+            "nothing can be rolled back: every package in this run published to a registry that cannot be unpublished"
+        ))
+        .error_code(error_code::ROLLBACK_BLOCKED);
+    }
+
+    if plan.is_empty() {
+        return Ok(());
+    }
+
+    if !yes {
+        tracing::info!("");
+        tracing::info!(
+            "{}",
+            "This was a dry run. Re-run with --yes to apply it.".dimmed()
+        );
+        return Ok(());
+    }
+
+    apply(&plan, &repo, &config, config_path)?;
+    Checkpoint::delete(&root)?;
+    tracing::info!("");
+    tracing::info!("{}", "✓ Rolled back".green());
+    Ok(())
+}
+
+/// Which package a tag belongs to, by matching the tag against each package's
+/// rendered prefix. Returns None when no package claims it, which keeps a
+/// stray tag out of a narrowed rollback rather than guessing.
+fn tag_owner(config: &Config, tag: &str) -> Option<String> {
+    let is_monorepo = config.is_monorepo();
+    config
+        .packages
+        .iter()
+        .filter_map(|pkg| {
+            let prefix = pkg.tag_prefix(&config.workspace, is_monorepo);
+            (!prefix.is_empty() && tag.starts_with(&prefix)).then(|| pkg.name.clone())
+        })
+        .next()
+}
+
+fn print_plan(plan: &RollbackPlan) {
+    for blocked in &plan.blocked {
+        tracing::warn!(
+            "{}",
+            format!("  ! {} {}", blocked.package.bold(), blocked.reason).yellow()
+        );
+    }
+    if !plan.blocked.is_empty() {
+        tracing::info!("");
+    }
+    for step in &plan.steps {
+        tracing::info!("  {}", describe(step));
+    }
+    if plan.steps.is_empty() && plan.blocked.is_empty() {
+        tracing::info!("{}", "Nothing to roll back.".dimmed());
+    }
+}
+
+fn describe(step: &Step) -> String {
+    match step {
+        Step::DeleteTag { name, sha } => {
+            format!("delete tag {} ({})", name.cyan(), &sha[..sha.len().min(7)])
+        }
+        Step::DeleteRelease { tag, id } => {
+            format!("delete release {} (#{id})", tag.cyan())
+        }
+        Step::RevertCommit { sha } => {
+            format!("revert commit {}", &sha[..sha.len().min(7)])
+        }
+        Step::RestoreManifest => "restore the manifest".to_string(),
+    }
+}
+
+fn apply(
+    plan: &RollbackPlan,
+    repo: &Repository,
+    config: &Config,
+    config_path: Option<&Path>,
+) -> Result<()> {
+    let remote = &config.workspace.remote;
+    let forge = crate::monorepo::preview::build_forge_instance(repo, config);
+
+    for step in &plan.steps {
+        match step {
+            Step::DeleteRelease { tag, id } => match forge.as_ref() {
+                Some(f) => f.delete_release(*id).with_context(|| {
+                    format!("Failed to delete the release for {tag}; delete it by hand and rerun")
+                })?,
+                None => tracing::warn!(
+                    "{}",
+                    format!("  skipped release for {tag}: no forge token available").yellow()
+                ),
+            },
+            Step::DeleteTag { name, sha } => {
+                crate::git::delete_tag_if_unchanged(repo, remote, name, sha)?;
+            }
+            Step::RevertCommit { sha } => {
+                crate::git::revert_commit(repo, sha)?;
+            }
+            Step::RestoreManifest => {
+                crate::manifest::sync_cwd(config_path)?;
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/rollback/plan.rs
+++ b/src/rollback/plan.rs
@@ -1,0 +1,346 @@
+use crate::monorepo::run::checkpoint::{Checkpoint, Phase};
+
+/// One undo step, decided before anything is touched so `--dry-run` and the
+/// real run print exactly the same list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Step {
+    DeleteTag { name: String, sha: String },
+    DeleteRelease { tag: String, id: u64 },
+    RevertCommit { sha: String },
+    RestoreManifest,
+}
+
+/// A package that cannot be rolled back, and why.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Blocked {
+    pub package: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RollbackPlan {
+    pub steps: Vec<Step>,
+    pub blocked: Vec<Blocked>,
+}
+
+impl RollbackPlan {
+    pub fn is_empty(&self) -> bool {
+        self.steps.is_empty()
+    }
+}
+
+/// Decides what a rollback would do, from the checkpoint alone.
+///
+/// `packages` narrows the rollback to a subset; empty means everything the run
+/// touched. A package that published to an immutable registry is reported as
+/// blocked and contributes no steps, so a partially-published monorepo run
+/// rolls back the packages it can and refuses the rest rather than doing half
+/// of each.
+pub fn plan(
+    checkpoint: &Checkpoint,
+    packages: &[String],
+    has_manifest: bool,
+    tag_owner: impl Fn(&str) -> Option<String>,
+) -> RollbackPlan {
+    let mut out = RollbackPlan::default();
+
+    let blocked_packages = immutable_packages(checkpoint);
+    for package in &blocked_packages {
+        if wanted(packages, package) {
+            out.blocked.push(Blocked {
+                package: package.clone(),
+                reason: immutable_reason(checkpoint, package),
+            });
+        }
+    }
+
+    let skip = |tag: &str| {
+        tag_owner(tag)
+            .map(|pkg| blocked_packages.contains(&pkg) || !wanted(packages, &pkg))
+            .unwrap_or(!packages.is_empty())
+    };
+
+    for release in &checkpoint.forge_releases {
+        if !skip(&release.tag) {
+            out.steps.push(Step::DeleteRelease {
+                tag: release.tag.clone(),
+                id: release.id,
+            });
+        }
+    }
+
+    for tag in &checkpoint.created_tags {
+        if !skip(&tag.name) {
+            out.steps.push(Step::DeleteTag {
+                name: tag.name.clone(),
+                sha: tag.sha.clone(),
+            });
+        }
+    }
+
+    // The release commit carries every package's bump, so reverting it while
+    // some packages stay released would undo their version files too. Only
+    // revert on a whole-run rollback with nothing blocked.
+    let whole_run = packages.is_empty() && out.blocked.is_empty();
+    if whole_run
+        && checkpoint.phase >= Phase::CommitDone
+        && let Some(sha) = &checkpoint.commit_sha
+    {
+        out.steps.push(Step::RevertCommit { sha: sha.clone() });
+        // Only when the repo actually keeps a manifest; planning it otherwise
+        // makes the rollback fail at the last step, after it has already
+        // deleted the tags, and leaves the checkpoint behind.
+        if has_manifest {
+            out.steps.push(Step::RestoreManifest);
+        }
+    }
+
+    out
+}
+
+fn wanted(packages: &[String], package: &str) -> bool {
+    packages.is_empty() || packages.iter().any(|p| p == package)
+}
+
+fn immutable_packages(checkpoint: &Checkpoint) -> Vec<String> {
+    let mut names: Vec<String> = checkpoint
+        .published
+        .iter()
+        .filter(|p| p.immutable)
+        .map(|p| p.package.clone())
+        .collect();
+    names.sort();
+    names.dedup();
+    names
+}
+
+fn immutable_reason(checkpoint: &Checkpoint, package: &str) -> String {
+    let mut kinds: Vec<&str> = checkpoint
+        .published
+        .iter()
+        .filter(|p| p.immutable && p.package == package)
+        .map(|p| p.kind.as_str())
+        .collect();
+    kinds.sort_unstable();
+    kinds.dedup();
+    format!(
+        "already published to {}, which cannot be unpublished; release a new patch version instead",
+        kinds.join(" and ")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::monorepo::run::checkpoint::{RecordedPublish, RecordedRelease, RecordedTag};
+
+    fn checkpoint(phase: Phase) -> Checkpoint {
+        let mut cp = Checkpoint::new("head".to_string(), Vec::new());
+        cp.phase = phase;
+        cp.commit_sha = Some("commit".to_string());
+        cp
+    }
+
+    fn tag(cp: &mut Checkpoint, name: &str, sha: &str) {
+        cp.created_tags.push(RecordedTag {
+            name: name.to_string(),
+            sha: sha.to_string(),
+        });
+    }
+
+    fn release(cp: &mut Checkpoint, tag: &str, id: u64) {
+        cp.forge_releases.push(RecordedRelease {
+            tag: tag.to_string(),
+            id,
+        });
+    }
+
+    fn published(cp: &mut Checkpoint, package: &str, kind: &str, immutable: bool) {
+        cp.published.push(RecordedPublish {
+            package: package.to_string(),
+            kind: kind.to_string(),
+            immutable,
+        });
+    }
+
+    /// Maps `pkg@v1.0.0` back to `pkg`, which is what the real caller derives
+    /// from the config.
+    fn owner(tag: &str) -> Option<String> {
+        tag.split_once('@').map(|(p, _)| p.to_string())
+    }
+
+    #[test]
+    fn a_clean_run_rolls_back_releases_then_tags_then_the_commit() {
+        let mut cp = checkpoint(Phase::ReleasesCreated);
+        tag(&mut cp, "api@v1.1.0", "sha-api");
+        release(&mut cp, "api@v1.1.0", 42);
+
+        let out = plan(&cp, &[], true, owner);
+
+        assert_eq!(
+            out.steps,
+            vec![
+                Step::DeleteRelease {
+                    tag: "api@v1.1.0".to_string(),
+                    id: 42
+                },
+                Step::DeleteTag {
+                    name: "api@v1.1.0".to_string(),
+                    sha: "sha-api".to_string()
+                },
+                Step::RevertCommit {
+                    sha: "commit".to_string()
+                },
+                Step::RestoreManifest,
+            ]
+        );
+        assert!(out.blocked.is_empty());
+    }
+
+    #[test]
+    fn a_monorepo_failing_at_package_three_rolls_back_one_to_three_only() {
+        let mut cp = checkpoint(Phase::ReleasesCreated);
+        for name in ["a", "b", "c"] {
+            tag(&mut cp, &format!("{name}@v1.0.0"), name);
+            release(&mut cp, &format!("{name}@v1.0.0"), 1);
+        }
+
+        let out = plan(&cp, &[], true, owner);
+        let tags: Vec<&str> = out
+            .steps
+            .iter()
+            .filter_map(|s| match s {
+                Step::DeleteTag { name, .. } => Some(name.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(tags, vec!["a@v1.0.0", "b@v1.0.0", "c@v1.0.0"]);
+    }
+
+    #[test]
+    fn an_immutable_publish_blocks_that_package_and_spares_the_others() {
+        let mut cp = checkpoint(Phase::ReleasesCreated);
+        tag(&mut cp, "api@v1.1.0", "sha-api");
+        tag(&mut cp, "web@v2.0.0", "sha-web");
+        published(&mut cp, "api", "cargo", true);
+
+        let out = plan(&cp, &[], true, owner);
+
+        assert_eq!(out.blocked.len(), 1);
+        assert_eq!(out.blocked[0].package, "api");
+        assert!(out.blocked[0].reason.contains("cargo"));
+        assert!(out.blocked[0].reason.contains("new patch version"));
+
+        let tags: Vec<&str> = out
+            .steps
+            .iter()
+            .filter_map(|s| match s {
+                Step::DeleteTag { name, .. } => Some(name.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            tags,
+            vec!["web@v2.0.0"],
+            "api's tag must survive its publish"
+        );
+    }
+
+    #[test]
+    fn a_blocked_package_stops_the_commit_from_being_reverted() {
+        let mut cp = checkpoint(Phase::ReleasesCreated);
+        tag(&mut cp, "api@v1.1.0", "sha-api");
+        published(&mut cp, "api", "npm", true);
+
+        let out = plan(&cp, &[], true, owner);
+
+        assert!(
+            !out.steps.contains(&Step::RevertCommit {
+                sha: "commit".to_string()
+            }),
+            "reverting would undo the version bump of a package that stays released"
+        );
+    }
+
+    #[test]
+    fn a_mutable_publish_does_not_block_anything() {
+        let mut cp = checkpoint(Phase::ReleasesCreated);
+        tag(&mut cp, "api@v1.1.0", "sha-api");
+        published(&mut cp, "api", "docker", false);
+
+        let out = plan(&cp, &[], true, owner);
+
+        assert!(out.blocked.is_empty(), "a docker tag can be overwritten");
+        assert!(
+            out.steps
+                .iter()
+                .any(|s| matches!(s, Step::DeleteTag { .. }))
+        );
+    }
+
+    #[test]
+    fn naming_a_package_narrows_the_rollback_to_it() {
+        let mut cp = checkpoint(Phase::ReleasesCreated);
+        tag(&mut cp, "api@v1.1.0", "sha-api");
+        tag(&mut cp, "web@v2.0.0", "sha-web");
+
+        let out = plan(&cp, &["web".to_string()], true, owner);
+
+        let tags: Vec<&str> = out
+            .steps
+            .iter()
+            .filter_map(|s| match s {
+                Step::DeleteTag { name, .. } => Some(name.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(tags, vec!["web@v2.0.0"]);
+        assert!(
+            !out.steps.contains(&Step::RestoreManifest),
+            "a partial rollback must not rewrite the whole manifest"
+        );
+    }
+
+    #[test]
+    fn a_run_that_never_committed_has_nothing_to_revert() {
+        let mut cp = checkpoint(Phase::Pending);
+        cp.commit_sha = None;
+        tag(&mut cp, "api@v1.1.0", "sha-api");
+
+        let out = plan(&cp, &[], true, owner);
+
+        assert!(
+            !out.steps
+                .iter()
+                .any(|s| matches!(s, Step::RevertCommit { .. }))
+        );
+        assert!(
+            out.steps
+                .iter()
+                .any(|s| matches!(s, Step::DeleteTag { .. }))
+        );
+    }
+
+    #[test]
+    fn a_repo_without_a_manifest_does_not_plan_to_restore_one() {
+        let mut cp = checkpoint(Phase::CommitDone);
+        tag(&mut cp, "api@v1.1.0", "sha-api");
+
+        let out = plan(&cp, &[], false, owner);
+
+        assert!(
+            !out.steps.contains(&Step::RestoreManifest),
+            "planning it would fail the run after the tags were already deleted"
+        );
+        assert!(out.steps.contains(&Step::RevertCommit {
+            sha: "commit".to_string()
+        }));
+    }
+
+    #[test]
+    fn a_checkpoint_with_nothing_recorded_plans_nothing() {
+        let out = plan(&checkpoint(Phase::Pending), &[], true, owner);
+        assert!(out.is_empty());
+    }
+}


### PR DESCRIPTION
Closes #804.

`ferrflow rollback` undoes what a partially-failed release did, reading the checkpoint that run left behind rather than reconstructing it from a job log.

```
$ ferrflow rollback
  delete tag v1.1.0 (8845b54)
  revert commit 8845b54

This was a dry run. Re-run with --yes to apply it.
```

Dry run is the default, as the issue asked. `--yes` applies it. Naming packages narrows it.

## The checkpoint had to learn what the run did

#549 recorded enough to resume forward: the phase, the head, the planned tag names. Going backwards needs to know what actually happened, so schema 2 adds three records, all written as the side effects occur:

- `created_tags`, each with the commit sha it pointed at
- `forge_releases`, by id rather than by tag name
- `published`, per package and publisher, with whether that registry can be unpublished

The publish record is written **even when the batch then fails**. A publisher that already pushed to crates.io is a fact rollback must respect, and the run that discovers it is the one that errors out.

Old checkpoints stay loadable: the three fields are `#[serde(default)]`.

## Three refusals, which are the point

**A tag that moved is never deleted.** Each tag is checked against its recorded sha, and a mismatch is reported and skipped. A rollback can happen long after the failure, and a tag someone else recreated is not ours.

**An immutable publish blocks its package.** crates.io and PyPI keep every version forever and npm refuses to republish an unpublished one, so deleting the tag would strand a version the world can still install. `PublisherConfig::is_immutable_publish` draws that line; docker, helm, release assets and webhooks are replaceable and block nothing. A monorepo where one package published and three did not rolls back the three and refuses the one, rather than doing half of each.

**The commit is reverted only on a whole-run rollback with nothing blocked.** It carries every package's bump, so reverting it while one package stays released would silently undo that package's version too.

## Shape

`src/rollback/plan.rs` decides everything from the checkpoint and returns a list of steps. It touches nothing, so `--dry-run` and the real run print the same list by construction rather than by two code paths agreeing. `src/rollback/mod.rs` executes them. New git helpers `delete_tag_if_unchanged` and `revert_commit`, and `Forge::delete_release`, defaulted so a forge that cannot do it says so instead of silently reporting success.

## Tests

Nine on the planner, covering the issue's three scenarios plus the narrowing, the blocked-package interaction with the commit revert, and a mutable publish not blocking.

Four on the destructive helpers against real repositories with a bare remote: a tag whose sha no longer matches survives, one that still matches goes from both local and remote, deleting a tag never pushed still succeeds, and the revert actually restores the version file.

1223 bin and 928 lib tests passing, clippy clean, wasm surface builds.

Verified end to end by making a release fail on a `postPublish` hook, then rolling it back: tag gone locally and on the remote, `Cargo.toml` back to `1.0.0`, revert commit on the branch, checkpoint cleared.

## Found while testing

The first end-to-end run failed on the last step because I planned `RestoreManifest` unconditionally, and the repo had no `manifest_file`. It errored *after* deleting the tags and left the checkpoint behind, which is the worst possible ordering. The step is now planned only when a manifest is configured, with a test.

## Deliberately not done

The revert is not pushed. Rollback has just deleted remote refs, and forcing a branch update on top of that is a decision to take with the branch in front of you.

`--to <checkpoint>` from the issue is not implemented: there is only ever one checkpoint file, so it has nothing to select between until checkpoints are kept in history.
