### PR TITLE
feat(versioning): add calver-short-seq and surface a refused release

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ versioning = "calver"  # override: date-based
 | `calver` | `YYYY.M.D` | `2025.3.28` | Date-based, ignores commit types |
 | `calver-short` | `YY.M.D` | `25.3.28` | Compact date-based |
 | `calver-seq` | `YYYY.M.SEQ` | `2025.3.3` | Date + daily sequence counter |
+| `calver-short-seq` | `YY.M.SEQ` | `25.3.3` | Compact date + sequence counter |
 | `sequential` | `N` | `42` | Simple incrementing build number |
 | `zerover` | `0.MINOR.PATCH` | `0.15.2` | Permanently unstable, never hits 1.0 |
 

--- a/schema/ferrflow.json
+++ b/schema/ferrflow.json
@@ -50,6 +50,7 @@
             "calver",
             "calver-short",
             "calver-seq",
+            "calver-short-seq",
             "sequential",
             "zerover"
           ],
@@ -591,6 +592,7 @@
               "calver",
               "calver-short",
               "calver-seq",
+              "calver-short-seq",
               "sequential",
               "zerover"
             ]

--- a/src/config/package.rs
+++ b/src/config/package.rs
@@ -106,6 +106,7 @@ pub enum VersioningStrategy {
     Calver,
     CalverShort,
     CalverSeq,
+    CalverShortSeq,
     Sequential,
     Zerover,
 }

--- a/src/monorepo/run/mod.rs
+++ b/src/monorepo/run/mod.rs
@@ -329,12 +329,16 @@ pub(super) fn run_release_logic(
                             ));
                         }
                     }
