### PR TITLE
fix(git): ask ls-remote for the peeled ref so annotated tags resolve to their commit

### DIFF
--- a/src/git/push.rs
+++ b/src/git/push.rs
@@ -57,6 +57,11 @@ pub(super) fn remote_tag_target_shas(
     cmd.arg("ls-remote").arg("--tags").arg(push_url);
     for tag in tags {
         cmd.arg(format!("refs/tags/{tag}"));
+        // Without this second refspec, `refs/tags/<tag>^{}` never comes back and
+        // an annotated tag resolves to its tag object instead of the commit it
+        // points at. Callers compare against peeled local shas, so every
+        // annotated tag would look like it moved. See #949.
+        cmd.arg(format!("refs/tags/{tag}^{{}}"));
     }
     let output = cmd
         .output()

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -1,5 +1,5 @@
 use super::auth::{configure_git_command, extract_url_password, server_config_url, token_for_url};
-use super::push::{local_tag_target_sha, parse_ls_remote_tags};
+use super::push::{local_tag_target_sha, parse_ls_remote_tags, remote_tag_target_shas};
 use super::repo::Repository;
 use super::retry::{is_transient_git_error, retry_transient};
 use super::tags::{find_highest_semver_tag, find_last_tag, is_floating_tag, is_prerelease_tag};
@@ -1891,4 +1891,109 @@ fn reverting_the_release_commit_undoes_its_changes() {
     );
     let head_subject = git(&local, &["log", "-1", "--format=%s"]);
     assert!(head_subject.starts_with("Revert"), "{head_subject}");
+}
+
+/// Local clone plus a bare remote, the only shape where a peeled sha can differ
+/// from an unpeeled one.
+fn repo_and_remote(dir: &Path) -> (PathBuf, PathBuf) {
+    let remote = dir.join("remote.git");
+    std::fs::create_dir_all(&remote).unwrap();
+    git(&remote, &["init", "--bare", "-b", "main"]);
+
+    let local = dir.join("local");
+    std::fs::create_dir_all(&local).unwrap();
+    init_repo_at(&local);
+    git(
+        &local,
+        &["remote", "add", "origin", remote.to_str().unwrap()],
+    );
+    commit_file_at(&local, "a.txt", "feat: first");
+    git(&local, &["push", "origin", "main:main"]);
+    (local, remote)
+}
+
+#[test]
+fn remote_tag_shas_peel_an_annotated_tag_to_its_commit() {
+    let dir = tempfile::tempdir().unwrap();
+    let (local, remote) = repo_and_remote(dir.path());
+    git(&local, &["tag", "-a", "v1.0.0", "-m", "Release v1.0.0"]);
+    git(&local, &["push", "origin", "v1.0.0"]);
+
+    let repo = open_repo(&local).unwrap();
+    let commit = local_tag_target_sha(&repo, "v1.0.0").unwrap();
+    let tag_object = git(&local, &["rev-parse", "refs/tags/v1.0.0"])
+        .trim()
+        .to_string();
+    assert_ne!(
+        commit, tag_object,
+        "precondition: an annotated tag's object is not its commit"
+    );
+
+    let shas = remote_tag_target_shas(&local, remote.to_str().unwrap(), &["v1.0.0"]).unwrap();
+
+    assert_eq!(
+        shas.get("v1.0.0").map(String::as_str),
+        Some(commit.as_str()),
+        "the remote sha must be the commit, not the tag object"
+    );
+}
+
+#[test]
+fn pushing_an_annotated_tag_already_on_the_remote_is_a_no_op() {
+    // FerrFlow creates annotated tags, so this is the ordinary case. Comparing
+    // a peeled local sha against an unpeeled remote one made it look diverged
+    // and failed the push with a message about a commit difference that was not
+    // there. See #949.
+    let dir = tempfile::tempdir().unwrap();
+    let (local, _remote) = repo_and_remote(dir.path());
+    git(&local, &["tag", "-a", "v1.0.0", "-m", "Release v1.0.0"]);
+    git(&local, &["push", "origin", "v1.0.0"]);
+
+    let repo = open_repo(&local).unwrap();
+
+    push_tags(&repo, "origin", &["v1.0.0"])
+        .expect("re-pushing the same annotated tag must succeed");
+}
+
+#[test]
+fn a_lightweight_tag_already_on_the_remote_is_still_a_no_op() {
+    let dir = tempfile::tempdir().unwrap();
+    let (local, _remote) = repo_and_remote(dir.path());
+    git(&local, &["tag", "v1.0.0"]);
+    git(&local, &["push", "origin", "v1.0.0"]);
+
+    let repo = open_repo(&local).unwrap();
+
+    push_tags(&repo, "origin", &["v1.0.0"])
+        .expect("the case that already worked must keep working");
+}
+
+#[test]
+fn an_annotated_tag_the_remote_holds_at_another_commit_is_still_rejected() {
+    // The fix must not turn the divergence check off: a tag the remote really
+    // does hold elsewhere has to keep failing the push.
+    let dir = tempfile::tempdir().unwrap();
+    let (local, remote) = repo_and_remote(dir.path());
+
+    let other = dir.path().join("other");
+    std::fs::create_dir_all(&other).unwrap();
+    init_repo_at(&other);
+    git(
+        &other,
+        &["remote", "add", "origin", remote.to_str().unwrap()],
+    );
+    commit_file_at(&other, "b.txt", "feat: theirs");
+    git(&other, &["tag", "-a", "v1.0.0", "-m", "Theirs"]);
+    git(&other, &["push", "origin", "v1.0.0"]);
+
+    git(&local, &["tag", "-a", "v1.0.0", "-m", "Ours"]);
+    let repo = open_repo(&local).unwrap();
+
+    let err = push_tags(&repo, "origin", &["v1.0.0"])
+        .expect_err("a genuinely divergent tag must still be refused");
+    let rendered = format!("{err:#}");
+    assert!(
+        rendered.contains("already exist on remote"),
+        "expected the divergence error, got {rendered}"
+    );
 }


