### PR TITLE
fix(release): key the commit path dedupe on the normalised path

### DIFF
--- a/src/monorepo/run/authored_commit.rs
+++ b/src/monorepo/run/authored_commit.rs
@@ -19,7 +19,7 @@ pub(super) fn file_changes(
     // the whole commit over it. The contents are read from disk per path, so
     // the copies are identical and the first one is the file.
     for file in files {
-        if !seen.insert(*file) {
+        if !seen.insert(to_forge_path(file)) {
             continue;
         }
 
@@ -137,6 +137,27 @@ mod tests {
         assert_eq!(additions.len(), 1);
         assert_eq!(additions[0].path, "Chart.yaml");
         assert_eq!(deletions, vec!["gone.txt".to_string()]);
+    }
+
+    // The API judges uniqueness on the normalised path, so the guard has to
+    // as well: a backslashed lockfile path next to a forward-slashed config
+    // path is one file to GitHub and was two to a dedupe keyed on the raw
+    // string.
+    #[test]
+    fn separator_variants_of_one_file_are_sent_once() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("crates/api")).unwrap();
+        std::fs::write(dir.path().join("crates/api/Cargo.toml"), "x").unwrap();
+
+        let (additions, deletions) = file_changes(
+            dir.path(),
+            &["crates/api/Cargo.toml", r"crates\api\Cargo.toml"],
+        )
+        .unwrap();
+
+        assert_eq!(additions.len(), 1);
+        assert_eq!(additions[0].path, "crates/api/Cargo.toml");
+        assert!(deletions.is_empty(), "{deletions:?}");
     }
 
     #[test]


### PR DESCRIPTION
Closes #968, the non-blocking finding from the review on #951.

The dedupe added there keys on the raw path string, and `to_forge_path` normalises separators one line later. So `crates/api/Cargo.toml` and `crates\api\Cargo.toml` are one file to the API and were two to the guard, and the mutation refuses the commit exactly as before #951 for that pair.

The pair is reachable: `to_forge_path` exists because Windows paths arrive in this function, and a release run locally on Windows can put a backslashed lockfile path next to the forward-slashed config path for the same file.

One line: the `seen` set now keys on `to_forge_path(file)`, the identity the API judges uniqueness by. New test sends both spellings and asserts one addition; it fails with `left: 2, right: 1` when the dedupe keys on the raw string, verified by putting the raw key back. Full suite green (2230 tests), clippy clean.
