### PR TITLE
ci: fix the double-encoded dash in the fixture job names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
           retention-days: 1
 
   fixture-monorepo:
-    name: Fixtures â€” Monorepo
+    name: Fixtures — Monorepo
     needs: [build, fixture-generate]
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -160,7 +160,7 @@ jobs:
           if-no-files-found: ignore
 
   fixture-single:
-    name: Fixtures â€” Single Package
+    name: Fixtures — Single Package
     needs: [build, fixture-generate]
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -196,7 +196,7 @@ jobs:
           if-no-files-found: ignore
 
   fixture-config:
-    name: Fixtures â€” Config & Formats
+    name: Fixtures — Config & Formats
     needs: [build, fixture-generate]
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -232,7 +232,7 @@ jobs:
           if-no-files-found: ignore
 
   fixture-advanced:
-    name: Fixtures â€” Advanced Features
+    name: Fixtures — Advanced Features
     needs: [build, fixture-generate]
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -274,7 +274,7 @@ jobs:
   # Compile the bench binary ONCE per PR and hand it to the matrix shards
   # below. Before this split, every shard ran `cargo bench` with its own
   # cold rust-cache (all 11 shards start in parallel and share a key, so
-  # nobody hits a sibling's cache), paying the ~5â€“7 min build cost 11
+  # nobody hits a sibling's cache), paying the ~5-7 min build cost 11
   # times. With a pre-built binary the matrix only does the actual
   # measurement step. See FerrLabs/FerrFlow#397.
   micro-bench-build:
@@ -345,7 +345,7 @@ jobs:
         # Mirrors what FerrLabs/Benchmarks@v3 used to do for the micro
         # path: invoke the bench binary directly with the criterion
         # positional filter, capture bencher-format stdout, and keep
-        # only the well-formed `test â€¦ bench: â€¦` rows so the aggregate
+        # only the well-formed `test ... bench: ...` rows so the aggregate
         # job's benchmark-action consumer doesn't choke on noise.
         # The bench binary's fixtures are all in-process (tempdir +
         # libgit2), so no checkout is needed in this job.
@@ -358,7 +358,7 @@ jobs:
           bench_exit=${PIPESTATUS[0]}
           set -e
           if [ "$bench_exit" != "0" ]; then
-            echo "::warning::bench binary exited ${bench_exit} â€” tolerating as long as rows were captured. Stderr tail:"
+            echo "::warning::bench binary exited ${bench_exit} — tolerating as long as rows were captured. Stderr tail:"
             tail -40 bench-stderr.log || true
           fi
           grep -E '^test .+ \.\.\. bench:[[:space:]]+[0-9,]+ ns/iter' raw-output.txt > output.txt || true
@@ -586,7 +586,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-          # Don't bake GITHUB_TOKEN into the git remote â€” ferrflow's OIDC
+          # Don't bake GITHUB_TOKEN into the git remote — ferrflow's OIDC
           # exchange yields an App installation token that authenticates as
           # ferrflow[bot]. Without this, every git push silently reverts
           # to GITHUB_TOKEN (i.e. github-actions[bot]) which isn't in the


### PR DESCRIPTION
The four fixture jobs were named with the cp1252 reading of an em dash rather than the character itself, so GitHub reported checks called `Fixtures â€” Monorepo` and the ruleset on `main` had to carry the same broken sequence to match them. The pairing held only as long as nobody typed a real em dash on either side.

The job names now use `U+2014`, and the four required contexts on `main` have been rewritten to match. The checks on this pull request report under the new names, so it validates the pairing on the way in.

Two comments in the same file carried the same double-encoding (an en dash and two ellipses) and are fixed alongside.

Closes #952