### PR DESCRIPTION
Closes #949.

`remote_tag_target_shas` asked `ls-remote` for `refs/tags/<tag>` only. That refspec does not match `refs/tags/<tag>^{}`, so the peeled entry never came back, `parse_ls_remote_tags` had nothing to dereference with, and an annotated tag resolved to its tag object. Callers compare that against `local_tag_target_sha`, which peels, so every annotated tag looked like it had moved.

FerrFlow creates annotated tags, so this was the ordinary case.

Before, pushing the same tag twice against the same remote at the same commit:

```
ANNOTATED:   E2006: Tag(s) already exist on remote pointing to a different commit:
             v1.0.0 (local ebf8a82 != remote ffed861)
LIGHTWEIGHT: Ok
```

`ebf8a82` is the commit, `ffed861` is the annotated tag object. Same tag, same commit, and a message claiming a difference that was not there while telling the reader to delete a healthy tag.

## Fix

One extra refspec per tag, so `ls-remote` returns the peeled ref alongside the tag ref:

```rust
cmd.arg(format!("refs/tags/{tag}"));
cmd.arg(format!("refs/tags/{tag}^{{}}"));
```

Verified this is the form git accepts, against a real bare remote:

```
$ git ls-remote --tags <url> 'refs/tags/v1.0.0'
2e96f1c  refs/tags/v1.0.0

$ git ls-remote --tags <url> 'refs/tags/v1.0.0' 'refs/tags/v1.0.0^{}'
2e96f1c  refs/tags/v1.0.0
935a1ce  refs/tags/v1.0.0^{}
```

Fixed in `remote_tag_target_shas` rather than in its caller, so `shell_push_tags` and `force_push_tags` both get it, and `parse_ls_remote_tags` finally receives the input its dereferencing logic was written for. A `<tag>*` glob would also work but over-matches: `v1.0.0*` picks up `v1.0.0-beta.1` too.

## Tests

Four, against real repositories with a bare remote.

- `remote_tag_target_shas` returns the commit for an annotated tag, asserting first that the tag object and the commit actually differ so the test cannot pass vacuously
- re-pushing an annotated tag already on the remote is a no-op
- re-pushing a lightweight one still is, since that path already worked and must not regress
- a tag the remote genuinely holds at another commit is still refused, so the fix does not quietly disable the divergence check

Verified against the old refspec: the two annotated cases fail, the lightweight and genuine-divergence cases pass. That split is the point, since every pre-existing test in this area used `git tag <name>` and therefore lightweight tags, where the tag object *is* the commit. That is exactly why this survived.

1230 bin and 934 lib tests passing, clippy clean, wasm surface builds.

## Interaction with #946

#946 hit the same bug in `delete_tag_if_unchanged` and worked around it locally by passing a `<tag>*` pattern. Once this merges that workaround is redundant and can be simplified to a plain tag name. Harmless if it lands first: the glob still matches. I will tidy it there rather than touching that branch from here.
