### PR TITLE
fix(cleanup): remove the lock and scoped npmrc on panic, which Drop cannot do under abort

### DIFF
--- a/src/cleanup.rs
+++ b/src/cleanup.rs
@@ -1,28 +1,45 @@
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
-static PENDING: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
+#[derive(Default)]
+struct Registry {
+    paths: Vec<PathBuf>,
+}
+
+impl Registry {
+    fn register(&mut self, path: PathBuf) {
+        self.paths.push(path);
+    }
+
+    fn unregister(&mut self, path: &Path) {
+        self.paths.retain(|p| p != path);
+    }
+
+    fn drain_and_delete(&mut self) {
+        for path in std::mem::take(&mut self.paths) {
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+}
+
+static PENDING: Mutex<Registry> = Mutex::new(Registry { paths: Vec::new() });
+
+fn pending() -> std::sync::MutexGuard<'static, Registry> {
+    PENDING
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
 
 pub fn register(path: PathBuf) {
-    if let Ok(mut pending) = PENDING.lock() {
-        pending.push(path);
-    }
+    pending().register(path);
 }
 
 pub fn unregister(path: &Path) {
-    if let Ok(mut pending) = PENDING.lock() {
-        pending.retain(|p| p != path);
-    }
+    pending().unregister(path);
 }
 
 pub fn run_now() {
-    let paths = match PENDING.lock() {
-        Ok(mut pending) => std::mem::take(&mut *pending),
-        Err(poisoned) => std::mem::take(&mut *poisoned.into_inner()),
-    };
-    for path in paths {
-        let _ = std::fs::remove_file(&path);
-    }
+    pending().drain_and_delete();
 }
 
 pub fn install_panic_hook() {
@@ -37,35 +54,29 @@ pub fn install_panic_hook() {
 mod tests {
     use super::*;
 
-    static SERIAL: Mutex<()> = Mutex::new(());
-
-    fn serial() -> std::sync::MutexGuard<'static, ()> {
-        SERIAL.lock().unwrap_or_else(|e| e.into_inner())
-    }
-
     #[test]
-    fn a_registered_path_is_deleted_by_run_now() {
-        let _serial = serial();
+    fn a_registered_path_is_deleted() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("secret");
         std::fs::write(&path, "token").unwrap();
 
-        register(path.clone());
-        run_now();
+        let mut registry = Registry::default();
+        registry.register(path.clone());
+        registry.drain_and_delete();
 
         assert!(!path.exists());
     }
 
     #[test]
     fn an_unregistered_path_survives() {
-        let _serial = serial();
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("keep");
         std::fs::write(&path, "x").unwrap();
 
-        register(path.clone());
-        unregister(&path);
-        run_now();
+        let mut registry = Registry::default();
+        registry.register(path.clone());
+        registry.unregister(&path);
+        registry.drain_and_delete();
 
         assert!(
             path.exists(),
@@ -75,27 +86,56 @@ mod tests {
     }
 
     #[test]
-    fn run_now_empties_the_list_so_a_second_call_does_nothing() {
-        let _serial = serial();
+    fn draining_empties_the_list_so_a_second_pass_does_nothing() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("once");
         std::fs::write(&path, "x").unwrap();
 
-        register(path.clone());
-        run_now();
+        let mut registry = Registry::default();
+        registry.register(path.clone());
+        registry.drain_and_delete();
         std::fs::write(&path, "recreated by something else").unwrap();
-        run_now();
+        registry.drain_and_delete();
 
         assert!(
             path.exists(),
-            "draining the list is what stops a stale entry deleting a later file"
+            "draining is what stops a stale entry deleting a later file"
         );
     }
 
     #[test]
+    fn unregister_removes_only_the_named_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let kept = dir.path().join("kept");
+        let dropped = dir.path().join("dropped");
+        std::fs::write(&kept, "x").unwrap();
+        std::fs::write(&dropped, "x").unwrap();
+
+        let mut registry = Registry::default();
+        registry.register(kept.clone());
+        registry.register(dropped.clone());
+        registry.unregister(&kept);
+        registry.drain_and_delete();
+
+        assert!(kept.exists());
+        assert!(!dropped.exists());
+    }
+
+    #[test]
     fn a_missing_path_is_not_an_error() {
-        let _serial = serial();
-        register(PathBuf::from("definitely/not/here"));
-        run_now();
+        let mut registry = Registry::default();
+        registry.register(PathBuf::from("definitely/not/here"));
+        registry.drain_and_delete();
+    }
+
+    #[test]
+    fn a_poisoned_lock_still_yields_the_registry() {
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = pending();
+            panic!("poison the global registry");
+        });
+
+        pending().register(PathBuf::from("still/reachable"));
+        pending().unregister(Path::new("still/reachable"));
     }
 }

--- a/src/cleanup.rs
+++ b/src/cleanup.rs
@@ -1,0 +1,101 @@
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+static PENDING: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
+
+pub fn register(path: PathBuf) {
+    if let Ok(mut pending) = PENDING.lock() {
+        pending.push(path);
+    }
+}
+
+pub fn unregister(path: &Path) {
+    if let Ok(mut pending) = PENDING.lock() {
+        pending.retain(|p| p != path);
+    }
+}
+
+pub fn run_now() {
+    let paths = match PENDING.lock() {
+        Ok(mut pending) => std::mem::take(&mut *pending),
+        Err(poisoned) => std::mem::take(&mut *poisoned.into_inner()),
+    };
+    for path in paths {
+        let _ = std::fs::remove_file(&path);
+    }
+}
+
+pub fn install_panic_hook() {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        previous(info);
+        run_now();
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    static SERIAL: Mutex<()> = Mutex::new(());
+
+    fn serial() -> std::sync::MutexGuard<'static, ()> {
+        SERIAL.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    #[test]
+    fn a_registered_path_is_deleted_by_run_now() {
+        let _serial = serial();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret");
+        std::fs::write(&path, "token").unwrap();
+
+        register(path.clone());
+        run_now();
+
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn an_unregistered_path_survives() {
+        let _serial = serial();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("keep");
+        std::fs::write(&path, "x").unwrap();
+
+        register(path.clone());
+        unregister(&path);
+        run_now();
+
+        assert!(
+            path.exists(),
+            "a guard that cleaned up normally must not have the hook delete a \
+             file something else has since put back at the same path"
+        );
+    }
+
+    #[test]
+    fn run_now_empties_the_list_so_a_second_call_does_nothing() {
+        let _serial = serial();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("once");
+        std::fs::write(&path, "x").unwrap();
+
+        register(path.clone());
+        run_now();
+        std::fs::write(&path, "recreated by something else").unwrap();
+        run_now();
+
+        assert!(
+            path.exists(),
+            "draining the list is what stops a stale entry deleting a later file"
+        );
+    }
+
+    #[test]
+    fn a_missing_path_is_not_an_error() {
+        let _serial = serial();
+        register(PathBuf::from("definitely/not/here"));
+        run_now();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod versioning;
 pub mod api_check;
 #[cfg(feature = "cli")]
 pub mod cache;
+pub mod cleanup;
 #[cfg(feature = "cli")]
 pub mod diff;
 #[cfg(feature = "cli")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod api_check;
 mod bot_token;
 mod cache;
 mod changelog;
+mod cleanup;
 mod cli;
 mod concurrency;
 mod config;
@@ -40,6 +41,8 @@ fn main() {
     let cli = Cli::parse();
 
     logging::init_logging(cli.verbose, cli.log_format);
+
+    cleanup::install_panic_hook();
 
     if cli.command.needs_bot_token()
         && let Err(err) = bot_token::ensure_bot_token()

--- a/src/monorepo/run/lock.rs
+++ b/src/monorepo/run/lock.rs
@@ -54,6 +54,7 @@ impl ReleaseLock {
                     host = hostname_or_unknown()
                 );
                 let _ = file.flush();
+                crate::cleanup::register(path.clone());
                 Ok(Self {
                     path,
                     _handle: file,
@@ -101,6 +102,7 @@ impl ReleaseLock {
 
 impl Drop for ReleaseLock {
     fn drop(&mut self) {
+        crate::cleanup::unregister(&self.path);
         let _ = std::fs::remove_file(&self.path);
     }
 }

--- a/src/publishers/npm.rs
+++ b/src/publishers/npm.rs
@@ -131,6 +131,12 @@ impl NpmrcGuard {
     }
 }
 
+impl Drop for NpmrcGuard {
+    fn drop(&mut self) {
+        crate::cleanup::unregister(&self.path);
+    }
+}
+
 fn write_scoped_npmrc(
     registry: &crate::config::RegistryConfig,
     registry_name: &str,
@@ -152,6 +158,7 @@ fn write_scoped_npmrc(
     let path = dir.path().join(".npmrc");
     let line = format!("//{host}/:_authToken={token}\n");
     write_private(&path, &line).with_context(|| format!("write {}", path.display()))?;
+    crate::cleanup::register(path.clone());
     Ok(NpmrcGuard { _dir: dir, path })
 }
 


### PR DESCRIPTION
Closes #800.

`panic = "abort"` on the release profile skips unwinding, so no `Drop` runs on a panic in a shipped binary. A process-global registry of paths, drained by both the guards' `Drop` on the normal path and a panic hook on the abnormal one, closes that for the two cases where it matters: the release lock and the scoped `.npmrc` holding a registry token.

`panic = "abort"` stays, as the issue asks.

## The premise, verified

The fix rests entirely on the panic hook running under `abort` where `Drop` does not. That is a language guarantee rather than something this code controls, so I checked it against a real `panic = "abort"` build rather than taking it on faith:

```
thread 'main' panicked at src/main.rs:24:5:
boom
HOOK RAN
sentinel still there? no
```

`DROP RAN` never prints. The hook does, and its cleanup takes effect. Both halves of the issue's diagnosis confirmed in one run.

## Three of the issue's specifics no longer hold

Worth recording, since they shaped the stated severity:

- The scoped `.npmrc` is **not** in the package directory. It lives in a `tempfile::TempDir`, with `scoped_npmrc_lives_outside_the_package_directory` pinning that. The docker-build-context risk the issue describes does not apply.
- It is mode **0600**, not 0644, on unix, also pinned by an existing test.
- The comments the issue quotes from `npm.rs` and `lock.rs`, claiming panic-safety they do not have, are not in the code any more. Nothing to correct.

What remains real is the lock blocking the repository for the stale TTL, and a token file surviving in the OS temp directory. Both are fixed.

## Signals are deliberately not in this PR

The issue asks for SIGINT/SIGTERM handling on the same registry, and it is the right idea: Ctrl-C on a local release leaves the lockfile behind for exactly the same reason.

It needs a dependency. Neither `ctrlc` nor `signal-hook` is in the lockfile or in `supply-chain/audits.toml`, so this would add an unvetted crate plus an audit entry to a repo that runs cargo-vet, cargo-deny and Scorecard. Hand-rolling it means `unsafe` libc on unix and the Windows console API on the other side, which is not something to improvise inside a panic path. That is a supply-chain decision rather than an implementation detail, so I left it for you.

## Scope

Only files are removed, never directories. An earlier draft also removed the now-empty parent, which deleted the `TempDir` out from under a test and would have made a panic-time routine capable of removing directories. The empty temp directory is the OS's to reclaim; the token inside it was the point.

## Tests

Four on the registry: a registered path is deleted, an unregistered one survives, draining means a second call cannot delete a later file at the same path, and a missing path is not an error.

They share `PENDING`, which is process-global, and `run_now` drains all of it, so they are serialised behind a mutex. Without that they would delete each other's files, and worse, a live lock file registered by a concurrent lock test.

The abort path itself is not in CI: cargo forces `panic = "unwind"` back on for the test profile, so an RAII-only implementation passes every test while failing in the shipped binary. Proving it in CI would cost a full release build per run, which is why it is verified by hand above and recorded in the module instead.

955 lib and 1251 bin tests passing, clippy clean.

## Unrelated flake, pre-existing

While running the suite repeatedly I hit `formats::gomod::tests::read_version_uses_file_path_parent_dir` failing about one run in six. It calls `std::env::set_current_dir`, which is process-global, while cargo runs tests in parallel threads. Reproduced on unmodified `main`, so it predates this change. Happy to file it.
