### PR TITLE
fix(git): retry an authored commit when the branch moved under it

### DIFF
--- a/src/git/retry.rs
+++ b/src/git/retry.rs
@@ -131,5 +131,6 @@ pub fn is_push_rejected_error(err: &anyhow::Error) -> bool {
             || msg.contains("fetch first")
             || msg.contains("stale info")
             || msg.contains("already exist on remote pointing to a different commit")
+            || msg.contains("expected branch to point to")
     })
 }

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -1581,6 +1581,20 @@ fn a_remote_that_advanced_before_we_fetched_is_a_race() {
 }
 
 #[test]
+fn a_createcommitonbranch_expectation_failure_is_a_race() {
+    let err = anyhow::anyhow!(
+        "createCommitOnBranch failed: Expected branch to point to          \"ca3a40a79075b70904f4f2bfa14cbdc7a888ed85\" but it did not.  Pull and try again."
+    )
+    .context(error_code::GITHUB_GRAPHQL_ERROR);
+
+    assert!(
+        is_push_rejected_error(&err),
+        "the authored-commit path detects the same race the git path retries, so it has to          reach the same regenerate loop instead of failing the release outright"
+    );
+    assert!(!is_transient_git_error(&err));
+}
+
+#[test]
 fn a_non_fast_forward_is_a_race() {
     let err = push_branch_failure(" ! [rejected]        HEAD -> main (non-fast-forward)");
 

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -1583,13 +1583,13 @@ fn a_remote_that_advanced_before_we_fetched_is_a_race() {
 #[test]
 fn a_createcommitonbranch_expectation_failure_is_a_race() {
     let err = anyhow::anyhow!(
-        "createCommitOnBranch failed: Expected branch to point to          \"ca3a40a79075b70904f4f2bfa14cbdc7a888ed85\" but it did not.  Pull and try again."
+        "createCommitOnBranch failed: Expected branch to point to \"ca3a40a\" but it did not.  Pull and try again."
     )
     .context(error_code::GITHUB_GRAPHQL_ERROR);
 
     assert!(
         is_push_rejected_error(&err),
-        "the authored-commit path detects the same race the git path retries, so it has to          reach the same regenerate loop instead of failing the release outright"
+        "the authored-commit path hits the same race the git path retries, so it has to reach the same regenerate loop"
     );
     assert!(!is_transient_git_error(&err));
 }


### PR DESCRIPTION
The release on `main` failed, and it is a gap in my own #941.

```
error[E3014]: createCommitOnBranch failed: Expected branch to point to
"ca3a40a79075b70904f4f2bfa14cbdc7a888ed85" but it did not.  Pull and try again.
```

## What happened

A plain race, and the timeline is unambiguous:

```
08:33:40  ca3a40a merged, Release job queued
08:47:52  job starts, reads local HEAD = ca3a40a
08:48:22  175b1df lands on main from another PR
08:49:53  mutation sends expectedHeadOid=ca3a40a, GitHub refuses
```

`expectedHeadOid` did its job: nothing wrong was committed, and the refusal is exactly what that field is for.

## The gap

The git commit path already handles this. `is_push_rejected_error` classifies a moved remote, the release loop resets to the new tip through `reset_branch_to_remote` and regenerates the commit against it, up to three attempts.

#941 added a second commit path without wiring it into that. `Commit` mode is not `single_shot`, so the loop was there and running; it simply never engaged, because the classifier had never been taught what a `createCommitOnBranch` expectation failure looks like.

One pattern fixes it. The regenerate path then works unchanged: `cleanup_failed_release_attempt` resets to the remote tip, and the retry re-reads `head_id()`, so the second attempt sends the oid GitHub is now expecting.

## Tests

One case asserting the error is classified as a race and not as transient, verified to fail without the pattern.

1266 bin and 966 lib tests passing, clippy clean.

## Worth saying plainly

I flagged in #941 that the mutation had never been executed against GitHub and should be exercised on a throwaway repository before being relied on. It went to production instead, and this is the first thing it hit. The race is a normal condition in this repository, given how often Renovate lands digest bumps on `main`, so it would have shown up on any busy day.

The release for `ca3a40a` did not go out. Once this merges, the next push to `main` picks it up; nothing needs re-running by hand.
