### PR TITLE
fix(publishers): report the crate name from Cargo.toml, not the ferrflow name

### DIFF
--- a/src/publishers/cargo.rs
+++ b/src/publishers/cargo.rs
@@ -67,7 +67,7 @@ pub fn run(
 
         if output.status.success() {
             return Ok(PublishOutcome::Published {
-                url: derive_crate_url(ctx.package_name, ctx.new_version, registry),
+                url: derive_crate_url(&published_name(ctx), ctx.new_version, registry),
             });
         }
 
@@ -75,7 +75,9 @@ pub fn run(
             return Ok(PublishOutcome::Skipped {
                 reason: format!(
                     "{}@{} already exists on {}",
-                    ctx.package_name, ctx.new_version, registry_label
+                    published_name(ctx),
+                    ctx.new_version,
+                    registry_label
                 ),
             });
         }
@@ -156,6 +158,30 @@ fn first_meaningful_line(stderr: &str, stdout: &str) -> String {
         .rfind(|l| !l.trim().is_empty())
         .unwrap_or("(no output)")
         .to_string()
+}
+
+/// The crate name cargo publishes under, which is `[package].name` in the
+/// manifest and not the FerrFlow package name.
+///
+/// A workspace routinely uses short FerrFlow names against prefixed crate names
+/// (`bridge` for `idlewarden-bridge`), and short crate names are long since
+/// taken on crates.io, so the wrong one links a stranger's crate rather than
+/// 404ing. Falls back to the FerrFlow name when the manifest cannot be read or
+/// carries no `[package]` table, which is no worse than what it replaces.
+fn published_name(ctx: &PublishContext<'_>) -> String {
+    std::fs::read_to_string(ctx.package_path.join("Cargo.toml"))
+        .ok()
+        .and_then(|raw| raw.parse::<toml_edit::DocumentMut>().ok())
+        .and_then(|doc| {
+            // `doc["package"]` panics with "index not found" when the manifest
+            // has no [package] table, which is exactly what a workspace root
+            // looks like. Index by get() so that falls back instead.
+            doc.get("package")?
+                .get("name")?
+                .as_str()
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| ctx.package_name.to_string())
 }
 
 fn derive_crate_url(name: &str, version: &str, registry: Option<&str>) -> Option<String> {
@@ -288,5 +314,102 @@ mod tests {
             Some("https://crates.io/crates/foo/1.0.0")
         );
         assert_eq!(derive_crate_url("foo", "1.0.0", Some("kellnr")), None);
+    }
+
+    fn ctx_at<'a>(
+        registries: &'a BTreeMap<String, RegistryConfig>,
+        package_path: &'a std::path::Path,
+        ferrflow_name: &'a str,
+    ) -> PublishContext<'a> {
+        PublishContext {
+            package_name: ferrflow_name,
+            package_path,
+            new_version: "26.8.27",
+            tag: "v26.8.27",
+            registries,
+            dry_run: false,
+            verbose: false,
+        }
+    }
+
+    #[test]
+    fn the_published_name_comes_from_the_manifest_not_the_ferrflow_name() {
+        // The shape from #948: short FerrFlow names against prefixed crates.
+        // `crates.io/crates/bridge` is a real, unrelated crate, so the wrong
+        // name links somebody else's project rather than 404ing.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"idlewarden-bridge\"\nversion = \"26.8.27\"\n",
+        )
+        .unwrap();
+        let registries = BTreeMap::new();
+
+        let name = published_name(&ctx_at(&registries, dir.path(), "bridge"));
+
+        assert_eq!(name, "idlewarden-bridge");
+    }
+
+    #[test]
+    fn a_manifest_with_no_package_table_falls_back_instead_of_panicking() {
+        // A workspace root manifest has [workspace] and no [package]. toml_edit
+        // indexing a missing key must not bring the publish down.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"crates/*\"]\n",
+        )
+        .unwrap();
+        let registries = BTreeMap::new();
+
+        let name = published_name(&ctx_at(&registries, dir.path(), "bridge"));
+
+        assert_eq!(name, "bridge");
+    }
+
+    #[test]
+    fn an_absent_manifest_falls_back_to_the_ferrflow_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let registries = BTreeMap::new();
+
+        let name = published_name(&ctx_at(&registries, dir.path(), "bridge"));
+
+        assert_eq!(
+            name, "bridge",
+            "no manifest is no worse than before, so it must not fail the publish"
+        );
+    }
+
+    #[test]
+    fn an_unparseable_manifest_falls_back_too() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("Cargo.toml"), "[package\nname = broken").unwrap();
+        let registries = BTreeMap::new();
+
+        let name = published_name(&ctx_at(&registries, dir.path(), "bridge"));
+
+        assert_eq!(name, "bridge");
+    }
+
+    #[test]
+    fn a_matching_name_is_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"ferrflow\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        let registries = BTreeMap::new();
+
+        let name = published_name(&ctx_at(&registries, dir.path(), "ferrflow"));
+
+        assert_eq!(name, "ferrflow");
+    }
+
+    #[test]
+    fn the_crate_url_uses_the_manifest_name() {
+        let url = derive_crate_url("idlewarden-bridge", "26.8.27", None).unwrap();
+
+        assert_eq!(url, "https://crates.io/crates/idlewarden-bridge/26.8.27");
     }
 }


### PR DESCRIPTION
Closes #948. Symmetric to #961, which fixed the same defect in the npm publisher.

The cargo publisher built its success URL from the FerrFlow package name rather than the crate name. `published_name` now reads `[package].name` from the package's `Cargo.toml`, falling back to the FerrFlow name when the manifest cannot be read.

The upload was never wrong: `cargo publish` runs in the package directory and cargo reads the manifest itself. Only the printed link was.

Using the issue's own case, `bridge` against `idlewarden-bridge`, the link goes from `crates.io/crates/bridge/26.8.27`, a real and unrelated crate, to `crates.io/crates/idlewarden-bridge/26.8.27`.

## A panic the tests caught

The obvious implementation is `doc["package"]["name"]`, mirroring how the config code indexes TOML. It compiles, passes the happy path, and **panics** on a manifest with no `[package]` table:

```
a_manifest_with_no_package_table_falls_back_instead_of_panicking ... FAILED
panicked at src/publishers/cargo.rs:175:28: index not found
```

That is what a workspace root manifest looks like, so this would have turned a cosmetic wrong link into a crash during publish. Now indexed with `get()` so it falls back instead. I wrote that test because the panic was a suspicion rather than something I had seen, which turned out to be worth the five minutes.

The npm side has no equivalent risk: `serde_json::Value::get` is already fallible.

## Consistent with #961

Same split on the surrounding messages, for the same reason:

- the success URL and the `"{name}@{version} already exists on {registry}"` line use the crate name, because both make a claim about what is on the registry
- the spawn failure, the transient-retry warning and the final error keep the FerrFlow name, because they identify which of *your* packages is involved and that is what you would grep your config for

## Tests

Six: the issue's case, the workspace-root panic above, an absent manifest, an unparseable one, the already-correct case where both names match, and the URL shape itself.

Verified the main one fails against the old behaviour:

```
left: "bridge"
right: "idlewarden-bridge"
```

1241 bin and 945 lib tests passing, clippy clean, wasm surface builds.