-                    SkipReason::VersionUnchanged => {
+                    SkipReason::VersionUnchanged { ref version } => {
                         if !quiet {
-                            tracing::debug!(
-                                "{} {} — version unchanged",
-                                "○".dimmed(),
-                                pkg.name.dimmed()
+                            shared_outputs.push(
+                                format!(
+                                    "{} {} has releasable commits but stays at {version}, so nothing was published",
+                                    "!".yellow().bold(),
+                                    pkg.name.bold()
+                                )
+                                .yellow()
+                                .to_string(),
                             );
                         }
                     }

--- a/src/monorepo/run/plan.rs
+++ b/src/monorepo/run/plan.rs
@@ -23,7 +23,7 @@ pub(super) enum SkipReason {
     NotTouched,
     NoNewCommits,
     NoReleasableCommits,
-    VersionUnchanged,
+    VersionUnchanged { version: String },
     Excluded,
 }
 
@@ -33,7 +33,7 @@ impl SkipReason {
             SkipReason::NotTouched => "not touched",
             SkipReason::NoNewCommits => "no new commits",
             SkipReason::NoReleasableCommits => "no releasable commits",
-            SkipReason::VersionUnchanged => "version unchanged",
+            SkipReason::VersionUnchanged { .. } => "version unchanged",
             SkipReason::Excluded => "excluded",
         }
     }
@@ -335,7 +335,9 @@ pub(super) fn compute_plan(
 
     if current_version == new_version {
         return Ok(PackagePlan::Skipped {
-            reason: SkipReason::VersionUnchanged,
+            reason: SkipReason::VersionUnchanged {
+                version: new_version,
+            },
             recovered,
         });
     }
@@ -372,6 +374,7 @@ fn is_date_or_seq(strategy: VersioningStrategy) -> bool {
         VersioningStrategy::Calver
             | VersioningStrategy::CalverShort
             | VersioningStrategy::CalverSeq
+            | VersioningStrategy::CalverShortSeq
             | VersioningStrategy::Sequential
     )
 }
@@ -384,6 +387,49 @@ mod tests {
     use crate::test_utils::{commit_file, git, init_repo};
     use rayon::prelude::*;
     use std::path::Path;
+
+    #[test]
+    fn every_date_or_sequence_strategy_reports_itself_rather_than_a_bump_type() {
+        for strategy in [
+            VersioningStrategy::Calver,
+            VersioningStrategy::CalverShort,
+            VersioningStrategy::CalverSeq,
+            VersioningStrategy::CalverShortSeq,
+            VersioningStrategy::Sequential,
+        ] {
+            assert!(
+                is_date_or_seq(strategy),
+                "{strategy:?} computes its version from the date or a counter, so the                  output must name the strategy, not a bump type it never used"
+            );
+        }
+        assert!(!is_date_or_seq(VersioningStrategy::Semver));
+        assert!(!is_date_or_seq(VersioningStrategy::Zerover));
+    }
+
+    #[test]
+    fn version_unchanged_carries_the_version_it_recomputed() {
+        let reason = SkipReason::VersionUnchanged {
+            version: "26.8.28".to_string(),
+        };
+
+        assert_eq!(reason.json_label(), "version unchanged");
+        match reason {
+            SkipReason::VersionUnchanged { version } => assert_eq!(version, "26.8.28"),
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn version_unchanged_is_distinct_from_having_nothing_to_release() {
+        assert_ne!(
+            SkipReason::VersionUnchanged {
+                version: "26.8.28".to_string()
+            }
+            .json_label(),
+            SkipReason::NoReleasableCommits.json_label(),
+            "the two must stay tellable apart: one is idle, the other is work held back"
+        );
+    }
 
     fn write_pkg(dir: &Path, name: &str, version: &str) {
         std::fs::create_dir_all(dir.join(name)).unwrap();

--- a/src/versioning/mod.rs
+++ b/src/versioning/mod.rs
@@ -16,7 +16,7 @@ pub fn bootstrap_version(strategy: VersioningStrategy) -> String {
     match strategy {
         VersioningStrategy::Semver | VersioningStrategy::Zerover => "0.0.0".to_string(),
         VersioningStrategy::Sequential => "0".to_string(),
-        VersioningStrategy::CalverSeq => "0.0".to_string(),
+        VersioningStrategy::CalverSeq | VersioningStrategy::CalverShortSeq => "0.0".to_string(),
         VersioningStrategy::Calver | VersioningStrategy::CalverShort => "0.0.0".to_string(),
     }
 }
@@ -34,7 +34,8 @@ pub fn compute_next_version(
         VersioningStrategy::Semver => bump_semver(current, bump),
         VersioningStrategy::Calver => calver_version("%Y.%m.%d"),
         VersioningStrategy::CalverShort => calver_version("short"),
-        VersioningStrategy::CalverSeq => calver_seq_version(current),
+        VersioningStrategy::CalverSeq => calver_seq_version(current, "%Y"),
+        VersioningStrategy::CalverShortSeq => calver_seq_version(current, "%y"),
         VersioningStrategy::Sequential => bump_sequential(current),
         VersioningStrategy::Zerover => bump_zerover(current, bump),
     }

--- a/src/versioning/strategies.rs
+++ b/src/versioning/strategies.rs
@@ -46,9 +46,9 @@ pub(super) fn calver_version(format: &str) -> Result<String> {
     }
 }
 
-pub(super) fn calver_seq_version(current: &str) -> Result<String> {
+pub(super) fn calver_seq_version(current: &str, year_format: &str) -> Result<String> {
     let now = Utc::now();
-    let year_month = format!("{}.{}", now.format("%Y"), now.format("%-m"));
+    let year_month = format!("{}.{}", now.format(year_format), now.format("%-m"));
 
     let seq = if current.starts_with(&year_month) {
         let parts: Vec<&str> = current.splitn(3, '.').collect();

--- a/src/versioning/tests.rs
+++ b/src/versioning/tests.rs
@@ -609,8 +609,6 @@ fn calver_short_seq_can_publish_more_than_once_a_day() {
 
 #[test]
 fn migrating_from_calver_short_continues_from_the_day_number() {
-    // The point of the short variant: a repo on YY.M.D whose last release was
-    // the 28th gets 29 next, so the switch costs no version discontinuity.
     let now = chrono::Utc::now();
     let last_short = format!("{}.{}.28", now.format("%y"), now.format("%-m"));
 

--- a/src/versioning/tests.rs
+++ b/src/versioning/tests.rs
@@ -110,7 +110,7 @@ fn test_calver_short_format() {
 
 #[test]
 fn test_calver_seq_new_month() {
-    let v = calver_seq_version("2024.1.5").unwrap();
+    let v = calver_seq_version("2024.1.5", "%Y").unwrap();
     let parts: Vec<&str> = v.split('.').collect();
     assert_eq!(parts.len(), 3);
     assert_eq!(parts[2], "1");
@@ -120,7 +120,7 @@ fn test_calver_seq_new_month() {
 fn test_calver_seq_same_month() {
     let now = chrono::Utc::now();
     let current = format!("{}.{}.3", now.format("%Y"), now.format("%-m"));
-    let v = calver_seq_version(&current).unwrap();
+    let v = calver_seq_version(&current, "%Y").unwrap();
     assert!(v.ends_with(".4"));
 }
 
@@ -356,7 +356,7 @@ fn sequential_with_v_prefix_semver() {
 
 #[test]
 fn calver_seq_empty_string() {
-    let v = calver_seq_version("").unwrap();
+    let v = calver_seq_version("", "%Y").unwrap();
     let parts: Vec<&str> = v.split('.').collect();
     assert_eq!(parts.len(), 3);
     assert_eq!(parts[2], "1");
@@ -364,7 +364,7 @@ fn calver_seq_empty_string() {
 
 #[test]
 fn calver_seq_malformed_input() {
-    let v = calver_seq_version("garbage").unwrap();
+    let v = calver_seq_version("garbage", "%Y").unwrap();
     assert!(v.ends_with(".1"));
 }
 
@@ -372,7 +372,7 @@ fn calver_seq_malformed_input() {
 fn calver_seq_two_parts_only() {
     let now = chrono::Utc::now();
     let current = format!("{}.{}", now.format("%Y"), now.format("%-m"));
-    let v = calver_seq_version(&current).unwrap();
+    let v = calver_seq_version(&current, "%Y").unwrap();
     assert!(v.ends_with(".1"));
 }
 
@@ -380,7 +380,7 @@ fn calver_seq_two_parts_only() {
 fn calver_seq_non_numeric_seq() {
     let now = chrono::Utc::now();
     let current = format!("{}.{}.abc", now.format("%Y"), now.format("%-m"));
-    let v = calver_seq_version(&current).unwrap();
+    let v = calver_seq_version(&current, "%Y").unwrap();
     assert!(v.ends_with(".1"));
 }
 
@@ -573,4 +573,96 @@ fn compute_next_version_all_strategies() {
         )
         .is_ok()
     );
+}
+
+#[test]
+fn calver_short_seq_bootstraps_at_one() {
+    let v = calver_seq_version("0.0", "%y").unwrap();
+    let now = chrono::Utc::now();
+    assert_eq!(v, format!("{}.{}.1", now.format("%y"), now.format("%-m")));
+}
+
+#[test]
+fn calver_short_seq_increments_within_the_same_month() {
+    let now = chrono::Utc::now();
+    let current = format!("{}.{}.7", now.format("%y"), now.format("%-m"));
+
+    let v = calver_seq_version(&current, "%y").unwrap();
+
+    assert_eq!(v, format!("{}.{}.8", now.format("%y"), now.format("%-m")));
+}
+
+#[test]
+fn calver_short_seq_can_publish_more_than_once_a_day() {
+    let now = chrono::Utc::now();
+    let first = calver_seq_version("0.0", "%y").unwrap();
+    let second = calver_seq_version(&first, "%y").unwrap();
+    let third = calver_seq_version(&second, "%y").unwrap();
+
+    assert_ne!(first, second);
+    assert_ne!(second, third);
+    assert_eq!(
+        third,
+        format!("{}.{}.3", now.format("%y"), now.format("%-m"))
+    );
+}
+
+#[test]
+fn migrating_from_calver_short_continues_from_the_day_number() {
+    // The point of the short variant: a repo on YY.M.D whose last release was
+    // the 28th gets 29 next, so the switch costs no version discontinuity.
+    let now = chrono::Utc::now();
+    let last_short = format!("{}.{}.28", now.format("%y"), now.format("%-m"));
+
+    let v = calver_seq_version(&last_short, "%y").unwrap();
+
+    assert_eq!(v, format!("{}.{}.29", now.format("%y"), now.format("%-m")));
+}
+
+#[test]
+fn calver_short_seq_keeps_the_two_digit_year_where_calver_seq_widens_it() {
+    let now = chrono::Utc::now();
+    let short = calver_seq_version("0.0", "%y").unwrap();
+    let long = calver_seq_version("0.0", "%Y").unwrap();
+
+    assert!(short.starts_with(&now.format("%y").to_string()));
+    assert!(long.starts_with(&now.format("%Y").to_string()));
+    assert_ne!(
+        short, long,
+        "switching to calver-seq is what jumps the major from 26 to 2026"
+    );
+}
+
+#[test]
+fn calver_short_seq_restarts_when_the_month_rolls_over() {
+    let v = calver_seq_version("01.1.9", "%y").unwrap();
+    let now = chrono::Utc::now();
+
+    assert_eq!(
+        v,
+        format!("{}.{}.1", now.format("%y"), now.format("%-m")),
+        "a version from another month must not carry its counter forward"
+    );
+}
+
+#[test]
+fn calver_short_seq_bootstraps_like_calver_seq() {
+    assert_eq!(
+        bootstrap_version(VersioningStrategy::CalverShortSeq),
+        bootstrap_version(VersioningStrategy::CalverSeq)
+    );
+}
+
+#[test]
+fn calver_short_seq_is_reachable_through_compute_next_version() {
+    let now = chrono::Utc::now();
+    let v = compute_next_version(
+        "0.0",
+        BumpType::Minor,
+        VersioningStrategy::CalverShortSeq,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(v, format!("{}.{}.1", now.format("%y"), now.format("%-m")));
 }


### PR DESCRIPTION
Closes #965. Both halves, which are independent as the issue notes.

## A refused release is no longer silent

`VersionUnchanged` only reached `tracing::debug!`, invisible in normal output, while `NoReleasableCommits` was pushed to the visible output. So the two opposite situations, nothing to do and work being held back, both printed "Nothing to release."

It is now a warning naming the package and the version it recomputed:

```
! app has releasable commits but stays at 26.8.29, so nothing was published
Nothing to release.
```

The variant carries the version to say it, which is what makes the line actionable rather than another way of saying nothing happened.

## calver-short-seq

`calver_seq_version` is parameterised on the year format, so `%Y` gives the existing `calver-seq` and `%y` the new `YY.M.SEQ`. Nothing else about the sequencing changes.

The migration property the issue predicted holds, verified end to end on a real repo:

```
calver-short:      1.0.0    → 26.8.29   (calvershort)
same day, again:   ! app has releasable commits but stays at 26.8.29
switch strategy:   26.8.29  → 26.8.30   (calvershortseq)
same day, again:   26.8.30  → 26.8.31   (calvershortseq)
```

The day number becomes the counter's starting point, so the switch costs no discontinuity, and the second same-day release now goes through instead of being swallowed.

## Caught only by running it

`is_date_or_seq` decides whether the output names the strategy or a bump type, and it enumerates the strategies by hand. Adding the variant to the enum left it out, so the first run printed `(minor, ...)` for a version no bump type had produced. Every unit test still passed, because none of them went through that function.

Fixed, with a test that asserts the property for every date or sequence strategy rather than for the one I had just added, so the next variant cannot slip through the same way.

## Tests

Eight on the strategy: bootstrap, incrementing within a month, three releases in one day, the migration continuity above, the two-digit year staying two digits where `calver-seq` widens it, the counter restarting on a month rollover, bootstrap parity with `calver-seq`, and reachability through `compute_next_version`.

Three on the reporting: the variant carries its version, it stays distinguishable from `NoReleasableCommits`, and the `is_date_or_seq` coverage above.

1258 bin and 959 lib tests passing, clippy clean, wasm surface builds.

## Not done

Tag detection in `detect.rs` does not learn the new strategy. `YY.M.SEQ` and `YY.M.D` are the same shape, and `26.8.29` is a valid day as well as a valid counter, so auto-detection cannot tell them apart without guessing. A repo on this strategy should set it explicitly, which is what the issue describes doing anyway. Worth its own decision rather than a heuristic folded in here.

The schema is updated in both enums; the served copy in FerrFlow-Cloud needs the same, as usual.
