### PR TITLE
fix(release): send a path named by several versionedFiles entries once

### DIFF
--- a/src/monorepo/run/authored_commit.rs
+++ b/src/monorepo/run/authored_commit.rs
@@ -11,8 +11,18 @@ pub(super) fn file_changes(
 ) -> Result<(Vec<FileAddition>, Vec<String>)> {
     let mut additions = Vec::new();
     let mut deletions = Vec::new();
+    let mut seen = std::collections::HashSet::new();
 
+    // The bump loop pushes a path once per versionedFiles entry, and a file
+    // carrying several selectors is a supported shape, so the same path
+    // arrives here more than once. `git add` never minded; the API refuses
+    // the whole commit over it. The contents are read from disk per path, so
+    // the copies are identical and the first one is the file.
     for file in files {
+        if !seen.insert(*file) {
+            continue;
+        }
+
         let path = root.join(file);
         if path.exists() {
             let bytes = std::fs::read(&path).with_context(|| {
@@ -101,6 +111,32 @@ mod tests {
             .unwrap();
 
         assert_eq!(decoded, bytes);
+    }
+
+    // Three selectors on one Chart.yaml is how a Helm chart bumps its
+    // version, appVersion and image line, and the API refuses a commit whose
+    // fileChanges name a path twice. This is the shape that failed LFSX's
+    // v1.5.1 release under v7.9.0.
+    #[test]
+    fn a_path_named_by_several_entries_is_sent_once() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("Chart.yaml"), "version: 1.2.3").unwrap();
+
+        let (additions, deletions) = file_changes(
+            dir.path(),
+            &[
+                "Chart.yaml",
+                "Chart.yaml",
+                "Chart.yaml",
+                "gone.txt",
+                "gone.txt",
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(additions.len(), 1);
+        assert_eq!(additions[0].path, "Chart.yaml");
+        assert_eq!(deletions, vec!["gone.txt".to_string()]);
     }
 
     #[test]


### PR DESCRIPTION
Closes #950.

Since #941 the release commit goes through `createCommitOnBranch`, and that API refuses a commit whose `fileChanges` name a path twice. A package whose `versionedFiles` carry several entries for one file, one per selector, produces exactly that: the bump loop pushes the path once per entry, `git add` never minded, and the mutation refuses the whole release.

This is not a corner case. Several selectors on one file is the documented way a Helm chart bumps `version`, `appVersion` and its image line in one `Chart.yaml`. LFSX releases that way, shipped v1.5.0 under v7.7.1 on 08-25, and failed its next release under v7.9.0 with `E3014` (run 33122158943 vs 33148431181; the only relevant delta between those two runs is the FerrFlow pin).

## The fix

`file_changes` deduplicates, keeping the first occurrence. It is the one place that feeds the API requiring uniqueness, so it covers both call sites and any future one, rather than trusting every producer of the files list. The contents are read from disk per path, so duplicates are byte-identical and dropping the copies loses nothing. Deletions get the same guard: a path listed twice that is gone from disk was two deletions.

The bump loop keeps pushing per entry. `refresh_lockfiles` beside it already guards its own pushes with a `handled` set, and collapsing the producer as well would just hide the invariant the API boundary now owns.

## Verified

The new test sends `Chart.yaml` three times and a missing file twice, and asserts one addition and one deletion. Without the guard it fails with `left: 3, right: 1`; with it, it passes. Full suite: 2156 tests green, clippy clean.

## After this merges

The reusable release workflow in `.github` pins FerrFlow by SHA (`7477600 # v7.9.0`), so consumers pick this up once that pin bumps to the release this PR ships in. LFSX's failed v1.5.1 release then just needs its Release run re-run.
